### PR TITLE
Use load sprites script to load icons file

### DIFF
--- a/preview/app/assets/javascripts/globals.js.erb
+++ b/preview/app/assets/javascripts/globals.js.erb
@@ -5,4 +5,5 @@
 
 /* global AblyUi */
 
+AblyUi.Core.loadSprites("<%= asset_path("ably_ui/core/sprites.svg") %>");
 AblyUi.Core.Meganav();

--- a/preview/app/javascript/packs/application.js
+++ b/preview/app/javascript/packs/application.js
@@ -1,7 +1,10 @@
 import "../styles/application.css";
 
 import Meganav from "@ably/ably-ui/core/Meganav";
-import { reactRenderer } from "@ably/ably-ui/core/scripts";
+import { reactRenderer, loadSprites } from "@ably/ably-ui/core/scripts";
+
+import sprites from "@ably/ably-ui/core/sprites.svg";
+loadSprites(sprites);
 
 document.addEventListener("DOMContentLoaded", () => {
   reactRenderer({ Meganav });

--- a/src/core/FeaturedLink/component.html.erb
+++ b/src/core/FeaturedLink/component.html.erb
@@ -1,5 +1,5 @@
 <%= link_to(@url, class: "text-menu3 font-medium text-gui-default hover:text-gui-hover focus:text-gui-focus focus:outline-gui-focus py-8 block group") do %>
   <%= content %><svg class="w-12 h-12 transform -rotate-90 align-top ui-icon-dark-grey group-hover:icon-gui-hover group-focus:icon-gui-focus ml-4">
-    <%= tag.use "xlink:href": "#{asset_path 'ably_ui/core/sprites.svg'}#sprite-disclosure-arrow" %>
+    <use xlink:href="#sprite-disclosure-arrow"></use>
   </svg>
 <% end %>

--- a/src/core/FeaturedLink/component.jsx
+++ b/src/core/FeaturedLink/component.jsx
@@ -1,17 +1,16 @@
 import React from "react";
 import T from "prop-types";
 
-const FeaturedLink = ({ iconSpritesPath, url, children }) => (
+const FeaturedLink = ({ url, children }) => (
   <a href={url} className="text-menu3 font-medium text-gui-default hover:text-gui-hover focus:text-gui-focus focus:outline-gui-focus py-8 block group">
     {children}
     <svg className="w-12 h-12 transform -rotate-90 align-top ui-icon-dark-grey group-hover:icon-gui-hover group-focus:icon-gui-focus ml-4">
-      <use xlinkHref={`${iconSpritesPath}#sprite-disclosure-arrow`} />
+      <use xlinkHref="#sprite-disclosure-arrow" />
     </svg>
   </a>
 );
 
 FeaturedLink.propTypes = {
-  iconSpritesPath: T.string,
   url: T.string,
   children: T.node,
 };

--- a/src/core/MeganavContentDevelopers/component.html.erb
+++ b/src/core/MeganavContentDevelopers/component.html.erb
@@ -4,7 +4,7 @@
     <div class="relative mb-16">
       <form class="relative" action="/search" method="get">
         <svg class="absolute top-8 left-8 w-24 h-24 pt-1 mt-1 ui-icon-cool-black">
-          <%= tag.use "xlink:href": "#{asset_path 'ably_ui/core/sprites.svg'}#sprite-search" %>
+          <use xlink:href="#sprite-search"></use>
         </svg>
         <input
           type="search"

--- a/src/core/MeganavContentDevelopers/component.jsx
+++ b/src/core/MeganavContentDevelopers/component.jsx
@@ -1,16 +1,15 @@
 import React from "react";
-import T from "prop-types";
 
 import FeaturedLink from "../FeaturedLink/component.jsx";
 
-const MeganavContentDevelopers = ({ paths }) => (
+const MeganavContentDevelopers = () => (
   <section className="ui-meganav-content ui-grid-gap md:grid-cols-3">
     <div>
       <h3 className="ui-meganav-overline md:mb-8">Documentation</h3>
       <div className="mb-16">
         <form className="relative" action="/search" method="get">
           <svg className="absolute top-8 left-8 w-24 h-24 pt-1 mt-1 ui-icon-cool-black">
-            <use xlinkHref={`${paths.iconSprites}#sprite-search`}></use>
+            <use xlinkHref="#sprite-search" />
           </svg>
           <input type="search" name="q" className="ui-input pl-48" placeholder="Search docs" />
         </form>
@@ -19,9 +18,7 @@ const MeganavContentDevelopers = ({ paths }) => (
         Docs, quick start guides, tutorials, and API reference to help you start building with Ably’s platform and APIs.
       </p>
 
-      <FeaturedLink url="/documentation" iconSpritesPath={paths.iconSprites}>
-        Visit Documentation
-      </FeaturedLink>
+      <FeaturedLink url="/documentation">Visit Documentation</FeaturedLink>
     </div>
 
     <div>
@@ -79,11 +76,5 @@ const MeganavContentDevelopers = ({ paths }) => (
     </div>
   </section>
 );
-
-MeganavContentDevelopers.propTypes = {
-  paths: T.shape({
-    iconSprites: T.string,
-  }),
-};
 
 export default MeganavContentDevelopers;

--- a/src/core/MeganavContentPlatform/component.jsx
+++ b/src/core/MeganavContentPlatform/component.jsx
@@ -15,9 +15,7 @@ const MeganavContentPlatform = ({ paths }) => (
         realtime, and lets you focus on your code.
       </p>
 
-      <FeaturedLink url="/pub-sub-messaging" iconSpritesPath={paths.iconSprites}>
-        Explore how it works
-      </FeaturedLink>
+      <FeaturedLink url="/pub-sub-messaging">Explore how it works</FeaturedLink>
     </div>
 
     <div>
@@ -57,9 +55,7 @@ const MeganavContentPlatform = ({ paths }) => (
         </li>
       </ul>
 
-      <FeaturedLink url="/platform" iconSpritesPath={paths.iconSprites}>
-        Explore all platform features
-      </FeaturedLink>
+      <FeaturedLink url="/platform">Explore all platform features</FeaturedLink>
     </div>
 
     <div>
@@ -93,9 +89,7 @@ const MeganavContentPlatform = ({ paths }) => (
         </li>
       </ul>
 
-      <FeaturedLink url="/four-pillars-of-dependability" iconSpritesPath={paths.iconSprites}>
-        Explore our Four Pillars of Dependability
-      </FeaturedLink>
+      <FeaturedLink url="/four-pillars-of-dependability">Explore our Four Pillars of Dependability</FeaturedLink>
     </div>
   </section>
 );

--- a/src/core/MeganavContentWhyAbly/component.jsx
+++ b/src/core/MeganavContentWhyAbly/component.jsx
@@ -1,9 +1,8 @@
 import React from "react";
-import T from "prop-types";
 
 import FeaturedLink from "../FeaturedLink/component.jsx";
 
-const MeganavContentWhyAbly = ({ paths }) => (
+const MeganavContentWhyAbly = () => (
   <section className="ui-meganav-content ui-grid-gap md:grid-cols-3">
     <div>
       <h3 className="ui-meganav-overline" id="meganav-why-ably-panel-list-why-companies">
@@ -67,9 +66,7 @@ const MeganavContentWhyAbly = ({ paths }) => (
         </li>
       </ul>
 
-      <FeaturedLink url="/four-pillars-of-dependability" iconSpritesPath={paths.iconSprites}>
-        Explore our Four Pillars of Dependability
-      </FeaturedLink>
+      <FeaturedLink url="/four-pillars-of-dependability">Explore our Four Pillars of Dependability</FeaturedLink>
     </div>
 
     <div>
@@ -98,20 +95,9 @@ const MeganavContentWhyAbly = ({ paths }) => (
         </li>
       </ul>
 
-      <FeaturedLink url="/blog" iconSpritesPath={paths.iconSprites}>
-        More from our Blog
-      </FeaturedLink>
+      <FeaturedLink url="/blog">More from our Blog</FeaturedLink>
     </div>
   </section>
 );
-
-MeganavContentWhyAbly.propTypes = {
-  paths: T.shape({
-    blogThumb1: T.string,
-    blogThumb2: T.string,
-    blogThumb3: T.string,
-    iconSprites: T.string,
-  }),
-};
 
 export default MeganavContentWhyAbly;

--- a/src/core/MeganavControl/component.html.erb
+++ b/src/core/MeganavControl/component.html.erb
@@ -2,6 +2,6 @@
                class: ["ui-meganav-link", "h-64", "flex", "items-center", "group", theme(:text_color)],
                data: { id: "meganav-control" },
                aria: { expanded: false, controls: @aria_controls, label: "Show #{content}" }) do %><%= content %><svg class="w-12 h-12 ml-8 ui-icon-dark-grey group-hover:icon-gui-hover group-focus:icon-gui-focus">
-    <%= tag.use "xlink:href": "#{asset_path 'ably_ui/core/sprites.svg'}#sprite-disclosure-arrow" %>
+    <use xlink:href="#sprite-disclosure-arrow"></use>
   </svg>
 <% end %>

--- a/src/core/MeganavControl/component.jsx
+++ b/src/core/MeganavControl/component.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import T from "prop-types";
 
-const MeganavControl = ({ iconSpritesPath, ariaControls, children, theme }) => (
+const MeganavControl = ({ ariaControls, children, theme }) => (
   <button
     type="button"
     data-id="meganav-control"
@@ -12,13 +12,12 @@ const MeganavControl = ({ iconSpritesPath, ariaControls, children, theme }) => (
   >
     {children}
     <svg className="w-12 h-12 ml-8 ui-icon-dark-grey group-hover:icon-gui-hover group-focus:icon-gui-focus">
-      <use xlinkHref={`${iconSpritesPath}#sprite-disclosure-arrow`}></use>
+      <use xlinkHref="#sprite-disclosure-arrow"></use>
     </svg>
   </button>
 );
 
 MeganavControl.propTypes = {
-  iconSpritesPath: T.string,
   ariaControls: T.string,
   children: T.node,
   theme: T.object,

--- a/src/core/MeganavControlMobileDropdown/component.html.erb
+++ b/src/core/MeganavControlMobileDropdown/component.html.erb
@@ -3,10 +3,10 @@
                data: { id: "meganav-control-mobile-dropdown" },
                aria: { expanded: false, controls: "meganav-mobile-dropdown" }) do %>
   <%= tag.svg class: ["h-24", "w-24", "transition-colors", theme(:mobile_menu_color)], data: { id: "meganav-control-mobile-dropdown-menu" } do %>
-    <%= tag.use "xlink:href": "#{asset_path 'ably_ui/core/sprites.svg'}#sprite-menu" %>
+    <use xlink:href="#sprite-menu"></use>
   <% end %>
 
   <%= tag.svg class: ["h-24", "w-24", "transition-colors", "hidden", theme(:mobile_menu_color)], data: { id: "meganav-control-mobile-dropdown-close" } do %>
-    <%= tag.use "xlink:href": "#{asset_path 'ably_ui/core/sprites.svg'}#sprite-close" %>
+    <use xlink:href="#sprite-close"></use>
   <% end %>
 <% end %>

--- a/src/core/MeganavControlMobileDropdown/component.jsx
+++ b/src/core/MeganavControlMobileDropdown/component.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import T from "prop-types";
 
-const MeganavControlMobileDropdown = ({ iconSpritesPath, theme }) => (
+const MeganavControlMobileDropdown = ({ theme }) => (
   <button
     type="button"
     className="block ml-24 mr-0 px-0 py-16 hover:text-gui-hover focus:text-gui-focus focus:outline-none"
@@ -10,16 +10,15 @@ const MeganavControlMobileDropdown = ({ iconSpritesPath, theme }) => (
     aria-controls="meganav-mobile-dropdown"
   >
     <svg className={`h-24 w-24 transition-colors ${theme.mobileMenuColor}`} data-id="meganav-control-mobile-dropdown-menu">
-      <use xlinkHref={`${iconSpritesPath}#sprite-menu`}></use>
+      <use xlinkHref="#sprite-menu"></use>
     </svg>
     <svg className={`h-24 w-24 transition-colors hidden ${theme.mobileMenuColor}`} data-id="meganav-control-mobile-dropdown-close">
-      <use xlinkHref={`${iconSpritesPath}#sprite-close`}></use>
+      <use xlinkHref="#sprite-close"></use>
     </svg>
   </button>
 );
 
 MeganavControlMobileDropdown.propTypes = {
-  iconSpritesPath: T.string,
   theme: T.object,
 };
 

--- a/src/core/MeganavControlMobilePanelClose/component.html.erb
+++ b/src/core/MeganavControlMobilePanelClose/component.html.erb
@@ -4,7 +4,7 @@
                  data: { id: "meganav-control-mobile-panel-close" },
                  aria: { expanded: false, controls: @aria_controls, label: "Hide panel" }) do %>
     <svg class="transform rotate-90 w-12 h-12 mr-8 ui-icon-dark-grey">
-      <%= tag.use "xlink:href": "#{asset_path 'ably_ui/core/sprites.svg'}#sprite-disclosure-arrow" %>
+      <use xlink:href="#sprite-disclosure-arrow"></use>
     </svg>Menu
   <% end %>
   <hr class="ui-meganav-hr" />

--- a/src/core/MeganavControlMobilePanelClose/component.js
+++ b/src/core/MeganavControlMobilePanelClose/component.js
@@ -1,4 +1,4 @@
-import { queryId, queryIdAll } from "../dom-query";
+import { queryIdAll } from "../dom-query";
 
 export default () => {
   const closeControls = Array.from(

--- a/src/core/MeganavControlMobilePanelClose/component.jsx
+++ b/src/core/MeganavControlMobilePanelClose/component.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import T from "prop-types";
 
-const MeganavControlMobilePanelClose = ({ iconSpritesPath, ariaControls }) => (
+const MeganavControlMobilePanelClose = ({ ariaControls }) => (
   <div className="mx-24 md:mx-32">
     <button
       type="button"
@@ -12,7 +12,7 @@ const MeganavControlMobilePanelClose = ({ iconSpritesPath, ariaControls }) => (
       aria-label="Hide panel"
     >
       <svg className="transform rotate-90 w-12 h-12 mr-8 ui-icon-dark-grey">
-        <use xlinkHref={`${iconSpritesPath}#sprite-disclosure-arrow`}></use>
+        <use xlinkHref="#sprite-disclosure-arrow"></use>
       </svg>
       Menu
     </button>
@@ -21,7 +21,6 @@ const MeganavControlMobilePanelClose = ({ iconSpritesPath, ariaControls }) => (
 );
 
 MeganavControlMobilePanelClose.propTypes = {
-  iconSpritesPath: T.string,
   ariaControls: T.string,
 };
 

--- a/src/core/MeganavControlMobilePanelOpen/component.html.erb
+++ b/src/core/MeganavControlMobilePanelOpen/component.html.erb
@@ -4,6 +4,6 @@
                aria: { expanded: false, controls: @aria_controls, label: "Show #{content}" }) do %>
   <%= content %>
   <svg class="transform -rotate-90 ml-auto float-right w-12 h-12 ui-icon-dark-grey">
-    <%= tag.use "xlink:href": "#{asset_path 'ably_ui/core/sprites.svg'}#sprite-disclosure-arrow" %>
+    <use xlink:href="#sprite-disclosure-arrow"></use>
   </svg>
 <% end %>

--- a/src/core/MeganavControlMobilePanelOpen/component.jsx
+++ b/src/core/MeganavControlMobilePanelOpen/component.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import T from "prop-types";
 
-const MeganavControlMobilePanelOpen = ({ iconSpritesPath, ariaControls, children }) => (
+const MeganavControlMobilePanelOpen = ({ ariaControls, children }) => (
   <button
     type="button"
     className="ui-meganav-mobile-link"
@@ -12,13 +12,12 @@ const MeganavControlMobilePanelOpen = ({ iconSpritesPath, ariaControls, children
   >
     {children}
     <svg className="transform -rotate-90 ml-auto float-right w-12 h-12 ui-icon-dark-grey">
-      <use xlinkHref={`${iconSpritesPath}#sprite-disclosure-arrow`}></use>
+      <use xlinkHref="#sprite-disclosure-arrow"></use>
     </svg>
   </button>
 );
 
 MeganavControlMobilePanelOpen.propTypes = {
-  iconSpritesPath: T.string,
   ariaControls: T.string,
   children: T.node,
 };

--- a/src/core/MeganavItemsDesktop/component.jsx
+++ b/src/core/MeganavItemsDesktop/component.jsx
@@ -11,7 +11,7 @@ const MeganavDesktopItems = ({ panels, paths, theme }) => (
 
       return (
         <li className="ui-meganav-item" key={panel.id}>
-          <MeganavControl theme={theme} iconSpritesPath={paths.iconSprites} ariaControls={panel.id}>
+          <MeganavControl theme={theme} ariaControls={panel.id}>
             {panel.label}
           </MeganavControl>
 

--- a/src/core/MeganavItemsMobile/component.jsx
+++ b/src/core/MeganavItemsMobile/component.jsx
@@ -30,7 +30,7 @@ const MeganavItemsMobile = ({ panels, paths, sessionState, theme }) => {
       </li>
 
       <li className="ui-meganav-item">
-        <MeganavControlMobileDropdown theme={theme} iconSpritesPath={paths.iconSprites} />
+        <MeganavControlMobileDropdown theme={theme} />
 
         <div className="ui-meganav-mobile-dropdown invisible" id="meganav-mobile-dropdown" data-id="meganav-mobile-dropdown">
           <div className="py-16 ui-grid-px bg-white">
@@ -40,12 +40,10 @@ const MeganavItemsMobile = ({ panels, paths, sessionState, theme }) => {
 
                 return (
                   <li className="ui-meganav-mobile-item" key={`${panel.id}-mobile`}>
-                    <MeganavControlMobilePanelOpen iconSpritesPath={paths.iconSprites} ariaControls={`${panel.id}-mobile`}>
-                      {panel.label}
-                    </MeganavControlMobilePanelOpen>
+                    <MeganavControlMobilePanelOpen ariaControls={`${panel.id}-mobile`}>{panel.label}</MeganavControlMobilePanelOpen>
 
                     <div className="ui-meganav-panel-mobile hidden" id={`${panel.id}-mobile`} data-scroll-lock-scrollable>
-                      <MeganavControlMobilePanelClose iconSpritesPath={paths.iconSprites} ariaControls={`${panel.id}-mobile`} />
+                      <MeganavControlMobilePanelClose ariaControls={`${panel.id}-mobile`} />
                       <PanelComponent paths={paths} />
                     </div>
                   </li>

--- a/src/core/MeganavItemsSignedIn/component.jsx
+++ b/src/core/MeganavItemsSignedIn/component.jsx
@@ -4,13 +4,13 @@ import T from "prop-types";
 import MeganavControl from "../MeganavControl/component.jsx";
 import SignOutLink from "../SignOutLink/component.jsx";
 
-const MeganavItemsSignedIn = ({ sessionState, paths, theme }) => {
+const MeganavItemsSignedIn = ({ sessionState, theme }) => {
   const links = Object.keys(sessionState.account.links).map((key) => sessionState.account.links[key]);
 
   return (
     <ul className="hidden md:flex items-center">
       <li className="ui-meganav-item relative">
-        <MeganavControl iconSpritesPath={paths.iconSprites} ariaControls="account-panel" theme={theme}>
+        <MeganavControl ariaControls="account-panel" theme={theme}>
           {sessionState.accountName}
         </MeganavControl>
 

--- a/src/core/load-sprites.js
+++ b/src/core/load-sprites.js
@@ -1,0 +1,11 @@
+export default (spritesUrl) => {
+  fetch(spritesUrl)
+    .then((response) => response.text())
+    .then((image) => {
+      const container = document.createElement("div");
+      container.style.display = "none";
+      container.innerHTML = image;
+      document.body.appendChild(container);
+    })
+    .catch((err) => console.error(err));
+};

--- a/src/core/scripts.js
+++ b/src/core/scripts.js
@@ -4,3 +4,4 @@ import "./styles.css";
 
 export { default as reactRenderer } from "./react-renderer";
 export { default as fetchSessionData } from "./fetch-session-data";
+export { default as loadSprites } from "./load-sprites";


### PR DESCRIPTION
This necessary as `<use>` tags do not support crossorigin requests so won't work if the asset is loaded from a CDN or similar.

See https://oreillymedia.github.io/Using_SVG/extras/ch10-cors.html for a breakdown.