### PR TITLE
Explicitly specify workflow `permissions` required to succeed when our org switches default access from 'permissive' to 'restricted'

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   remove-package-versions:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Remove package versions
         uses: smartsquaregmbh/delete-old-packages@v0.2.0


### PR DESCRIPTION
Initial prototype: https://github.com/ably/ably-asset-tracking-android/pull/441

Adapted according to my understanding of what this periodically triggered workflow does. We'll not know for sure if what I've added here works until:

1. We switch the `ably` org default Actions permissions scope from 'permissive' to 'restricted'
2. This workflow runs again (Mondays, 9am, right? 😄)

The org-level setting tweak will happen once a number of `permissions`-related pull requests across repositories in the `ably` org have landed to their respective `main` branches. I shall be leading the effort and shepherding them all home.

See [this internal Slack thread](https://ably-real-time.slack.com/archives/CF7GGBF2N/p1631814436061500) for more context.

Related to https://github.com/ably/website/pull/4052 and https://github.com/ably/voltaire/pull/128.