### PR TITLE
[WEB-2175] Documentation now lives under /docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ably-ui (7.1.0.dev.02abc5e)
+    ably-ui (7.1.0.dev.97a5585)
       view_component (>= 2.33, < 2.50)
 
 GEM

--- a/cypress/integration/core/footer/__snapshots__/snapshots.js.snap
+++ b/cypress/integration/core/footer/__snapshots__/snapshots.js.snap
@@ -121,13 +121,13 @@ exports[`Footer Snapshot Test > react > test case common to both #0`] = `
       <ul>
         <li class="p-menu-row-snug">
           <a
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             class="ui-footer-menu-row-link"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a href="/documentation/" class="ui-footer-menu-row-link"
+          <a href="/docs/" class="ui-footer-menu-row-link"
             >Documentation</a
           >
         </li>
@@ -430,12 +430,12 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
         <li class="p-menu-row-snug">
           <a
             class="ui-footer-menu-row-link"
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a class="ui-footer-menu-row-link" href="/documentation"
+          <a class="ui-footer-menu-row-link" href="/docs"
             >Documentation</a
           >
         </li>

--- a/cypress/integration/core/showcase/__snapshots__/screenshots.js.snap
+++ b/cypress/integration/core/showcase/__snapshots__/screenshots.js.snap
@@ -131,13 +131,13 @@ exports[`Footer Snapshot Test > react > test case common to both #0`] = `
       <ul>
         <li class="p-menu-row-snug">
           <a
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             class="ui-footer-menu-row-link"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a href="/documentation/" class="ui-footer-menu-row-link"
+          <a href="/docs/" class="ui-footer-menu-row-link"
             >Documentation</a
           >
         </li>
@@ -404,13 +404,13 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
       <ul>
         <li class="p-menu-row-snug">
           <a
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             class="ui-footer-menu-row-link"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a href="/documentation/" class="ui-footer-menu-row-link"
+          <a href="/docs/" class="ui-footer-menu-row-link"
             >Documentation</a
           >
         </li>

--- a/cypress/integration/core/showcase/__snapshots__/snapshots.js.snap
+++ b/cypress/integration/core/showcase/__snapshots__/snapshots.js.snap
@@ -316,13 +316,13 @@ exports[`Footer Snapshot Test > react > test case common to both #0`] = `
       <ul>
         <li class="p-menu-row-snug">
           <a
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             class="ui-footer-menu-row-link"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a href="/documentation/" class="ui-footer-menu-row-link"
+          <a href="/docs/" class="ui-footer-menu-row-link"
             >Documentation</a
           >
         </li>
@@ -591,13 +591,13 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
       <ul>
         <li class="p-menu-row-snug">
           <a
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             class="ui-footer-menu-row-link"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a href="/documentation/" class="ui-footer-menu-row-link"
+          <a href="/docs/" class="ui-footer-menu-row-link"
             >Documentation</a
           >
         </li>

--- a/cypress/integration/core/uptime/__snapshots__/snapshots.js.snap
+++ b/cypress/integration/core/uptime/__snapshots__/snapshots.js.snap
@@ -445,10 +445,10 @@ exports[`Uptime Snapshot Test > react > test case common to both #1`] = `
 `;
 
 exports[`Code Snapshot Test > react > test case common to both #0`] = `
-<div class="hljs p-32 overflow-auto" data-id="code">
+<div class="hljs overflow-auto p-32 " data-id="code">
   <pre
     lang="javascript"
-  ><code class="font-mono language-javascript"><span class="hljs-keyword">var</span> ably = <span class="hljs-keyword">new</span> Ably.Realtime(<span class="hljs-string">'1WChTA.mc0Biw:kNfiYG4KiPgmHHgH'</span>);
+  ><code class="language-javascript ui-text-code"><span class="hljs-keyword">var</span> ably = <span class="hljs-keyword">new</span> Ably.Realtime(<span class="hljs-string">'1WChTA.mc0Biw:kNfiYG4KiPgmHHgH'</span>);
 <span class="hljs-keyword">var</span> channel = ably.channels.get(<span class="hljs-string">'web-pal'</span>);
 
 <span class="hljs-comment">// Subscribe to messages on channel</span>
@@ -459,10 +459,10 @@ channel.subscribe(<span class="hljs-string">'greeting'</span>, <span class="hljs
 `;
 
 exports[`Code Snapshot Test > react > test case common to both #1`] = `
-<div class="hljs p-32 overflow-auto" data-id="code">
+<div class="hljs overflow-auto p-32 " data-id="code">
   <pre
     lang="swift"
-  ><code class="font-mono language-swift"><span class="hljs-keyword">let</span> ably <span class="hljs-operator">=</span> <span class="hljs-type">ARTRealtime</span>(key: <span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>)
+  ><code class="language-swift ui-text-code"><span class="hljs-keyword">let</span> ably <span class="hljs-operator">=</span> <span class="hljs-type">ARTRealtime</span>(key: <span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>)
 <span class="hljs-keyword">let</span> channel <span class="hljs-operator">=</span> ably.channels.get(<span class="hljs-string">"web-pal"</span>)
 
 <span class="hljs-comment">// Subscribe to messages on channel</span>
@@ -473,10 +473,10 @@ channel.subscribe(<span class="hljs-string">"greeting"</span>) { message <span c
 `;
 
 exports[`Code Snapshot Test > react > test case common to both #2`] = `
-<div class="hljs p-32 overflow-auto" data-id="code">
+<div class="hljs overflow-auto p-32 " data-id="code">
   <pre
     lang="java"
-  ><code class="font-mono language-java">AblyRealtime ably = <span class="hljs-keyword">new</span> AblyRealtime(<span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>);
+  ><code class="language-java ui-text-code">AblyRealtime ably = <span class="hljs-keyword">new</span> AblyRealtime(<span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>);
 Channel channel = ably.channels.get(<span class="hljs-string">"web-pal"</span>);
 
 <span class="hljs-comment">/* Subscribe to messages on channel */</span>
@@ -493,10 +493,10 @@ channel.subscribe(<span class="hljs-string">"greeting"</span>, listener);</code>
 `;
 
 exports[`Code Snapshot Test > view component > test case common to both #0`] = `
-<div class="hljs p-32 overflow-auto" data-id="code">
+<div class="hljs overflow-auto p-32 " data-id="code">
   <pre
     lang="javascript"
-  ><code class="font-mono language-javascript"><span class="hljs-keyword">var</span> ably = <span class="hljs-keyword">new</span> Ably.Realtime(<span class="hljs-string">'1WChTA.mc0Biw:kNfiYG4KiPgmHHgH'</span>);
+  ><code class="language-javascript ui-text-code"><span class="hljs-keyword">var</span> ably = <span class="hljs-keyword">new</span> Ably.Realtime(<span class="hljs-string">'1WChTA.mc0Biw:kNfiYG4KiPgmHHgH'</span>);
 <span class="hljs-keyword">var</span> channel = ably.channels.get(<span class="hljs-string">'web-pal'</span>);
 
 <span class="hljs-comment">// Subscribe to messages on channel</span>
@@ -507,10 +507,10 @@ channel.subscribe(<span class="hljs-string">'greeting'</span>, <span class="hljs
 `;
 
 exports[`Code Snapshot Test > view component > test case common to both #1`] = `
-<div class="hljs p-32 overflow-auto" data-id="code">
+<div class="hljs overflow-auto p-32 " data-id="code">
   <pre
     lang="swift"
-  ><code class="font-mono language-swift"><span class="hljs-keyword">let</span> ably <span class="hljs-operator">=</span> <span class="hljs-type">ARTRealtime</span>(key: <span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>)
+  ><code class="language-swift ui-text-code"><span class="hljs-keyword">let</span> ably <span class="hljs-operator">=</span> <span class="hljs-type">ARTRealtime</span>(key: <span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>)
 <span class="hljs-keyword">let</span> channel <span class="hljs-operator">=</span> ably.channels.get(<span class="hljs-string">"web-pal"</span>)
 
 <span class="hljs-comment">// Subscribe to messages on channel</span>
@@ -521,10 +521,10 @@ channel.subscribe(<span class="hljs-string">"greeting"</span>) { message <span c
 `;
 
 exports[`Code Snapshot Test > view component > test case common to both #2`] = `
-<div class="hljs p-32 overflow-auto" data-id="code">
+<div class="hljs overflow-auto p-32 " data-id="code">
   <pre
     lang="java"
-  ><code class="font-mono language-java">AblyRealtime ably = <span class="hljs-keyword">new</span> AblyRealtime(<span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>);
+  ><code class="language-java ui-text-code">AblyRealtime ably = <span class="hljs-keyword">new</span> AblyRealtime(<span class="hljs-string">"1WChTA.mc0Biw:kNfiYG4KiPgmHHgH"</span>);
 Channel channel = ably.channels.get(<span class="hljs-string">"web-pal"</span>);
 
 <span class="hljs-comment">/* Subscribe to messages on channel */</span>
@@ -754,6 +754,18 @@ exports[`Footer Snapshot Test > react > test case common to both #0`] = `
       <h2 class="ui-footer-col-title">Ably is for</h2>
       <ul>
         <li class="p-menu-row-snug">
+          <a href="/solutions/asset-tracking" class="ui-footer-menu-row-link"
+            >Ably Asset Tracking</a
+          >
+        </li>
+        <li class="p-menu-row-snug">
+          <a
+            href="/solutions/extend-kafka-to-the-edge"
+            class="ui-footer-menu-row-link"
+            >Extend Kafka to the edge</a
+          >
+        </li>
+        <li class="p-menu-row-snug">
           <a href="/solutions/edtech" class="ui-footer-menu-row-link">EdTech</a>
         </li>
         <li class="p-menu-row-snug">
@@ -806,16 +818,12 @@ exports[`Footer Snapshot Test > react > test case common to both #0`] = `
       <h2 class="ui-footer-col-title">Developers</h2>
       <ul>
         <li class="p-menu-row-snug">
-          <a
-            href="/docs/quick-start-guide"
-            class="ui-footer-menu-row-link"
+          <a href="/docs/quick-start-guide" class="ui-footer-menu-row-link"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a href="/docs/" class="ui-footer-menu-row-link"
-            >Documentation</a
-          >
+          <a href="/docs/" class="ui-footer-menu-row-link">Documentation</a>
         </li>
         <li class="p-menu-row-snug">
           <a href="/tutorials" class="ui-footer-menu-row-link">Tutorials</a>
@@ -950,7 +958,7 @@ exports[`Footer Snapshot Test > react > test case common to both #0`] = `
             <use xlink:href="#sprite-github"></use></svg></a
         ><a
           class="h-24 pr-24 text-cool-black hover:text-icon-discord"
-          href="https://discord.com/invite/wPnfgACt"
+          href="https://discord.gg/jwBPhEZ9g5"
           ><svg class=" " style="width: 1.5rem; height: 1.5rem;">
             <use xlink:href="#sprite-discord"></use></svg
         ></a>
@@ -1049,6 +1057,18 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
       <h2 class="ui-footer-col-title">Ably is for</h2>
       <ul>
         <li class="p-menu-row-snug">
+          <a class="ui-footer-menu-row-link" href="/solutions/asset-tracking"
+            >Ably Asset Tracking</a
+          >
+        </li>
+        <li class="p-menu-row-snug">
+          <a
+            class="ui-footer-menu-row-link"
+            href="/solutions/extend-kafka-to-the-edge"
+            >Extend Kafka to the edge</a
+          >
+        </li>
+        <li class="p-menu-row-snug">
           <a class="ui-footer-menu-row-link" href="/solutions/edtech">EdTech</a>
         </li>
         <li class="p-menu-row-snug">
@@ -1102,16 +1122,12 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
       <h2 class="ui-footer-col-title">Developers</h2>
       <ul>
         <li class="p-menu-row-snug">
-          <a
-            class="ui-footer-menu-row-link"
-            href="/docs/quick-start-guide"
+          <a class="ui-footer-menu-row-link" href="/docs/quick-start-guide"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a class="ui-footer-menu-row-link" href="/docs"
-            >Documentation</a
-          >
+          <a class="ui-footer-menu-row-link" href="/docs">Documentation</a>
         </li>
         <li class="p-menu-row-snug">
           <a class="ui-footer-menu-row-link" href="/tutorials">Tutorials</a>
@@ -1137,7 +1153,7 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
           >
           <iframe
             class="w-24 h-24 mt-4"
-            src="https://status.ably.io/embed/icon"
+            src="https://status.ably.com/embed/icon"
             allowtransparency="true"
             frameborder="0"
             scrolling="no"
@@ -1258,6 +1274,14 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
         >
           <svg class=" " style="width: 1.5rem; height: 1.5rem">
             <use xlink:href="#sprite-github"></use>
+          </svg>
+        </a>
+        <a
+          class="h-24 pr-24 text-cool-black hover:text-icon-discord"
+          href="https://discord.gg/jwBPhEZ9g5"
+        >
+          <svg class=" " style="width: 1.5rem; height: 1.5rem">
+            <use xlink:href="#sprite-discord"></use>
           </svg>
         </a>
         <div class="border-l border-mid-grey h-40"></div>

--- a/cypress/integration/core/uptime/__snapshots__/snapshots.js.snap
+++ b/cypress/integration/core/uptime/__snapshots__/snapshots.js.snap
@@ -807,13 +807,13 @@ exports[`Footer Snapshot Test > react > test case common to both #0`] = `
       <ul>
         <li class="p-menu-row-snug">
           <a
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             class="ui-footer-menu-row-link"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a href="/documentation/" class="ui-footer-menu-row-link"
+          <a href="/docs/" class="ui-footer-menu-row-link"
             >Documentation</a
           >
         </li>
@@ -1104,12 +1104,12 @@ exports[`Footer Snapshot Test > view component > test case common to both #0`] =
         <li class="p-menu-row-snug">
           <a
             class="ui-footer-menu-row-link"
-            href="/documentation/quick-start-guide"
+            href="/docs/quick-start-guide"
             >Start in 5 minutes</a
           >
         </li>
         <li class="p-menu-row-snug">
-          <a class="ui-footer-menu-row-link" href="/documentation"
+          <a class="ui-footer-menu-row-link" href="/docs"
             >Documentation</a
           >
         </li>

--- a/lib/ably_ui/version.rb
+++ b/lib/ably_ui/version.rb
@@ -1,3 +1,3 @@
 module AblyUi
-  VERSION = '7.1.0.dev.02abc5e'
+  VERSION = '7.1.0.dev.97a5585'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "7.1.0-dev.02abc5e",
+  "version": "7.1.0-dev.97a5585",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/preview/Gemfile
+++ b/preview/Gemfile
@@ -36,4 +36,4 @@ gem 'view_component', '~> 2.33.0', require: 'view_component/engine'
 
 gem 'responders'
 
-gem 'ably-ui', '7.1.0.dev.02abc5e', require: 'ably_ui'
+gem 'ably-ui', '7.1.0.dev.97a5585', require: 'ably_ui'

--- a/preview/Gemfile.lock
+++ b/preview/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ably-ui (7.1.0.dev.02abc5e)
+    ably-ui (7.1.0.dev.97a5585)
       view_component (>= 2.33, < 2.50)
     actioncable (6.0.3.4)
       actionpack (= 6.0.3.4)
@@ -169,7 +169,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ably-ui (= 7.1.0.dev.02abc5e)
+  ably-ui (= 7.1.0.dev.97a5585)
   bootsnap (>= 1.4.2)
   byebug
   listen (~> 3.2)

--- a/preview/package.json
+++ b/preview/package.json
@@ -2,7 +2,7 @@
   "name": "preview",
   "private": true,
   "dependencies": {
-    "@ably/ui": "7.1.0-dev.02abc5e",
+    "@ably/ui": "7.1.0-dev.97a5585",
     "@babel/preset-react": "^7.12.5",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",

--- a/preview/yarn.lock
+++ b/preview/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@ably/ui@7.1.0-dev.02abc5e":
-  version "7.1.0-dev.02abc5e"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-7.1.0-dev.02abc5e.tgz#19d941bc83f1debd7c7920107935171d08217469"
-  integrity sha512-yyjXu45fDCKgudI6ZDi3u7+zyqOoeL9hQeKJ+sX08U1hu8DX8g10uBna1o0lIP1GivyTHOcoyBOHpyGnFnyR3g==
+"@ably/ui@7.1.0-dev.97a5585":
+  version "7.1.0-dev.97a5585"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-7.1.0-dev.97a5585.tgz#b819697fad5edc12a41d46d618ecf5887e9d3121"
+  integrity sha512-KSdWTqRrMWuRJbKniYdkJcplYuWxzgvLqhQnbYbLW/1XGztviOGKUkQotjoDxovmvppPygobEKbDLFrmWefMrg==
   dependencies:
     array-flat-polyfill "^1.0.1"
     deepmerge "^4.2.2"

--- a/src/core/Footer/component.html.erb
+++ b/src/core/Footer/component.html.erb
@@ -74,10 +74,10 @@
       <h2 class="ui-footer-col-title">Developers</h2>
       <ul>
         <li class="p-menu-row-snug">
-          <%= link_to 'Start in 5 minutes', abs_url("/documentation/quick-start-guide"), class: "ui-footer-menu-row-link" %>
+          <%= link_to 'Start in 5 minutes', abs_url("/docs/quick-start-guide"), class: "ui-footer-menu-row-link" %>
         </li>
         <li class="p-menu-row-snug">
-          <%= link_to 'Documentation', abs_url("/documentation"), class: "ui-footer-menu-row-link" %>
+          <%= link_to 'Documentation', abs_url("/docs"), class: "ui-footer-menu-row-link" %>
         </li>
         <li class="p-menu-row-snug">
           <%= link_to 'Tutorials', abs_url("/tutorials"), class: "ui-footer-menu-row-link" %>

--- a/src/core/Footer/component.jsx
+++ b/src/core/Footer/component.jsx
@@ -116,12 +116,12 @@ export default function Footer({ paths, urlBase }) {
           <h2 className="ui-footer-col-title">Developers</h2>
           <ul>
             <li className="p-menu-row-snug">
-              <a href={absUrl("/documentation/quick-start-guide")} className="ui-footer-menu-row-link">
+              <a href={absUrl("/docs/quick-start-guide")} className="ui-footer-menu-row-link">
                 Start in 5 minutes
               </a>
             </li>
             <li className="p-menu-row-snug">
-              <a href={absUrl("/documentation/")} className="ui-footer-menu-row-link">
+              <a href={absUrl("/docs/")} className="ui-footer-menu-row-link">
                 Documentation
               </a>
             </li>

--- a/src/core/MeganavContentDevelopers/component.html.erb
+++ b/src/core/MeganavContentDevelopers/component.html.erb
@@ -11,7 +11,7 @@
       Docs, quick start guides, tutorials, and API reference to help you start building with Ably’s platform and APIs.
     </p>
 
-    <%= render(AblyUi::Core::FeaturedLink.new(url: abs_url("/documentation"))) do %>Visit Documentation<% end %>
+    <%= render(AblyUi::Core::FeaturedLink.new(url: abs_url("/docs"))) do %>Visit Documentation<% end %>
   </div>
 
   <div>

--- a/src/core/MeganavContentDevelopers/component.jsx
+++ b/src/core/MeganavContentDevelopers/component.jsx
@@ -18,7 +18,7 @@ const MeganavContentDevelopers = ({ absUrl }) => (
         Docs, quick start guides, tutorials, and API reference to help you start building with Ably’s platform and APIs.
       </p>
 
-      <FeaturedLink url={absUrl("/documentation")}>Visit Documentation</FeaturedLink>
+      <FeaturedLink url={absUrl("/docs")}>Visit Documentation</FeaturedLink>
     </div>
 
     <div>


### PR DESCRIPTION
Jira Ticket Link / Motivation
----

Documentation now lives `/docs`, and no longer under `/documentation`. See WEB-2175 for more information.


Summary of changes
----

Updated all documentation likes to be `/docs`.

How do you manually test this?
----

Confirm the documentation links go to `/docs` directly.

Merge/Deploy Checklist
----

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [x] Rebased and squashed commits
- [x] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

Frontend Checklist
----

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
