### PR TITLE
Fix wrong font between xs and xl viewports for h1 and h2

### DIFF
--- a/src/core/styles/text.css
+++ b/src/core/styles/text.css
@@ -7,13 +7,13 @@
 
   .ui-text-h1 {
     @apply font-sans font-medium text-cool-black;
-    @apply text-h1-xs xs:text-title xl:text-h1-xl;
+    @apply text-h1-xs xs:text-h1 xl:text-h1-xl;
     @apply tracking-tighten-0.01;
   }
 
   .ui-text-h2 {
     @apply font-sans font-medium text-cool-black;
-    @apply text-h2-xs xs:text-title xl:text-h2-xl;
+    @apply text-h2-xs xs:text-h2 xl:text-h2-xl;
     @apply tracking-tighten-0.01;
   }
 


### PR DESCRIPTION
Jira Ticket Link / Motivation
----

<!-- The link should contain motivation for the changes. If it does not, provide the motivation / context here. -->

Fixes a bug introduced in https://github.com/ably/ably-ui/pull/97 where the font-size is wrong for h1 and h2 between certain viewports.

Summary of changes
----

<!-- Commits should already be describing what you are trying to achieve. If needed, use this space to explain how they connect to achieve criteria from the Motivation. Otherwise, uncomment the below: -->
See commits for details.

How do you manually test this?
----

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

Reviewer Tasks (optional)
----

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->


Merge/Deploy Checklist
----

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

Frontend Checklist
----

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
