### PR TITLE
Fix update versions action

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16.17.0
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm install -g yarn
       - name: Update preview app
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config --global user.email "github@action.code"
           git config --global user.name "Github Action"
@@ -40,3 +40,8 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           branch: update-versions-to-${{ steps.latesttag.outputs.tag }}
+          title: Update @ably/ui version in repo to ${{ steps.latesttag.outputs.tag }}
+          body: "Update files that are not updated during the release process. 
+            Sometimes published packages are not available immediately so we open this PR for convenience."
+          # This is doesn't work due to what seems a permission issue https://github.com/peter-evans/create-pull-request/issues/155
+          # team-reviewers: "team-website"

--- a/scripts/update-dependents.sh
+++ b/scripts/update-dependents.sh
@@ -20,6 +20,7 @@ if [ -z "$WEBSITE_RESULT" ]; then
 else
   echo "Failed to trigger workflow:"
   echo $WEBSITE_RESULT
+  exit 1
 fi
 
 echo ""
@@ -37,4 +38,5 @@ if [ -z "$VOLTAIRE_RESULT" ]; then
 else
   echo "Failed to trigger workflow:"
   echo $VOLTAIRE_RESULT
+  exit 1
 fi


### PR DESCRIPTION
Fix update versions action which on `release` and updates the values of versions for the preview up and library https://github.com/ably/ably-ui/actions/runs/7061490420. This is separate to the releasing because it sometimes takes a while for ruby gems to update the package availability - so we do it as a separate step.

I've also updated update-dependents to properly fail if the curl fails. This doesn't work however, as we need to obtain a valid REGISTRY_TOKEN.

