### PR TITLE
[FIX] Move @mrtkrcm/cypress-plugin-snapshots to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tailwind.extend.js"
   ],
   "devDependencies": {
+    "@mrtkrcm/cypress-plugin-snapshots": "https://github.com/mrtkrcm/cypress-plugin-snapshots#v1.13.0",
     "@storybook/addon-essentials": "^7.6.17",
     "@storybook/addon-interactions": "^7.6.17",
     "@storybook/addon-links": "^7.6.17",
@@ -65,7 +66,6 @@
     "build-storybook": "storybook build -o preview"
   },
   "dependencies": {
-    "@mrtkrcm/cypress-plugin-snapshots": "https://github.com/mrtkrcm/cypress-plugin-snapshots#v1.13.0",
     "addsearch-js-client": "^0.7.0",
     "array-flat-polyfill": "^1.0.1",
     "dompurify": "^2.2.9",


### PR DESCRIPTION
## Motivation

This dependency isn't required for using ably-ui and causes issues upstream with dependabot security notifications

## Summary of changes

See commits for details.

## How do you manually test this?

¯\\\_(ツ)\_/¯ 

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [x] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [x] No frontend changes in this PR
