### PR TITLE
[WEB-1727] Cookie PopUp

### DIFF
--- a/src/core/CookieMessage/component.css
+++ b/src/core/CookieMessage/component.css
@@ -2,7 +2,7 @@
   .ui-cookie-message {
     @apply rounded-lg bg-white;
     @apply justify-between items-center;
-    @apply opacity-100 z-20 bottom-0 fixed sm:flex;
+    @apply opacity-100 z-50 bottom-0 fixed sm:flex;
     @apply p-16 mb-16 ml-16;
     max-width: 70vw;
     box-shadow: 0px 24px 32px 0px #0000000d;


### PR DESCRIPTION
Jira Ticket Link / Motivation
----

# This is a patch fix
Increase z-index - this fixes the overlap that occurs on homepage between `cookie message` and  `code-explorer`
See the symptom here: https://website-web-1727-cookie-harlqy.herokuapp.com/

NOTE: the max available z-index offered by default tailwind classname is `50`


<!-- The link should contain motivation for the changes. If it does not, provide the motivation / context here. -->


Summary of changes
----

<!-- Commits should already be describing what you are trying to achieve. If needed, use this space to explain how they connect to achieve criteria from the Motivation. Otherwise, uncomment the below: -->
<!-- See commits for details. -->

How do you manually test this?
----

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

Reviewer Tasks (optional)
----

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->


Merge/Deploy Checklist
----

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

Frontend Checklist
----

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
