### PR TITLE
Fix double processing of CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "extra-watch-webpack-plugin": "^1.0.3",
     "mini-css-extract-plugin": "^1.2.1",
     "normalize.css": "^8.0.1",
+    "null-loader": "^4.0.1",
     "postcss": "^8.1.10",
     "postcss-calc": "^7.0.5",
     "postcss-custom-media": "^7.0.8",

--- a/src/core/ContactFooter/component.js
+++ b/src/core/ContactFooter/component.js
@@ -1,2 +1,3 @@
+import "./component.css";
 import toggleChatWidget from "../hubspot-chat-toggle";
 export default () => toggleChatWidget({ dataId: "contact-footer" });

--- a/src/core/ContactFooter/component.jsx
+++ b/src/core/ContactFooter/component.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 
-import "./component.css";
 import toggleChatWidget from "./component.js";
 
 export default function ContactFooter() {

--- a/src/core/Footer/component.js
+++ b/src/core/Footer/component.js
@@ -1,0 +1,1 @@
+import "./component.css";

--- a/src/core/Footer/component.jsx
+++ b/src/core/Footer/component.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 import T from "prop-types";
 
-import "./component.css";
-
 export default function Footer({ paths }) {
   return (
     <footer className="bg-light-grey font-sans antialiased" data-id="footer">

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,20 +6,22 @@ const SVGSpritemapPlugin = require("svg-spritemap-webpack-plugin");
 
 const modules = require("./modules-config");
 
-const commonConfig = {
-  module: {
-    rules: [
-      {
-        test: /\.css$/i,
-        use: [MiniCssExtractPlugin.loader, "css-loader", "postcss-loader"],
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: ["babel-loader"],
-      },
-    ],
+const cssRules = [
+  {
+    test: /\.css$/i,
+    use: [MiniCssExtractPlugin.loader, "css-loader", "postcss-loader"],
   },
+];
+
+const jsRules = [
+  {
+    test: /\.(js|jsx)$/,
+    exclude: /node_modules/,
+    use: ["babel-loader"],
+  },
+];
+
+const externalsConfig = {
   externals: {
     react: {
       commonjs: "react",
@@ -39,7 +41,10 @@ const commonOutputConfig = {
 };
 
 const modulesConfig = modules.map((mod) => ({
-  ...commonConfig,
+  ...externalsConfig,
+  module: {
+    rules: [...cssRules, ...jsRules],
+  },
   entry: {
     [mod.name]: {
       import: `./src/${mod.directory}/scripts.js`,
@@ -67,7 +72,10 @@ const modulesConfig = modules.map((mod) => ({
 }));
 
 const componentsConfig = modules.map((mod) => ({
-  ...commonConfig,
+  ...externalsConfig,
+  module: {
+    rules: [...cssRules, ...jsRules],
+  },
   entry: mod.components.reduce(
     (acc, componentName) => ({
       [componentName]: {
@@ -91,7 +99,10 @@ const componentsConfig = modules.map((mod) => ({
 }));
 
 const reactConfig = modules.map((mod) => ({
-  ...commonConfig,
+  ...externalsConfig,
+  module: {
+    rules: [{ test: /\.css$/i, loader: "null-loader" }, ...jsRules],
+  },
   entry: mod.components.reduce((acc, componentName) => {
     const path = `./src/${mod.directory}/${componentName}/component.jsx`;
 
@@ -109,11 +120,6 @@ const reactConfig = modules.map((mod) => ({
   output: {
     ...commonOutputConfig,
   },
-  plugins: [
-    new MiniCssExtractPlugin({
-      filename: `${mod.directory}/[name]/component.css`,
-    }),
-  ],
 }));
 
 module.exports = [...modulesConfig, ...componentsConfig, ...reactConfig];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,6 +4171,14 @@ nth-check@^1.0.2:
   dependencies:
     boolbase "~1.0.0"
 
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"


### PR DESCRIPTION
This removes the processing of CSS files from React components.

When using webpack watch, we would process these twice and from time to time these would be out of sync, producing an invalid file, most
commonly around inline source maps (example WxsXSwic291cmNlUm9vdCI6IiJ9*/WxsXSwic291cmNlUm9vdCI6IiJ9*/).