### PR TITLE
WEB-2689 - Update meganav for atomic examples to include Chat Admin Privileges

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ably-ui (8.7.0.dev.c29ac14)
+    ably-ui (8.7.0.dev.3fee7c0)
       view_component (>= 2.33, < 2.50)
 
 GEM

--- a/lib/ably_ui/version.rb
+++ b/lib/ably_ui/version.rb
@@ -1,3 +1,3 @@
 module AblyUi
-  VERSION = '8.7.0.dev.c29ac14'
+  VERSION = '8.7.0.dev.3fee7c0'
 end

--- a/lib/ably_ui/version.rb
+++ b/lib/ably_ui/version.rb
@@ -1,3 +1,3 @@
 module AblyUi
-  VERSION = '8.7.0.dev.c29ac14'
+  VERSION = '8.7.0.dev.9e03cd7'
 end

--- a/lib/ably_ui/version.rb
+++ b/lib/ably_ui/version.rb
@@ -1,3 +1,3 @@
 module AblyUi
-  VERSION = '8.7.0.dev.9e03cd7'
+  VERSION = '8.7.0.dev.c29ac14'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "8.7.0-dev.c29ac14",
+  "version": "8.7.0-dev.3fee7c0",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "8.7.0-dev.c29ac14",
+  "version": "8.7.0-dev.9e03cd7",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "8.7.0-dev.9e03cd7",
+  "version": "8.7.0-dev.c29ac14",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/preview/Gemfile
+++ b/preview/Gemfile
@@ -37,7 +37,7 @@ gem 'view_component', '~> 2.33.0', require: 'view_component/engine'
 
 gem 'responders'
 
-gem 'ably-ui', '8.7.0.dev.c29ac14', require: 'ably_ui'
+gem 'ably-ui', '8.7.0.dev.3fee7c0', require: 'ably_ui'
 
 # https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias
 gem 'psych', '< 4'

--- a/preview/Gemfile.lock
+++ b/preview/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ably-ui (8.7.0.dev.c29ac14)
+    ably-ui (8.7.0.dev.3fee7c0)
       view_component (>= 2.33, < 2.50)
     actioncable (6.0.5.1)
       actionpack (= 6.0.5.1)
@@ -175,7 +175,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  ably-ui (= 8.7.0.dev.c29ac14)
+  ably-ui (= 8.7.0.dev.3fee7c0)
   bootsnap (>= 1.4.2)
   byebug
   dotenv-rails

--- a/preview/package.json
+++ b/preview/package.json
@@ -2,7 +2,7 @@
   "name": "preview",
   "private": true,
   "dependencies": {
-    "@ably/ui": "8.7.0-dev.c29ac14",
+    "@ably/ui": "8.7.0-dev.3fee7c0",
     "@babel/preset-react": "^7.12.5",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",

--- a/preview/yarn.lock
+++ b/preview/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@ably/ui@8.7.0-dev.c29ac14":
-  version "8.7.0-dev.c29ac14"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-8.7.0-dev.c29ac14.tgz#1cf1f79ca41827500de68dcc57cea284a618376d"
-  integrity sha512-lTcxGZ0EAKTzQZTPB93Cx214WdDg7G3qFRTq/HK0GGdl1NbrHGf4BZopmDh78G8T193AbIaeam2XkyQaajMxyg==
+"@ably/ui@8.7.0-dev.3fee7c0":
+  version "8.7.0-dev.3fee7c0"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-8.7.0-dev.3fee7c0.tgz#a4c177b90efa2026a0698f9d66edc2732e81f1c2"
+  integrity sha512-CyY1vnaMoIRcMcqXIPyPcgByFu5qbpQYz7GqNAO+0DElrdlWoTX76Qu0Wr3JQqcnQXqXwnKHtiqfPDI7H6Lcdg==
   dependencies:
     addsearch-js-client "^0.7.0"
     array-flat-polyfill "^1.0.1"

--- a/src/core/MeganavContentPlatform/component.html.erb
+++ b/src/core/MeganavContentPlatform/component.html.erb
@@ -37,12 +37,6 @@
           <% end %>
         </li>
         <li>
-          <%= link_to abs_url("/examples/live-charts"), class: "ui-meganav-media group" do %>
-            <p class="ui-meganav-media-heading">Live Charts</p>
-            <p class="ui-meganav-media-copy">Visualise live metrics and data in a chart.</p>
-          <% end %>
-        </li>
-        <li>
           <%= link_to abs_url("/examples/live-cursors"), class: "ui-meganav-media group" do %>
             <p class="ui-meganav-media-heading">Live Cursors</p>
             <p class="ui-meganav-media-copy">Track all cursors in realtime.</p>
@@ -52,6 +46,12 @@
           <%= link_to abs_url("/examples/typing-indicator"), class: "ui-meganav-media group" do %>
             <p class="ui-meganav-media-heading">Typing Indicator</p>
             <p class="ui-meganav-media-copy">See when a user is typing a message.</p>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to abs_url("/examples/chat-admin-privileges"), class: "ui-meganav-media group" do %>
+            <p class="ui-meganav-media-heading">Chat Admin Privileges</p>
+            <p class="ui-meganav-media-copy">Control who can take admin actions in a digital space.</p>
           <% end %>
         </li>
       </ul>

--- a/src/core/MeganavContentPlatform/component.jsx
+++ b/src/core/MeganavContentPlatform/component.jsx
@@ -46,12 +46,6 @@ const MeganavContentPlatform = ({ paths, absUrl }) => (
             </a>
           </li>
           <li>
-            <a href={absUrl("/examples/live-charts")} className="ui-meganav-media group">
-              <p className="ui-meganav-media-heading">Live Charts</p>
-              <p className="ui-meganav-media-copy">Visualise live metrics and data in a chart.</p>
-            </a>
-          </li>
-          <li>
             <a href={absUrl("/examples/live-cursors")} className="ui-meganav-media group">
               <p className="ui-meganav-media-heading">Live Cursors</p>
               <p className="ui-meganav-media-copy">Track all cursors in realtime.</p>
@@ -61,6 +55,12 @@ const MeganavContentPlatform = ({ paths, absUrl }) => (
             <a href={absUrl("/examples/typing-indicator")} className="ui-meganav-media group">
               <p className="ui-meganav-media-heading">Typing Indicator</p>
               <p className="ui-meganav-media-copy">See when a user is typing a message.</p>
+            </a>
+          </li>
+          <li>
+            <a href={absUrl("/examples/chat-admin-privileges")} className="ui-meganav-media group">
+              <p className="ui-meganav-media-heading">Chat Admin Privileges</p>
+              <p className="ui-meganav-media-copy">Control who can take admin actions in a digital space.</p>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Jira Ticket Link / Motivation
----

WEB-2689


Summary of changes
----

Remove Live Charts and Add Chat Admin Privileges for Mega Nav for both JS and erb

Screenshot
<img width="1376" alt="Screenshot 2023-01-13 at 12 26 56" src="https://user-images.githubusercontent.com/9053042/212320205-c1baabec-006f-49c0-8841-b687c545e3fd.png">



How do you manually test this?
----

- Check here
JS: https://ably-ui-web-2689-tcp1hyds64yiu.herokuapp.com/components/meganav
Rails:  https://ably-ui-web-2689-tcp1hyds64yiu.herokuapp.com/components/meganav?framework=vw

Reviewer Tasks (optional)
----

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->


Merge/Deploy Checklist
----

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [x] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

Frontend Checklist
----

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [x] Added before/after screenshots for changes
- [x] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
