### PR TITLE
[FIX] Links to status.ably.com should be using https

### DIFF
--- a/src/core/MeganavContentDevelopers/component.html.erb
+++ b/src/core/MeganavContentDevelopers/component.html.erb
@@ -66,7 +66,7 @@
       </li>
 
       <li>
-        <a href="http://status.ably.com/" class="group ui-meganav-media py-12">
+        <a href="https://status.ably.com/" class="group ui-meganav-media py-12">
           <p class="ui-meganav-media-heading">
             Status<iframe
               src="https://status.ably.com/embed/icon"

--- a/src/core/MeganavContentDevelopers/component.jsx
+++ b/src/core/MeganavContentDevelopers/component.jsx
@@ -74,7 +74,7 @@ const MeganavContentDevelopers = ({ absUrl }) => (
           </a>
         </li>
         <li>
-          <a href="http://status.ably.com/" className="group ui-meganav-media py-12">
+          <a href="https://status.ably.com/" className="group ui-meganav-media py-12">
             <p className="ui-meganav-media-heading">
               Status
               <iframe


### PR DESCRIPTION
Motivation
----

All our own properties are served over HTTPS so we should link to them like this and save the clients a needless redirect.


Summary of changes
----

Updated two references from `http://status.ably.com` to `https://status.ably.com`. See commit for details.

How do you manually test this?
----

The status links in the meganav should be https.

Merge/Deploy Checklist
----

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [x] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

Frontend Checklist
----

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
