### PR TITLE
Use latest version of ably ui in repo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ably-ui (8.7.0.dev.827e917)
+    ably-ui (11.7.1)
       view_component (>= 2.33, < 2.50)
 
 GEM

--- a/lib/ably_ui/version.rb
+++ b/lib/ably_ui/version.rb
@@ -1,3 +1,3 @@
 module AblyUi
-  VERSION = '8.7.0.dev.827e917'
+  VERSION = '11.7.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "8.7.0-dev.827e917",
+  "version": "11.7.1",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/preview/Gemfile
+++ b/preview/Gemfile
@@ -37,7 +37,7 @@ gem 'view_component', '~> 2.33.0', require: 'view_component/engine'
 
 gem 'responders'
 
-gem 'ably-ui', '8.7.0.dev.827e917', require: 'ably_ui'
+gem 'ably-ui', '11.7.1', require: 'ably_ui'
 
 # https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias
 gem 'psych', '< 4'

--- a/preview/Gemfile.lock
+++ b/preview/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ably-ui (8.7.0.dev.827e917)
+    ably-ui (11.7.1)
       view_component (>= 2.33, < 2.50)
     actioncable (6.0.5.1)
       actionpack (= 6.0.5.1)
@@ -176,7 +176,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  ably-ui (= 8.7.0.dev.827e917)
+  ably-ui (= 11.7.1)
   bootsnap (>= 1.4.2)
   byebug
   dotenv-rails

--- a/preview/package.json
+++ b/preview/package.json
@@ -2,7 +2,7 @@
   "name": "preview",
   "private": true,
   "dependencies": {
-    "@ably/ui": "8.7.0-dev.827e917",
+    "@ably/ui": "11.7.1",
     "@babel/preset-react": "^7.12.5",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.4",

--- a/preview/yarn.lock
+++ b/preview/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@ably/ui@8.7.0-dev.827e917":
-  version "8.7.0-dev.827e917"
-  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-8.7.0-dev.827e917.tgz#cde64121b09c017ea54e7c8a1ff39214aab3b366"
-  integrity sha512-d6lGUiyz192gxESyC/Jd2HAtr1Es+txrvTGCSuNyqPVbvhZX2aMho9wcdhVmaEBcbw7m/PE6xfAraguuUG0Ktg==
+"@ably/ui@11.7.1":
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/@ably/ui/-/ui-11.7.1.tgz#dd59f45b2ccd8889d3f0cc1f2c751fa542f9ec27"
+  integrity sha512-izRK2DAYhBlmcrBzpwAOMoH8iMRaz+LNfbL7MzGNCwkPipuPqL1+9hVTXIhp0tfcGIlOAnR/CjZECjKVxLcTeg==
   dependencies:
     "@mrtkrcm/cypress-plugin-snapshots" "https://github.com/mrtkrcm/cypress-plugin-snapshots#v1.13.0"
     addsearch-js-client "^0.7.0"


### PR DESCRIPTION
The released version is always based on the GitHub tag, but to avoid confusion it's good to update it in the repo as well.
