### PR TITLE
[FIX] Bump Ruby version used in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           ref: "main"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.0
+          ruby-version: 3.1.2
           bundler-cache: true
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Motivation
----

After locking down the `required_ruby_version` in #312 the `release` action fails as it was pinned at Ruby 3.0

Summary of changes
----

See commit for details
