### PR TITLE
[FIX] Bundler & Gemfile issues preventing release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ably-ui (12.0.0.dev.9a060af)
+    ably-ui (13.1.0)
       view_component (>= 2.33, < 2.50)
 
 GEM

--- a/ably-ui.gemspec
+++ b/ably-ui.gemspec
@@ -1,22 +1,25 @@
+# frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "ably_ui/version"
+require 'ably_ui/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "ably-ui"
+  spec.name          = 'ably-ui'
   spec.version       = AblyUi::VERSION
-  spec.authors       = ["Dominik Piatek", "Arti Mathanda", "Bruce Thomas"]
-  spec.email         = ["dominik.piatek@ably.com", "arti.mathanda@ably.com", "bruce.thomas@ably.com"]
-  spec.summary       = "Shared component library and design system for Ably Real-time Ltd (ably.com)"
+  spec.authors       = ['Kenneth Kalmer']
+  spec.email         = ['kenneth.kalmer@ably.com']
+  spec.summary       = 'Shared component library and design system for Ably Real-time Ltd (ably.com)'
   spec.licenses      = ['Apache-2.0']
-  spec.homepage      = "https://github.com/ably/ably-ui"
+  spec.homepage      = 'https://github.com/ably/ably-ui'
 
   spec.metadata = {
-    "source_code_uri" => "https://github.com/ably/ably-ui",
+    'source_code_uri' => 'https://github.com/ably/ably-ui'
   }
 
-  spec.files         = Dir['lib/**/*'] + %w[Gemfile Gemfile.lock LICENSE README.md ably-ui.gemspec]
+  spec.files = Dir['lib/**/*'] + %w[Gemfile Gemfile.lock LICENSE README.md ably-ui.gemspec]
 
-  spec.add_dependency "view_component", '>= 2.33', '< 2.50'
+  spec.add_dependency 'view_component', '>= 2.33', '< 2.50'
+
+  spec.required_ruby_version = '>= 3.1', '< 3.3'
 end


### PR DESCRIPTION
Motivation
----

#310 failed to release because the `Gemfile.lock` wasn't correct and so the release action just failed. This PR ultimately just updates the `Gemfile.lock` so we can get a new version published (13.2.1)
