### PR TITLE
[FEAT] Add support to FeaturedLink for opening in a new window

### DIFF
--- a/src/core/FeaturedLink/component.jsx
+++ b/src/core/FeaturedLink/component.jsx
@@ -3,37 +3,70 @@ import T from "prop-types";
 
 import Icon from "../Icon/component.jsx";
 
-const FeaturedLink = ({ url, textSize = "text-p2", iconColor = "text-cool-black", flush = false, reverse = false, additionalCSS = "", children }) => (
-  <a
-    href={url}
-    className={`font-sans font-bold block text-gui-default hover:text-gui-hover focus:text-gui-focus focus:outline-gui-focus group ui-${textSize} ${
-      flush ? "" : "py-8"
-    } ${additionalCSS}`}
-    style={{ "--featured-link-icon-size": `var(${textSize.replace("text", "--fs")})` }}
-  >
-    {reverse ? (
-      <>
-        <Icon
-          name="icon-gui-link-arrow"
-          size={`calc(var(--featured-link-icon-size) * 1.25)`}
-          color={iconColor}
-          additionalCSS="align-middle mr-8 relative -top-1 -right-4 transition-all group-hover:right-0 transform rotate-180"
-        />
-        {children}
-      </>
-    ) : (
-      <>
-        {children}
-        <Icon
-          name="icon-gui-link-arrow"
-          size={`calc(var(--featured-link-icon-size) * 1.25)`}
-          color={iconColor}
-          additionalCSS="align-middle ml-8 relative -top-1 -left-4 transition-all group-hover:left-0"
-        />
-      </>
-    )}
-  </a>
-);
+// When generating links with target=_blank, we only add `noreferrer` to
+// links that don't start with `/`, so we can continue tracking referrers
+// across our own domains
+const buildTargetAndRel = (url, newWindow) => {
+  const props = {};
+
+  if (newWindow) {
+    props.target = "_blank";
+
+    if (url.startsWith("/") && !url.startsWith("//")) {
+      props.rel = "noopener";
+    } else {
+      props.rel = "noopenner noreferrer";
+    }
+  }
+
+  return props;
+};
+
+const FeaturedLink = ({
+  url,
+  textSize = "text-p2",
+  iconColor = "text-cool-black",
+  flush = false,
+  reverse = false,
+  additionalCSS = "",
+  newWindow = false,
+  children,
+}) => {
+  const targetAndRel = buildTargetAndRel(url, newWindow);
+
+  return (
+    <a
+      href={url}
+      className={`font-sans font-bold block text-gui-default hover:text-gui-hover focus:text-gui-focus focus:outline-gui-focus group ui-${textSize} ${
+        flush ? "" : "py-8"
+      } ${additionalCSS}`}
+      style={{ "--featured-link-icon-size": `var(${textSize.replace("text", "--fs")})` }}
+      {...targetAndRel}
+    >
+      {reverse ? (
+        <>
+          <Icon
+            name="icon-gui-link-arrow"
+            size={`calc(var(--featured-link-icon-size) * 1.25)`}
+            color={iconColor}
+            additionalCSS="align-middle mr-8 relative -top-1 -right-4 transition-all group-hover:right-0 transform rotate-180"
+          />
+          {children}
+        </>
+      ) : (
+        <>
+          {children}
+          <Icon
+            name="icon-gui-link-arrow"
+            size={`calc(var(--featured-link-icon-size) * 1.25)`}
+            color={iconColor}
+            additionalCSS="align-middle ml-8 relative -top-1 -left-4 transition-all group-hover:left-0"
+          />
+        </>
+      )}
+    </a>
+  );
+};
 
 FeaturedLink.propTypes = {
   url: T.string,
@@ -43,6 +76,7 @@ FeaturedLink.propTypes = {
   flush: T.bool,
   reverse: T.bool,
   additionalCSS: T.string,
+  newWindow: T.bool,
 };
 
 export default FeaturedLink;


### PR DESCRIPTION
Jira Ticket Link / Motivation
----

In the dashboard we want to have featured links that open in new windows.

Summary of changes
----

By passing `newWindow: true` to `<FeaturedLink>` you'll get a link that opens in a new window.

When generating links with `target="_blank"`, we only add `noreferrer` to links that don't start with `/`, so we can continue tracking referrers across our own domains.

How do you manually test this?
----

¯\\\_(ツ)\_/¯ 

Merge/Deploy Checklist
----

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [x] Rebased and squashed commits
- [x] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

Frontend Checklist
----

<!-- Committer frontend changes checklist  -->

- [x] No frontend changes in this PR
