### PR TITLE
Add missing check for account existence before rendering account links

### DIFF
--- a/src/core/MeganavItemsSignedIn/component.html.erb
+++ b/src/core/MeganavItemsSignedIn/component.html.erb
@@ -5,14 +5,16 @@
     <% end %>
 
     <div class="ui-meganav-panel-account invisible" id="account-panel" data-id="meganav-panel">
-      <p class="ui-meganav-overline mt-16 mx-16">Your account</p>
-      <ul class="mb-16 mx-16">
-        <% @session_data[:account][:links].each do |key, link| %>
-          <li>
-            <%= link_to link[:text], link[:href], class: "ui-meganav-account-link" %>
-          </li>
-        <% end %>
-      </ul>
+      <% if account? %>
+        <p class="ui-meganav-overline mt-16 mx-16">Your account</p>
+        <ul class="mb-16 mx-16">
+          <% @session_data[:account][:links].each do |key, link| %>
+            <li>
+              <%= link_to link[:text], link[:href], class: "ui-meganav-account-link" %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
 
       <p class="ui-meganav-overline mx-16"><%= preferred_email %></p>
       <ul class="mb-8 mx-16">
@@ -31,7 +33,7 @@
     </div>
   </li>
 
-  <% if @session_data[:account] %>
+  <% if account? %>
     <li class="ml-16">
       <%= link_to "Dashboard", @session_data[:account][:links][:dashboard][:href], class: "ui-btn-secondary p-btn-small" %>
     </li>

--- a/src/core/MeganavItemsSignedIn/component.jsx
+++ b/src/core/MeganavItemsSignedIn/component.jsx
@@ -9,7 +9,7 @@ const truncate = (string, length) => {
 };
 
 const MeganavItemsSignedIn = ({ sessionState, theme }) => {
-  const links = Object.keys(sessionState.account.links).map((key) => sessionState.account.links[key]);
+  const links = sessionState.account ? Object.keys(sessionState.account.links).map((key) => sessionState.account.links[key]) : [];
   const accountName = truncate(sessionState.accountName, 20);
   const preferredEmail = truncate(sessionState.preferredEmail, 20);
 
@@ -21,16 +21,21 @@ const MeganavItemsSignedIn = ({ sessionState, theme }) => {
         </MeganavControl>
 
         <div className="ui-meganav-panel-account invisible" id="account-panel" data-id="meganav-panel">
-          <p className="ui-meganav-overline mt-16 mx-16">Your account</p>
-          <ul className="mb-16 mx-16">
-            {links.map((item) => (
-              <li key={item.href}>
-                <a className="ui-meganav-account-link" href={item.href}>
-                  {item.text}
-                </a>
-              </li>
-            ))}
-          </ul>
+          {/* Users exist without accounts in which case there is no links here */}
+          {sessionState.account && (
+            <>
+              <p className="ui-meganav-overline mt-16 mx-16">Your account</p>
+              <ul className="mb-16 mx-16">
+                {links.map((item) => (
+                  <li key={item.href}>
+                    <a className="ui-meganav-account-link" href={item.href}>
+                      {item.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
 
           <p className="ui-meganav-overline mx-16">{preferredEmail}</p>
           <ul className="mb-8 mx-16">

--- a/src/core/MeganavItemsSignedIn/component.rb
+++ b/src/core/MeganavItemsSignedIn/component.rb
@@ -8,6 +8,10 @@ module AblyUi
         @session_data = session_data
       end
 
+      def account?
+        @session_data[:account].present?
+      end
+
       def account_name
         truncate(@session_data[:accountName], length: 20)
       end


### PR DESCRIPTION
Addresses this error https://rollbar.com/matt.oriordan/Ably-Website/items/117683/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification where we have user who doesn't have an account (user is not equal to account in db)