### PR TITLE
Add Kotlin in the Syntax Highlighter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ably-ui (8.7.0.dev.f4e6f79)
+    ably-ui (8.7.0.dev.de58591)
       view_component (>= 2.33, < 2.50)
 
 GEM

--- a/lib/ably_ui/version.rb
+++ b/lib/ably_ui/version.rb
@@ -1,3 +1,3 @@
 module AblyUi
-  VERSION = '8.7.0.dev.f4e6f79'
+  VERSION = '8.7.0.dev.de58591'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "8.7.0-dev.f4e6f79",
+  "version": "8.7.0-dev.de58591",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/preview/Gemfile
+++ b/preview/Gemfile
@@ -37,7 +37,7 @@ gem 'view_component', '~> 2.33.0', require: 'view_component/engine'
 
 gem 'responders'
 
-gem 'ably-ui', '8.7.0.dev.f4e6f79', require: 'ably_ui'
+gem 'ably-ui', '8.7.0.dev.de58591', require: 'ably_ui'
 
 # https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias
 gem 'psych', '< 4'

--- a/preview/Gemfile.lock
+++ b/preview/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ably-ui (8.7.0.dev.f4e6f79)
+    ably-ui (8.7.0.dev.de58591)
       view_component (>= 2.33, < 2.50)
     actioncable (6.0.5.1)
       actionpack (= 6.0.5.1)
@@ -175,7 +175,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  ably-ui (= 8.7.0.dev.f4e6f79)
+  ably-ui (= 8.7.0.dev.de58591)
   bootsnap (>= 1.4.2)
   byebug
   dotenv-rails

--- a/preview/app/views/components/code_react.html.erb
+++ b/preview/app/views/components/code_react.html.erb
@@ -50,10 +50,33 @@ listener = new MessageListener() {
 channel.subscribe("greeting", listener);
 }}) %>
 
+
+
+<h1 class="text-h2 my-16">Kotlin</h1>
+
+<%= react_component('code', {
+  language: "kotlin",
+  snippet: %q{
+val exampleConstraints = DefaultResolutionConstraints(
+  DefaultResolutionSet( // this constructor provides one Resolution for all states
+      Resolution(
+          accuracy = Accuracy.BALANCED,
+          desiredInterval = 1000L,
+          minimumDisplacement = 1.0
+      )
+  ),
+  proximityThreshold = DefaultProximity(spatial = 1.0),
+  batteryLevelThreshold = 10.0f,
+  lowBatteryMultiplier = 2.0f
+)
+}}) %>
+
 <% content_for :component do %>
   <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", () => {
       document.body.classList.add("bg-light-grey", "m-32");
     });
   </script>
+
+
 <% end %>

--- a/preview/app/views/components/code_vw.html.erb
+++ b/preview/app/views/components/code_vw.html.erb
@@ -47,6 +47,25 @@ listener = new MessageListener() {
 channel.subscribe("greeting", listener);
 })) %>
 
+
+<h1 class="text-h2 my-16">Kotlin</h1>
+
+<%= render(AblyUi::Core::Code.new(language: "kotlin",
+  snippet: %q{
+val exampleConstraints = DefaultResolutionConstraints(
+  DefaultResolutionSet( // this constructor provides one Resolution for all states
+      Resolution(
+          accuracy = Accuracy.BALANCED,
+          desiredInterval = 1000L,
+          minimumDisplacement = 1.0
+      )
+  ),
+  proximityThreshold = DefaultProximity(spatial = 1.0),
+  batteryLevelThreshold = 10.0f,
+  lowBatteryMultiplier = 2.0f
+)
+})) %>
+
 <% content_for :component do %>
   <%= javascript_packs_with_chunks_tag 'code-vw' %>
 <% end %>

--- a/preview/package.json
+++ b/preview/package.json
@@ -2,7 +2,7 @@
   "name": "preview",
   "private": true,
   "dependencies": {
-    "@ably/ui": "8.7.0-dev.f4e6f79",
+    "@ably/ui": "8.7.0-dev.de58591",
     "@babel/preset-react": "^7.12.5",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",

--- a/preview/yarn.lock
+++ b/preview/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@ably/ui@8.7.0-dev.f4e6f79":
-  version "8.7.0-dev.f4e6f79"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-8.7.0-dev.f4e6f79.tgz#c19ab543452408dbc63393587f6c1dd050779903"
-  integrity sha512-o+XPz2xJmtjY3sGckMNxiioqswEwcgK0ZMh8FM+pbxX505VzqqVG5R1Wr2php43ZebSnDem/R6q43QKn3uya3Q==
+"@ably/ui@8.7.0-dev.de58591":
+  version "8.7.0-dev.de58591"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-8.7.0-dev.de58591.tgz#5ba758a199309a943af75ada8937e8f98bee4479"
+  integrity sha512-YMuOw3kpZk72lcrAn56Y0EyKiGwWNhFF0w7AFOz5nmrmvsw8+0UaixE+L3G5vDfSjvNZpTQmx9ic4N0xDC5JQw==
   dependencies:
     addsearch-js-client "^0.7.0"
     array-flat-polyfill "^1.0.1"

--- a/src/core/utils/syntax-highlighter-registry.js
+++ b/src/core/utils/syntax-highlighter-registry.js
@@ -22,6 +22,7 @@ import php from "highlight.js/lib/languages/php";
 import python from "highlight.js/lib/languages/python";
 import ruby from "highlight.js/lib/languages/ruby";
 import swift from "highlight.js/lib/languages/swift";
+import kotlin from "highlight.js/lib/languages/kotlin";
 import sql from "highlight.js/lib/languages/sql";
 import xml from "highlight.js/lib/languages/xml";
 import yaml from "highlight.js/lib/languages/yaml";
@@ -44,6 +45,7 @@ const registry = [
   { label: "C++", key: "cpp", module: cpp },
   { label: "Dart", key: "dart", module: dart },
   { label: "Swift", key: "swift", module: swift },
+  { label: "Kotlin", key: "kotlin", module: kotlin },
   { label: "Objective C", key: "objectivec", module: objectivec },
   { label: "Node.js", key: "javascript", module: javascript },
   { label: "JSON", key: "json", module: json },

--- a/src/core/utils/syntax-highlighter.js
+++ b/src/core/utils/syntax-highlighter.js
@@ -43,6 +43,11 @@ const languageToHighlightKey = (lang) => {
       id = "typescript";
       break;
 
+    case "kotlin":
+    case "kt":
+      id = "kotlin";
+      break;
+
     case "shell":
     case "fh":
     case "sh":


### PR DESCRIPTION
Jira Ticket Link / Motivation
----

Kotlin is not added yet in ably-ui and is being used in docs
Issue reported [here](https://ably-real-time.slack.com/archives/C01LR5XFHFX/p1681672091395959)


Summary of changes
----

Add Kotlin in the syntax highlighter and add examples so users can test
the user can use `kotlin` or `kt` as keyword for this language

How do you manually test this?
----
Kotlin added here - https://ably-ui-add-kotlin-lang-t7xpqz.herokuapp.com/components/code
Rails - https://ably-ui-add-kotlin-lang-t7xpqz.herokuapp.com/components/code?framework=vw

Reviewer Tasks (optional)
----

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->


Merge/Deploy Checklist
----

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

Frontend Checklist
----

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
