### PR TITLE
Add github action to delete old package versions

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -1,0 +1,18 @@
+name: Remove old package versions
+on:
+  schedule:
+    # every Monday 9:00am
+    - cron: "0 0 9 ? * MON *"
+
+jobs:
+  remove-package-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove package versions
+        uses: smartsquaregmbh/delete-old-packages@v0.2.0
+        with:
+          # See https://github.com/marketplace/actions/delete-old-packages for options
+          names: ably-ui
+          # should match 2.1.2.dev.3gdf4 and 2.1.2-dev.3gdf4
+          version-pattern: "^\\d+\\.\\d+\\.\\d+(\\.|-)dev\\..+"
+          keep: 20


### PR DESCRIPTION
Relies on https://github.com/EpitomeGlobal/remove-package-versions

Main use case is to delete old .dev versions. Cron is set to every Monday 9:00.

Tested locally with `https://github.com/nektos/act` by running:
```
act schedule --secret GITHUB_TOKEN=$GITHUB_REGISTRY_TOKEN
```

Note I've done a cleanup of old packages as well.