### PR TITLE
[WEB-1368] contact footer

### DIFF
--- a/src/core/ContactFooter/component.css
+++ b/src/core/ContactFooter/component.css
@@ -1,8 +1,8 @@
 @layer components {
   .ui-contact-footer {
-    background: var(--gradient-active-orange), var(--color-active-orange);
-    background-size: 3000px 500px;
-    background-position: 200px 50%;
+    background: var(--gradient-active-orange);
+    background-size: 100% 100%;
+    background-position: right center;
 
     @apply relative top-64 w-full;
   }

--- a/src/core/ContactFooter/component.html.erb
+++ b/src/core/ContactFooter/component.html.erb
@@ -1,6 +1,6 @@
 <div class="ui-contact-footer font-sans" data-id="contact-footer">
-  <div class="w-full bp-lg max-w-screen-xl mx-auto py-64 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 ui-grid-gap ui-grid-px">
-    <div class="p-24 bg-white flex flex-col justify-between">
+  <div class="w-full bp-lg max-w-screen-xl mx-auto py-64 grid grid-cols-1 md:grid-cols-3 ui-grid-gap ui-grid-px">
+    <div class="xs:p-24 xl:p-40 sm:p-32 bg-white flex flex-col justify-between rounded-sm">
       <svg class="w-48 h-48 block mb-16">
         <use xlink:href="#sprite-live-chat"></use>
       </svg>
@@ -8,12 +8,12 @@
         <div class="text-h3 mb-24">Live Chat</div>
         <p class="text-p1 font-light">Reach out team of experts over chat powered by Ably.</p>
       </div>
-      <button type="button" class="ui-btn-secondary self-start p-btn-small mt-16"
+      <button type="button" class="ui-btn-secondary self-start p-btn mt-16"
         data-id="open-chat-widget"> Start a live chat
       </button>
     </div>
 
-    <div class="p-24 bg-white flex flex-col justify-between">
+    <div class="p-24 bg-white flex flex-col justify-between rounded-sm">
       <svg class="w-48 h-48 block mb-16">
         <use xlink:href="#sprite-call-mobile"></use>
       </svg>
@@ -30,7 +30,7 @@
       </div>
     </div>
 
-    <div class="p-24 bg-white flex flex-col justify-between">
+    <div class="p-24 bg-white flex flex-col justify-between rounded-sm">
       <svg class="w-48 h-48 block mb-16">
         <use xlink:href="#sprite-tech-account-comms"></use>
       </svg>
@@ -38,7 +38,7 @@
         <div class="text-h3 mb-24">Technical and account support</div>
         <p class="text-p1 font-light">We're standing by to help with any questions or code.</p>
       </div>
-      <a class="ui-btn-secondary self-start p-btn-small mt-16" href="/contact">
+      <a class="ui-btn-secondary self-start p-btn mt-16" href="/contact">
         Get support now
       </a>
     </div>

--- a/src/core/ContactFooter/component.jsx
+++ b/src/core/ContactFooter/component.jsx
@@ -4,7 +4,7 @@ import "./component.css";
 import toggleChatWidget from "./component.js";
 
 export default function ContactFooter() {
-  const listItemClasses = "p-24 bg-white flex flex-col justify-between";
+  const listItemClasses = "xs:p-24 xl:p-40 sm:p-32 bg-white flex flex-col justify-between rounded-sm";
   const svgicon = (id) => (
     <svg className="w-48 h-48 block mb-16">
       <use xlinkHref={"#" + id}></use>
@@ -15,14 +15,14 @@ export default function ContactFooter() {
 
   return (
     <div className="ui-contact-footer font-sans" data-id="contact-footer">
-      <div className="w-full bp-lg max-w-screen-xl mx-auto py-64 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 ui-grid-gap ui-grid-px">
+      <div className="w-full bp-lg max-w-screen-xl mx-auto py-64 grid grid-cols-1 md:grid-cols-3 ui-grid-gap ui-grid-px">
         <div className={listItemClasses}>
           {svgicon("sprite-live-chat")}
           <div>
             <div className="text-h3 mb-24">Live Chat</div>
             <p className="text-p1 font-light">Reach out team of experts over chat powered by Ably.</p>
           </div>
-          <button type="button" className="ui-btn-secondary self-start p-btn-small mt-16" data-id="open-chat-widget">
+          <button type="button" className="ui-btn-secondary self-start p-btn mt-16" data-id="open-chat-widget">
             Start a live chat
           </button>
         </div>
@@ -48,7 +48,7 @@ export default function ContactFooter() {
             <div className="text-h3 mb-24">Technical and account support</div>
             <p className="text-p1 font-light">We're standing by to help with any questions or code.</p>
           </div>
-          <a className="ui-btn-secondary self-start p-btn-small mt-16" href="https://google.com">
+          <a className="ui-btn-secondary self-start p-btn mt-16" href="https://google.com">
             Get support now
           </a>
         </div>

--- a/src/core/styles.css
+++ b/src/core/styles.css
@@ -15,11 +15,11 @@
   }
 
   .ui-btn-secondary {
-    @apply text-cool-black bg-white text-btn2 font-sans font-medium inline-block border-2 border-cool-black rounded p-btn;
+    @apply text-cool-black bg-white text-btn2 font-sans font-medium inline-block border-btn border-cool-black rounded p-btn;
     @apply hover:text-active-orange hover:border-active-orange hover:bg-white;
     @apply active:text-red-orange hover:border-red-orange active:bg-white;
     @apply focus:text-cool-black focus:border-cool-black focus:bg-white focus:outline-gui-focus;
-    @apply disabled:text-mid-grey disabled:border-mid-grey disabled:bg-white;
+    @apply disabled:text-mid-grey disabled:border-gui-unavailable disabled:bg-white;
     @apply transition-colors;
   }
 

--- a/src/core/styles/properties.css
+++ b/src/core/styles/properties.css
@@ -20,10 +20,10 @@
   --color-gui-error: #fb0c0c;
 
   --gradient-active-orange: linear-gradient(
-    61.2deg,
-    var(--color-active-orange) 15%,
-    var(--color-red-orange) 45%,
-    var(--color-active-orange) 85%
+    62deg,
+    var(--color-active-orange) 0,
+    var(--color-active-orange) 60%,
+    var(--color-red-orange) 100%
   );
 
   --fs-title: 4rem;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -108,6 +108,7 @@ module.exports = {
     },
     borderRadius: {
       none: "0",
+      sm: '1px',
       DEFAULT: "0.375rem",
     },
     extend: {
@@ -120,6 +121,9 @@ module.exports = {
       width: {
         "extend-8": "calc(100% + var(--spacing-8))",
       },
+      borderWidth: {
+        "btn": "1.5px"
+      }
     },
   },
   variants: {


### PR DESCRIPTION
- [x] the CTA border is slightly too think, should be 1.5px
- [x] White card needs border radius 1px
- [x] Disabled button - check styling is good (see buttons in figma)
- [x] Red BG gradient - should align to RHS page edge, with gradient angle of 28'
- [x] Button CTA margins: (1) horizontal: +2px (2) vertical: +2px
- [x] On Tablet view: the gradient BG image is tiling, and the edge is visible
- [x] Breakpoint layout changes: we should skip the tablet view entirely and transform from 3 column (desktop) to 1 column (mobile) to avoid the awkwardness of 2 cards inline, with a wrapping orphan. 

Fix alllll the stuff