### PR TITLE
Truncate accountName and prefferedEmail when signed in

### DIFF
--- a/src/core/MeganavItemsSignedIn/component.html.erb
+++ b/src/core/MeganavItemsSignedIn/component.html.erb
@@ -1,7 +1,7 @@
 <ul class="hidden md:flex items-center">
   <li class="ui-meganav-item relative">
     <%= render(AblyUi::Core::MeganavControl.new(aria_controls: "account-panel", theme_name: @theme_name)) do %>
-      <%= @session_data[:accountName] %>
+      <%= account_name %>
     <% end %>
 
     <div class="ui-meganav-panel-account invisible" id="account-panel" data-id="meganav-panel">
@@ -14,7 +14,7 @@
         <% end %>
       </ul>
 
-      <p class="ui-meganav-overline mx-16"><%= @session_data[:preferredEmail] %></p>
+      <p class="ui-meganav-overline mx-16"><%= preferred_email %></p>
       <ul class="mb-8 mx-16">
         <li>
           <%= link_to @session_data[:mySettings][:text], @session_data[:mySettings][:href], class: "ui-meganav-account-link" %>

--- a/src/core/MeganavItemsSignedIn/component.jsx
+++ b/src/core/MeganavItemsSignedIn/component.jsx
@@ -4,14 +4,20 @@ import T from "prop-types";
 import MeganavControl from "../MeganavControl/component.jsx";
 import SignOutLink from "../SignOutLink/component.jsx";
 
+const truncate = (string, length) => {
+  return string?.length && string.length > length ? `${string.slice(0, length - 1)}…` : string;
+};
+
 const MeganavItemsSignedIn = ({ sessionState, theme }) => {
   const links = Object.keys(sessionState.account.links).map((key) => sessionState.account.links[key]);
+  const accountName = truncate(sessionState.accountName, 20);
+  const preferredEmail = truncate(sessionState.preferredEmail, 20);
 
   return (
     <ul className="hidden md:flex items-center">
       <li className="ui-meganav-item relative">
         <MeganavControl ariaControls="account-panel" theme={theme}>
-          {sessionState.accountName}
+          {accountName}
         </MeganavControl>
 
         <div className="ui-meganav-panel-account invisible" id="account-panel" data-id="meganav-panel">
@@ -26,7 +32,7 @@ const MeganavItemsSignedIn = ({ sessionState, theme }) => {
             ))}
           </ul>
 
-          <p className="ui-meganav-overline mx-16">{sessionState.preferredEmail}</p>
+          <p className="ui-meganav-overline mx-16">{preferredEmail}</p>
           <ul className="mb-8 mx-16">
             <li>
               <a href={sessionState.mySettings.href} className="ui-meganav-account-link">

--- a/src/core/MeganavItemsSignedIn/component.rb
+++ b/src/core/MeganavItemsSignedIn/component.rb
@@ -7,6 +7,14 @@ module AblyUi
         @theme_name = theme_name
         @session_data = session_data
       end
+
+      def account_name
+        truncate(@session_data[:accountName], length: 20)
+      end
+
+      def preferred_email
+        truncate(@session_data[:preferredEmail], length: 20)
+      end
     end
   end
 end


### PR DESCRIPTION
Truncate `accountName` and `prefferedEmail`, two user specific fields that we display in the nav and have a chance to be quite longer then the space we have to display them.