### PR TITLE
[FEA-349] - Rename status.ably.io to status.ably.com

### DIFF
--- a/src/core/MeganavContentDevelopers/component.html.erb
+++ b/src/core/MeganavContentDevelopers/component.html.erb
@@ -67,10 +67,10 @@
       </li>
 
       <li>
-        <a href="http://status.ably.io/" class="group ui-meganav-media py-12">
+        <a href="http://status.ably.com/" class="group ui-meganav-media py-12">
           <p class="ui-meganav-media-heading">Status
             <iframe
-              src="https://status.ably.io/embed/icon"
+              src="https://status.ably.com/embed/icon"
               allowtransparency="true"
               frameBorder="0"
               scrolling="no"

--- a/src/core/MeganavContentDevelopers/component.jsx
+++ b/src/core/MeganavContentDevelopers/component.jsx
@@ -68,11 +68,11 @@ const MeganavContentDevelopers = () => (
           </a>
         </li>
         <li>
-          <a href="http://status.ably.io/" className="group ui-meganav-media py-12">
+          <a href="http://status.ably.com/" className="group ui-meganav-media py-12">
             <p className="ui-meganav-media-heading">
               Status
               <iframe
-                src="https://status.ably.io/embed/icon"
+                src="https://status.ably.com/embed/icon"
                 allowtransparency="true"
                 frameBorder="0"
                 scrolling="no"


### PR DESCRIPTION
Update all references from status.ably.io to status.ably.com as part of FEA-349