### PR TITLE
Update ConnectStateWrapper to set initial state

### DIFF
--- a/src/core/remote-react-util.js
+++ b/src/core/remote-react-util.js
@@ -1,6 +1,16 @@
 import React, { useEffect, useState } from "react";
 
-import { connectState } from "./remote-data-store";
+import { connectState, getRemoteDataStore } from "./remote-data-store";
+
+/*
+  Connect a react component to a global store.
+  This is similar to what react-redux does but uses our global store so
+  can share state with other React mount points or anything that uses the
+  store.
+  - selectors is an object where keys are your prop names and values are your select
+  functions that work on the store to retrieve the state you are interested in
+  - initial state is set in useEffect so the wrapped component needs to handle it's props set to undefined initially
+*/
 
 export const ConnectStateWrapper = (Component, selectors) => {
   const [state, setState] = useState({});
@@ -9,10 +19,19 @@ export const ConnectStateWrapper = (Component, selectors) => {
     setState(() => ({ [key]: storeState }));
 
   useEffect(() => {
+    const store = getRemoteDataStore();
+    const resolvedState = Object.keys(selectors).reduce(
+      (acc, key) => ({ ...acc, [key]: selectors[key](store) }),
+      {}
+    );
+
+    // Set initial state
+    setState(resolvedState);
+
     // Create a store subscription for each selector. Depending on your use case, this can be inefficient.
     // When optimising for renders, look for wins with selectors better for your use and using connectState directly.
     Object.keys(selectors).forEach((key) => {
-      connectState(selectors[key], setStateForKey(key));
+      connectState(selectors[key], () => setStateForKey(key));
     });
   }, []);
 


### PR DESCRIPTION
Fix a bug I found when working on https://ably.atlassian.net/browse/WEB-1441

Set state immediately after render, not on the first subscription call.

The subscription update compares the state change in the store, not the component so we need to make sure
that we set the state immediately to the contents of the store.