### PR TITLE
Add my access tokens link to meganav

### DIFF
--- a/src/core/MeganavItemsSignedIn/component.html.erb
+++ b/src/core/MeganavItemsSignedIn/component.html.erb
@@ -21,6 +21,12 @@
         <li>
           <%= link_to @session_data[:mySettings][:text], @session_data[:mySettings][:href], class: "ui-meganav-account-link" %>
         </li>
+
+        <% if access_tokens? %>
+          <li>
+            <%= link_to @session_data[:myAccessTokens][:text], @session_data[:myAccessTokens][:href], class: "ui-meganav-account-link" %>
+          </li>
+        <% end %>
       </ul>
 
       <hr class="ui-meganav-hr mb-16" />

--- a/src/core/MeganavItemsSignedIn/component.jsx
+++ b/src/core/MeganavItemsSignedIn/component.jsx
@@ -44,6 +44,13 @@ const MeganavItemsSignedIn = ({ sessionState, theme }) => {
                 {sessionState.mySettings.text}
               </a>
             </li>
+            {sessionState.myAccessTokens && (
+              <li>
+                <a href={sessionState.myAccessTokens.href} className="ui-meganav-account-link">
+                  {sessionState.myAccessTokens.text}
+                </a>
+              </li>
+            )}
           </ul>
 
           <hr className="ui-meganav-hr mb-16" />

--- a/src/core/MeganavItemsSignedIn/component.rb
+++ b/src/core/MeganavItemsSignedIn/component.rb
@@ -12,6 +12,11 @@ module AblyUi
         @session_data[:account].present?
       end
 
+      # Access tokens are behind a feature flag
+      def access_tokens?
+        @session_data[:accessTokens].present?
+      end
+
       def account_name
         truncate(@session_data[:accountName], length: 20)
       end


### PR DESCRIPTION
Adds missing link to page with access token controls, as long as it's present in the session data.