### PR TITLE
[WEB-3702] Reinstate TW layer directives, remove JSX CSS imports

### DIFF
--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -5,6 +5,14 @@
 @import "../src/core/fonts/jetBrains-mono.css";
 @import "../src/core/fonts/manrope.css";
 @import "../src/core/styles.css";
+@import "../src/core/ContactFooter/component.css";
+@import "../src/core/CookieMessage/component.css";
+@import "../src/core/Flash/component.css";
+@import "../src/core/Footer/component.css";
+@import "../src/core/Meganav/component.css";
+@import "../src/core/Notice/component.css";
+@import "../src/core/Slider/component.css";
+@import "../src/core/utils/syntax-highlighter.css";
 @import "../src/reset/styles.css";
 
 @import "./application.css";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.0-dev.1939f45",
+  "version": "14.0.0-dev.d38dc6f",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.0-dev.d38dc6f",
+  "version": "14.0.0-dev.b96df46",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.0-dev.5379086",
+  "version": "14.0.0-dev.1939f45",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,7 @@
 export default {
   plugins: {
     "postcss-import": {},
+    "tailwindcss/nesting": {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/src/core/Code.tsx
+++ b/src/core/Code.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import "./utils/syntax-highlighter.css";
 import {
   highlightSnippet,
   registerDefaultLanguages,

--- a/src/core/ContactFooter.tsx
+++ b/src/core/ContactFooter.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from "react";
 import Icon from "./Icon";
 import _absUrl from "./url-base.js";
 import toggleChatWidget from "./hubspot-chat-toggle";
-import "./ContactFooter/component.css";
 
 type ContactFooterProps = {
   urlBase: string;

--- a/src/core/ContactFooter/component.css
+++ b/src/core/ContactFooter/component.css
@@ -1,9 +1,11 @@
-.ui-contact-footer {
-  background-size: 100% 100%;
-  background-position: right center;
-  @apply w-full bg-gradient-active-orange;
-}
+@layer components {
+  .ui-contact-footer {
+    background-size: 100% 100%;
+    background-position: right center;
+    @apply w-full bg-gradient-active-orange;
+  }
 
-.ui-contact-footer-box {
-  @apply p-24 sm:p-32 xl:p-40 bg-white flex flex-col justify-between rounded-sm;
+  .ui-contact-footer-box {
+    @apply p-24 sm:p-32 xl:p-40 bg-white flex flex-col justify-between rounded-sm;
+  }
 }

--- a/src/core/CookieMessage.tsx
+++ b/src/core/CookieMessage.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useEffect, useState } from "react";
 import Cookie from "js-cookie";
 
-import "./CookieMessage/component.css";
 import _absUrl from "./url-base";
 
 const COOKIE_EXPIRY = 365;

--- a/src/core/CookieMessage/component.css
+++ b/src/core/CookieMessage/component.css
@@ -1,11 +1,13 @@
-.ui-cookie-message {
-  @apply rounded-lg bg-white font-sans;
-  @apply justify-between items-center;
-  @apply opacity-100 z-50 bottom-0 fixed sm:flex;
-  @apply p-16 mb-16 ml-16;
-  max-width: 70vw;
-  box-shadow: 0px 24px 32px 0px #0000000d;
-  border: 1px solid var(--color-mid-grey);
-  border-left: 0.5rem solid var(--color-electric-cyan);
-  transition: bottom 250ms ease-out, opacity 150ms ease-out;
+@layer components {
+  .ui-cookie-message {
+    @apply rounded-lg bg-white font-sans;
+    @apply justify-between items-center;
+    @apply opacity-100 z-50 bottom-0 fixed sm:flex;
+    @apply p-16 mb-16 ml-16;
+    max-width: 70vw;
+    box-shadow: 0px 24px 32px 0px #0000000d;
+    border: 1px solid var(--color-mid-grey);
+    border-left: 0.5rem solid var(--color-electric-cyan);
+    transition: bottom 250ms ease-out, opacity 150ms ease-out;
+  }
 }

--- a/src/core/Flash.tsx
+++ b/src/core/Flash.tsx
@@ -5,7 +5,6 @@ import { nanoid } from "nanoid/non-secure";
 import { getRemoteDataStore } from "./remote-data-store.js";
 import ConnectStateWrapper from "./ConnectStateWrapper";
 import Icon from "./Icon";
-import "./Flash/component.css";
 
 type FlashProps = {
   id: string;

--- a/src/core/Flash/component.css
+++ b/src/core/Flash/component.css
@@ -1,23 +1,25 @@
-.ui-flash {
-  @apply w-full fixed;
-  top: 5.5rem;
-  z-index: calc(var(--stacking-context-page-meganav) - 10);
-  transition: margin-top 200ms;
-}
+@layer components {
+  .ui-flash {
+    @apply w-full fixed;
+    top: 5.5rem;
+    z-index: calc(var(--stacking-context-page-meganav) - 10);
+    transition: margin-top 200ms;
+  }
 
-.ui-flash-message {
-  @apply font-sans font-light antialiased max-w-screen-xl mx-auto mt-8 opacity-0 relative;
-  transition: opacity 200ms, transform 200ms, height 200ms 200ms,
-    margin-top 200ms 200ms;
-  transform: translateY(-200%) rotateX(-90deg);
-}
+  .ui-flash-message {
+    @apply font-sans font-light antialiased max-w-screen-xl mx-auto mt-8 opacity-0 relative;
+    transition: opacity 200ms, transform 200ms, height 200ms 200ms,
+      margin-top 200ms 200ms;
+    transform: translateY(-200%) rotateX(-90deg);
+  }
 
-/* dynamic content inside flash, can't add classes */
-.ui-flash-text a {
-  @apply underline;
-}
+  /* dynamic content inside flash, can't add classes */
+  .ui-flash-text a {
+    @apply underline;
+  }
 
-.ui-flash-message-enter {
-  @apply opacity-100;
-  transform: translateY(0) rotateX(0);
+  .ui-flash-message-enter {
+    @apply opacity-100;
+    transform: translateY(0) rotateX(0);
+  }
 }

--- a/src/core/Footer.tsx
+++ b/src/core/Footer.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import Icon from "./Icon";
 import _absUrl from "./url-base.js";
-import "./Footer/component.css";
 
 type FooterProps = {
   paths: {

--- a/src/core/Footer/component.css
+++ b/src/core/Footer/component.css
@@ -1,31 +1,33 @@
-.ui-footer-col-title {
-  @apply font-mono text-overline2 p-menu-row-title font-medium uppercase tracking-widen-0.16;
-}
-
-.ui-footer-menu-row-link {
-  @apply text-menu3 text-cool-black font-sans font-medium hover:text-gui-hover block;
-}
-
-.ui-footer-link {
-  @apply text-gui-default hover:text-gui-hover text-menu3 font-sans font-medium;
-}
-
-.ui-footer-compliance-text {
-  font-size: 12px;
-}
-
-.ui-footer-tick-icon {
-  min-width: 1.5rem;
-}
-
-@media (max-width: 1040px) {
-  .ui-footer-bottom-links {
-    @apply pb-40;
+@layer components {
+  .ui-footer-col-title {
+    @apply font-mono text-overline2 p-menu-row-title font-medium uppercase tracking-widen-0.16;
   }
-}
 
-@media screen {
-  .ui-footer-glassdoor {
-    display: none;
+  .ui-footer-menu-row-link {
+    @apply text-menu3 text-cool-black font-sans font-medium hover:text-gui-hover block;
+  }
+
+  .ui-footer-link {
+    @apply text-gui-default hover:text-gui-hover text-menu3 font-sans font-medium;
+  }
+
+  .ui-footer-compliance-text {
+    font-size: 12px;
+  }
+
+  .ui-footer-tick-icon {
+    min-width: 1.5rem;
+  }
+
+  @media (max-width: 1040px) {
+    .ui-footer-bottom-links {
+      @apply pb-40;
+    }
+  }
+
+  @media screen {
+    .ui-footer-glassdoor {
+      display: none;
+    }
   }
 }

--- a/src/core/Meganav.tsx
+++ b/src/core/Meganav.tsx
@@ -4,7 +4,6 @@ import { connectState } from "./remote-data-store.js";
 import { selectSessionData } from "./remote-session-data.js";
 
 import Logo from "./Logo";
-import "./Meganav/component.css";
 import MeganavData from "./Meganav/component.json";
 import MeganavScripts from "./Meganav/component.js";
 import MeganavItemsDesktop from "./MeganavItemsDesktop";

--- a/src/core/Meganav/component.css
+++ b/src/core/Meganav/component.css
@@ -1,112 +1,114 @@
-.ui-meganav-wrapper {
-  /* Define values for new stacking context defined by position: fixed */
-  --stacking-context-meganav-dropdown: 10;
-  --stacking-context-meganav-mobile-panel: 20;
+@layer components {
+  .ui-meganav-wrapper {
+    /* Define values for new stacking context defined by position: fixed */
+    --stacking-context-meganav-dropdown: 10;
+    --stacking-context-meganav-mobile-panel: 20;
 
-  z-index: var(--stacking-context-page-meganav);
+    z-index: var(--stacking-context-page-meganav);
 
-  @apply fixed top-0 w-full;
-  @apply antialiased font-sans transition-colors;
-}
+    @apply fixed top-0 w-full;
+    @apply antialiased font-sans transition-colors;
+  }
 
-.ui-meganav {
-  height: var(--ui-meganav-height);
+  .ui-meganav {
+    height: var(--ui-meganav-height);
 
-  @apply flex justify-between items-center max-w-screen-xl mx-auto;
-}
+    @apply flex justify-between items-center max-w-screen-xl mx-auto;
+  }
 
-.ui-meganav-panel,
-.ui-meganav-mobile-dropdown,
-.ui-meganav-panel-account {
-  z-index: var(--stacking-context-meganav-dropdown);
+  .ui-meganav-panel,
+  .ui-meganav-mobile-dropdown,
+  .ui-meganav-panel-account {
+    z-index: var(--stacking-context-meganav-dropdown);
 
-  @apply absolute left-0 right-0;
-  @apply border-mid-grey border-t shadow-container;
-}
+    @apply absolute left-0 right-0;
+    @apply border-mid-grey border-t shadow-container;
+  }
 
-.ui-meganav-panel {
-  @apply bg-white;
-}
+  .ui-meganav-panel {
+    @apply bg-white;
+  }
 
-.ui-meganav-panel-mobile {
-  z-index: var(--stacking-context-meganav-mobile-panel);
+  .ui-meganav-panel-mobile {
+    z-index: var(--stacking-context-meganav-mobile-panel);
 
-  /* Prevents momentum-based scrolling https://devdocs.io/css/-webkit-overflow-scrolling */
-  -webkit-overflow-scrolling: auto;
+    /* Prevents momentum-based scrolling https://devdocs.io/css/-webkit-overflow-scrolling */
+    -webkit-overflow-scrolling: auto;
 
-  @apply bg-white pt-16 border-0;
-  @apply border-mid-grey border-t shadow-container;
-  @apply fixed top-64 left-0 right-0 overflow-y-auto;
-}
+    @apply bg-white pt-16 border-0;
+    @apply border-mid-grey border-t shadow-container;
+    @apply fixed top-64 left-0 right-0 overflow-y-auto;
+  }
 
-.ui-meganav-panel-account {
-  left: auto;
-  min-width: 20rem;
-  @apply bg-white rounded-t-none;
-}
+  .ui-meganav-panel-account {
+    left: auto;
+    min-width: 20rem;
+    @apply bg-white rounded-t-none;
+  }
 
-.ui-meganav-panel-split-bg {
-  background: linear-gradient(to right, #fafafb 33%, white 33%, white 100%);
-}
+  .ui-meganav-panel-split-bg {
+    background: linear-gradient(to right, #fafafb 33%, white 33%, white 100%);
+  }
 
-.ui-meganav-link {
-  @apply text-menu2 font-bold font-sans;
-  @apply mr-12 lg:mr-24 px-0 py-20;
-  @apply hover:text-gui-hover focus:text-gui-focus focus:outline-none;
-  @apply transition-colors;
-}
+  .ui-meganav-link {
+    @apply text-menu2 font-bold font-sans;
+    @apply mr-12 lg:mr-24 px-0 py-20;
+    @apply hover:text-gui-hover focus:text-gui-focus focus:outline-none;
+    @apply transition-colors;
+  }
 
-.ui-meganav-item {
-  flex: 1 0 auto;
-}
+  .ui-meganav-item {
+    flex: 1 0 auto;
+  }
 
-.ui-meganav-mobile-link {
-  @apply p-menu-row relative -left-8 w-extend-8;
-  @apply text-menu2 font-mono font-medium block text-cool-black text-left;
-  @apply flex items-center;
-  @apply focus:text-gui-focus focus:outline-none;
-}
+  .ui-meganav-mobile-link {
+    @apply p-menu-row relative -left-8 w-extend-8;
+    @apply text-menu2 font-mono font-medium block text-cool-black text-left;
+    @apply flex items-center;
+    @apply focus:text-gui-focus focus:outline-none;
+  }
 
-.ui-meganav-account-link {
-  @apply block px-8 py-8 hover:bg-light-grey hover:text-gui-hover rounded relative -left-8 text-menu3 w-extend-8 font-bold font-mono;
-}
+  .ui-meganav-account-link {
+    @apply block px-8 py-8 hover:bg-light-grey hover:text-gui-hover rounded relative -left-8 text-menu3 w-extend-8 font-bold font-mono;
+  }
 
-.ui-meganav-content {
-  @apply max-w-screen-xl py-24 lg:py-32 mx-auto;
-  @apply grid grid-cols-1;
-  @apply px-24 md:px-32 lg:px-32 xl:px-64;
-}
+  .ui-meganav-content {
+    @apply max-w-screen-xl py-24 lg:py-32 mx-auto;
+    @apply grid grid-cols-1;
+    @apply px-24 md:px-32 lg:px-32 xl:px-64;
+  }
 
-/* This is implemented not as padding so we can change the color of just this space, while keeping the grid
+  /* This is implemented not as padding so we can change the color of just this space, while keeping the grid
      as close to the designs as possible */
-.ui-meganav-content-spacer {
-  @apply hidden md:block md:w-32 lg:w-32 xl:w-64 self-stretch flex-shrink-0 flex-grow-0;
-}
+  .ui-meganav-content-spacer {
+    @apply hidden md:block md:w-32 lg:w-32 xl:w-64 self-stretch flex-shrink-0 flex-grow-0;
+  }
 
-.ui-meganav-media {
-  @apply block px-8 py-8 hover:bg-light-grey rounded relative -left-8 w-extend-8;
-}
+  .ui-meganav-media {
+    @apply block px-8 py-8 hover:bg-light-grey rounded relative -left-8 w-extend-8;
+  }
 
-.ui-meganav-media-with-image {
-  grid-template-columns: max-content 1fr;
-  grid-template-rows: min-content 1fr;
+  .ui-meganav-media-with-image {
+    grid-template-columns: max-content 1fr;
+    grid-template-rows: min-content 1fr;
 
-  @apply block px-8 py-8 hover:bg-light-grey rounded relative -left-8 w-extend-8;
-  @apply grid gap-x-16;
-}
+    @apply block px-8 py-8 hover:bg-light-grey rounded relative -left-8 w-extend-8;
+    @apply grid gap-x-16;
+  }
 
-.ui-meganav-media-heading {
-  @apply text-menu3 text-cool-black font-bold font-sans group-hover:text-gui-hover group-focus:text-gui-focus leading-normal;
-}
+  .ui-meganav-media-heading {
+    @apply text-menu3 text-cool-black font-bold font-sans group-hover:text-gui-hover group-focus:text-gui-focus leading-normal;
+  }
 
-.ui-meganav-media-copy {
-  @apply text-p3 font-sans font-medium text-dark-grey leading-normal;
-}
+  .ui-meganav-media-copy {
+    @apply text-p3 font-sans font-medium text-dark-grey leading-normal;
+  }
 
-.ui-meganav-overline {
-  @apply text-overline2 text-cool-black uppercase font-medium font-mono tracking-widen-0.16 p-overline;
-}
+  .ui-meganav-overline {
+    @apply text-overline2 text-cool-black uppercase font-medium font-mono tracking-widen-0.16 p-overline;
+  }
 
-.ui-meganav-hr {
-  @apply my-0 text-mid-grey;
+  .ui-meganav-hr {
+    @apply my-0 text-mid-grey;
+  }
 }

--- a/src/core/Meganav/component.js
+++ b/src/core/Meganav/component.js
@@ -1,7 +1,5 @@
 import throttle from "lodash.throttle";
 
-import "./component.css";
-
 // Glossary:
 // item - is the element which contains both the control and the panel - these are adjacent
 // control - interactive element that controls showing and hiding of dropdown or panel

--- a/src/core/Notice.tsx
+++ b/src/core/Notice.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useEffect } from "react";
 
 import NoticeScripts from "./Notice/component.js";
-import "./Notice/component.css";
 import Icon from "./Icon";
 type ContentWrapperProps = {
   buttonLink: string;

--- a/src/core/Notice/component.css
+++ b/src/core/Notice/component.css
@@ -1,5 +1,7 @@
-.ui-announcement {
-  @apply font-sans;
-  max-height: 37.5rem;
-  transition: max-height 300ms;
+@layer components {
+  .ui-announcement {
+    @apply font-sans;
+    max-height: 37.5rem;
+    transition: max-height 300ms;
+  }
 }

--- a/src/core/Notice/component.js
+++ b/src/core/Notice/component.js
@@ -1,4 +1,3 @@
-import "./component.css";
 import Cookie from "js-cookie";
 import throttle from "lodash.throttle";
 

--- a/src/core/Slider.tsx
+++ b/src/core/Slider.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef, ReactNode } from "react";
 import Icon from "./Icon";
-import "./Slider/component.css";
 
 interface SliderProps {
   children: ReactNode[];

--- a/src/core/Slider/component.css
+++ b/src/core/Slider/component.css
@@ -1,38 +1,40 @@
-.ui-slider-marker {
-  font-size: 0.5rem;
-  top: -1px;
+@layer components {
+  .ui-slider-marker {
+    font-size: 0.5rem;
+    top: -1px;
 
-  @apply leading-none px-4 relative;
-}
+    @apply leading-none px-4 relative;
+  }
 
-@keyframes fillAnimation {
-  0% {
-    width: 0%;
+  @keyframes fillAnimation {
+    0% {
+      width: 0%;
+    }
+    100% {
+      width: 100%;
+    }
   }
-  100% {
-    width: 100%;
-  }
-}
 
-.ui-icon-cta {
-  @apply cursor-pointer overflow-hidden;
-  @apply rounded border-2 border-mid-grey hover:border-active-orange;
-  transition: all 0.4s;
-}
+  .ui-icon-cta {
+    @apply cursor-pointer overflow-hidden;
+    @apply rounded border-2 border-mid-grey hover:border-active-orange;
+    transition: all 0.4s;
+  }
 
-@screen sm {
-  .ui-icon-cta-left:hover .ui-icon-cta-holder {
-    transform: translateX(-120%);
+  @screen sm {
+    .ui-icon-cta-left:hover .ui-icon-cta-holder {
+      transform: translateX(-120%);
+    }
+    .ui-icon-cta-right .ui-icon-cta-holder {
+      transform: translateX(-120%);
+    }
+    .ui-icon-cta-right:hover .ui-icon-cta-holder {
+      transform: translateX(0%);
+    }
   }
-  .ui-icon-cta-right .ui-icon-cta-holder {
-    transform: translateX(-120%);
-  }
-  .ui-icon-cta-right:hover .ui-icon-cta-holder {
-    transform: translateX(0%);
-  }
-}
 
-.ui-icon-cta-holder {
-  @apply w-full h-full;
-  transition: all 0.4s;
+  .ui-icon-cta-holder {
+    @apply w-full h-full;
+    transition: all 0.4s;
+  }
 }

--- a/src/core/Slider/component.js
+++ b/src/core/Slider/component.js
@@ -1,5 +1,3 @@
-import "./component.css";
-
 import throttle from "lodash.throttle";
 
 import { queryId, queryIdAll } from "../dom-query";

--- a/src/core/scripts.js
+++ b/src/core/scripts.js
@@ -1,7 +1,5 @@
 import "array-flat-polyfill";
 
-import "./styles.css";
-
 export { default as reactRenderer, renderComponent } from "./react-renderer";
 export { default as loadSprites } from "./load-sprites";
 export { default as toggleChatWidget } from "./hubspot-chat-toggle";

--- a/src/core/styles.components.css
+++ b/src/core/styles.components.css
@@ -3,31 +3,33 @@
 @import "./styles/text.css";
 @import "./styles/forms.css";
 
-.ui-input {
-  @apply text-p2 font-medium bg-light-grey rounded p-input w-full leading-none appearance-none border border-mid-grey transition-input;
-  @apply hover:bg-white hover:shadow-input hover:border-transparent;
-  @apply focus:bg-white focus:shadow-input focus:border-transparent focus:outline-gui-focus;
-  @apply max-w-screen-sm;
-}
+@layer components {
+  .ui-input {
+    @apply text-p2 font-medium bg-light-grey rounded p-input w-full leading-none appearance-none border border-mid-grey transition-input;
+    @apply hover:bg-white hover:shadow-input hover:border-transparent;
+    @apply focus:bg-white focus:shadow-input focus:border-transparent focus:outline-gui-focus;
+    @apply max-w-screen-sm;
+  }
 
-/* Basis for icon component */
-.ui-icon-cool-black {
-  stroke: var(--color-cool-black);
-}
+  /* Basis for icon component */
+  .ui-icon-cool-black {
+    stroke: var(--color-cool-black);
+  }
 
-.ui-icon-white {
-  stroke: var(--color-white);
-}
+  .ui-icon-white {
+    stroke: var(--color-white);
+  }
 
-.ui-icon-dark-grey {
-  stroke: var(--color-dark-grey);
-}
+  .ui-icon-dark-grey {
+    stroke: var(--color-dark-grey);
+  }
 
-.ui-version-tag {
-  @apply inline-block absolute align-top uppercase font-bold whitespace-nowrap;
+  .ui-version-tag {
+    @apply inline-block absolute align-top uppercase font-bold whitespace-nowrap;
 
-  position: relative;
-  vertical-align: super;
-  margin-left: 3px;
-  font-size: 8px;
+    position: relative;
+    vertical-align: super;
+    margin-left: 3px;
+    font-size: 8px;
+  }
 }

--- a/src/core/styles/buttons.css
+++ b/src/core/styles/buttons.css
@@ -1,122 +1,124 @@
-.ui-btn {
-  @apply text-white bg-cool-black text-btn2 font-sans font-bold inline-block rounded p-btn;
-  @apply hover:text-white hover:bg-active-orange;
-  @apply active:text-white active:bg-red-orange;
-  @apply focus:text-white focus:bg-cool-black focus:outline-gui-focus;
-  @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
-  @apply transition-colors;
-  @apply inline-flex items-center justify-center;
-}
+@layer components {
+  .ui-btn {
+    @apply text-white bg-cool-black text-btn2 font-sans font-bold inline-block rounded p-btn;
+    @apply hover:text-white hover:bg-active-orange;
+    @apply active:text-white active:bg-red-orange;
+    @apply focus:text-white focus:bg-cool-black focus:outline-gui-focus;
+    @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
+    @apply transition-colors;
+    @apply inline-flex items-center justify-center;
+  }
 
-.ui-btn-alt {
-  transition: background-position 0.2s;
-  background: linear-gradient(
-    61.2deg,
-    var(--color-active-orange) 5%,
-    #fe5215 19%,
-    #fc4a13 27%,
-    #f73c10 33%,
-    #f1280a 39%,
-    #e90f04 44%,
-    var(--color-red-orange) 50%
-  );
-  background-size: 200% 100%;
-  background-position: 0% 0%;
+  .ui-btn-alt {
+    transition: background-position 0.2s;
+    background: linear-gradient(
+      61.2deg,
+      var(--color-active-orange) 5%,
+      #fe5215 19%,
+      #fc4a13 27%,
+      #f73c10 33%,
+      #f1280a 39%,
+      #e90f04 44%,
+      var(--color-red-orange) 50%
+    );
+    background-size: 200% 100%;
+    background-position: 0% 0%;
 
-  @apply text-white text-btn2 font-sans font-bold inline-block rounded p-btn;
-  @apply focus:outline-gui-focus;
-  @apply inline-flex items-center justify-center;
-}
+    @apply text-white text-btn2 font-sans font-bold inline-block rounded p-btn;
+    @apply focus:outline-gui-focus;
+    @apply inline-flex items-center justify-center;
+  }
 
-.ui-btn-alt:hover,
-.ui-btn-alt:focus {
-  background-position: 100% 0%;
-}
+  .ui-btn-alt:hover,
+  .ui-btn-alt:focus {
+    background-position: 100% 0%;
+  }
 
-.ui-btn-alt:disabled {
-  background: linear-gradient(var(--gradient-transparent));
-  @apply bg-gui-unavailable text-mid-grey cursor-not-allowed;
-}
+  .ui-btn-alt:disabled {
+    background: linear-gradient(var(--gradient-transparent));
+    @apply bg-gui-unavailable text-mid-grey cursor-not-allowed;
+  }
 
-.ui-btn-invert {
-  @apply text-cool-black bg-white text-btn2 font-sans font-bold inline-block rounded p-btn;
-  @apply hover:text-white hover:bg-active-orange;
-  @apply active:text-white active:bg-red-orange;
-  @apply focus:text-white focus:bg-cool-black focus:outline-gui-focus;
-  @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
-  @apply transition-colors;
-  @apply inline-flex items-center justify-center;
-}
+  .ui-btn-invert {
+    @apply text-cool-black bg-white text-btn2 font-sans font-bold inline-block rounded p-btn;
+    @apply hover:text-white hover:bg-active-orange;
+    @apply active:text-white active:bg-red-orange;
+    @apply focus:text-white focus:bg-cool-black focus:outline-gui-focus;
+    @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
+    @apply transition-colors;
+    @apply inline-flex items-center justify-center;
+  }
 
-.ui-btn-secondary {
-  @apply text-cool-black bg-white text-btn2 font-sans font-bold inline-block border-btn border-cool-black rounded p-btn;
-  @apply hover:text-cool-black hover:border-active-orange hover:bg-white;
-  @apply active:border-red-orange active:bg-white;
-  @apply focus:border-cool-black focus:bg-white focus:outline-gui-focus;
-  @apply disabled:text-gui-unavailable disabled:border-gui-unavailable disabled:bg-white disabled:cursor-not-allowed;
-  @apply transition-colors;
-  @apply inline-flex items-center justify-center;
-}
+  .ui-btn-secondary {
+    @apply text-cool-black bg-white text-btn2 font-sans font-bold inline-block border-btn border-cool-black rounded p-btn;
+    @apply hover:text-cool-black hover:border-active-orange hover:bg-white;
+    @apply active:border-red-orange active:bg-white;
+    @apply focus:border-cool-black focus:bg-white focus:outline-gui-focus;
+    @apply disabled:text-gui-unavailable disabled:border-gui-unavailable disabled:bg-white disabled:cursor-not-allowed;
+    @apply transition-colors;
+    @apply inline-flex items-center justify-center;
+  }
 
-.ui-btn-secondary-invert {
-  @apply text-white bg-cool-black text-btn2 font-sans font-bold inline-block border-btn border-mid-grey rounded p-btn;
-  @apply hover:text-white hover:border-active-orange;
-  @apply active:border-red-orange;
-  @apply focus:outline-gui-focus;
-  @apply disabled:text-gui-unavailable disabled:border-gui-unavailable disabled:cursor-not-allowed;
-  @apply transition-colors;
-  @apply inline-flex items-center justify-center;
-}
+  .ui-btn-secondary-invert {
+    @apply text-white bg-cool-black text-btn2 font-sans font-bold inline-block border-btn border-mid-grey rounded p-btn;
+    @apply hover:text-white hover:border-active-orange;
+    @apply active:border-red-orange;
+    @apply focus:outline-gui-focus;
+    @apply disabled:text-gui-unavailable disabled:border-gui-unavailable disabled:cursor-not-allowed;
+    @apply transition-colors;
+    @apply inline-flex items-center justify-center;
+  }
 
-.ui-btn-icon {
-  @apply w-24 h-24 mr-16;
-}
+  .ui-btn-icon {
+    @apply w-24 h-24 mr-16;
+  }
 
-.ui-btn-icon-small {
-  @apply w-20 h-20 mr-12;
-}
+  .ui-btn-icon-small {
+    @apply w-20 h-20 mr-12;
+  }
 
-.ui-btn-icon-xsmall {
-  @apply w-16 h-16 mr-8;
-}
+  .ui-btn-icon-xsmall {
+    @apply w-16 h-16 mr-8;
+  }
 
-.ui-chip {
-  @apply text-btn3 p-chip rounded text-cool-black;
-  @apply hover:bg-mid-grey;
-  @apply active:bg-red-orange active:text-white;
-  @apply focus:bg-red-orange focus:text-white focus:outline-none;
-  @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
-  @apply transition-colors;
-}
+  .ui-chip {
+    @apply text-btn3 p-chip rounded text-cool-black;
+    @apply hover:bg-mid-grey;
+    @apply active:bg-red-orange active:text-white;
+    @apply focus:bg-red-orange focus:text-white focus:outline-none;
+    @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
+    @apply transition-colors;
+  }
 
-.ui-chip[data-selected] {
-  @apply bg-active-orange text-white;
-}
+  .ui-chip[data-selected] {
+    @apply bg-active-orange text-white;
+  }
 
-.ui-chip[data-selected]:hover {
-  @apply bg-mid-grey text-cool-black;
-}
+  .ui-chip[data-selected]:hover {
+    @apply bg-mid-grey text-cool-black;
+  }
 
-.ui-chip[data-selected]:focus {
-  @apply bg-red-orange text-white;
-}
+  .ui-chip[data-selected]:focus {
+    @apply bg-red-orange text-white;
+  }
 
-.ui-chip-alt {
-  @apply text-btn3 p-chip rounded text-white;
-  @apply hover:bg-gui-hover;
-  @apply active:bg-gui-active active:text-white;
-  @apply focus:bg-gui-active focus:text-white focus:outline-none;
-  @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
-  @apply transition-colors;
-}
+  .ui-chip-alt {
+    @apply text-btn3 p-chip rounded text-white;
+    @apply hover:bg-gui-hover;
+    @apply active:bg-gui-active active:text-white;
+    @apply focus:bg-gui-active focus:text-white focus:outline-none;
+    @apply disabled:text-mid-grey disabled:bg-gui-unavailable disabled:cursor-not-allowed;
+    @apply transition-colors;
+  }
 
-.ui-chip-alt[data-selected] {
-  @apply bg-dark-grey text-white;
-}
-.ui-chip-alt[data-selected]:hover {
-  @apply bg-gui-hover text-white;
-}
+  .ui-chip-alt[data-selected] {
+    @apply bg-dark-grey text-white;
+  }
+  .ui-chip-alt[data-selected]:hover {
+    @apply bg-gui-hover text-white;
+  }
 
-.ui-chip-alt[data-selected]:focus {
-  @apply bg-gui-active text-white;
+  .ui-chip-alt[data-selected]:focus {
+    @apply bg-gui-active text-white;
+  }
 }

--- a/src/core/styles/forms.css
+++ b/src/core/styles/forms.css
@@ -1,62 +1,64 @@
-.ui-checkbox-p1 {
-  @apply flex items-start mb-16 font-sans font-medium;
-}
+@layer components {
+  .ui-checkbox-p1 {
+    @apply flex items-start mb-16 font-sans font-medium;
+  }
 
-.ui-checkbox-p2 {
-  @apply flex items-start mb-12 font-sans font-medium;
-}
+  .ui-checkbox-p2 {
+    @apply flex items-start mb-12 font-sans font-medium;
+  }
 
-.ui-checkbox-input {
-  @apply opacity-0 absolute h-20 w-20;
-}
+  .ui-checkbox-input {
+    @apply opacity-0 absolute h-20 w-20;
+  }
 
-.ui-checkbox-styled {
-  @apply w-20 h-20 mr-16;
-  @apply bg-white flex flex-shrink-0 justify-center items-center;
-  @apply border border-dark-grey rounded-md focus-within:border-active-orange;
-}
+  .ui-checkbox-styled {
+    @apply w-20 h-20 mr-16;
+    @apply bg-white flex flex-shrink-0 justify-center items-center;
+    @apply border border-dark-grey rounded-md focus-within:border-active-orange;
+  }
 
-.ui-checkbox-styled-tick {
-  @apply hidden text-white;
-}
+  .ui-checkbox-styled-tick {
+    @apply hidden text-white;
+  }
 
-.ui-checkbox-label-p1 {
-  @apply select-none;
-  @apply text-p1 font-medium text-cool-black;
-}
+  .ui-checkbox-label-p1 {
+    @apply select-none;
+    @apply text-p1 font-medium text-cool-black;
+  }
 
-.ui-checkbox-label-p2 {
-  @apply select-none;
-  @apply text-p2 font-medium text-cool-black;
-}
+  .ui-checkbox-label-p2 {
+    @apply select-none;
+    @apply text-p2 font-medium text-cool-black;
+  }
 
-.ui-checkbox-input:disabled + .ui-checkbox-styled {
-  @apply bg-gui-unavailable border;
-}
+  .ui-checkbox-input:disabled + .ui-checkbox-styled {
+    @apply bg-gui-unavailable border;
+  }
 
-.ui-checkbox-input:focus + .ui-checkbox-styled {
-  border-width: 0.125rem;
-  @apply border-gui-focus;
-}
+  .ui-checkbox-input:focus + .ui-checkbox-styled {
+    border-width: 0.125rem;
+    @apply border-gui-focus;
+  }
 
-.ui-checkbox-input:checked + .ui-checkbox-styled {
-  @apply bg-active-orange border-dark-grey border;
-}
+  .ui-checkbox-input:checked + .ui-checkbox-styled {
+    @apply bg-active-orange border-dark-grey border;
+  }
 
-.ui-checkbox-input:checked + .ui-checkbox-styled svg {
-  @apply block;
-}
+  .ui-checkbox-input:checked + .ui-checkbox-styled svg {
+    @apply block;
+  }
 
-.ui-textarea {
-  @apply font-sans font-medium text-cool-black text-p1;
-  @apply p-input mb-16;
-  @apply bg-light-grey border-mid-grey transition-input border rounded block w-full;
-  @apply hover:bg-white hover:shadow-input hover:border-transparent;
-  @apply focus:bg-white focus:shadow-input focus:border-transparent focus:outline-gui-focus;
-}
+  .ui-textarea {
+    @apply font-sans font-medium text-cool-black text-p1;
+    @apply p-input mb-16;
+    @apply bg-light-grey border-mid-grey transition-input border rounded block w-full;
+    @apply hover:bg-white hover:shadow-input hover:border-transparent;
+    @apply focus:bg-white focus:shadow-input focus:border-transparent focus:outline-gui-focus;
+  }
 
-.ui-textarea::placeholder {
-  /* CSS vars don't work in ::placeholder in Webkit :( */
-  /* color: var(--text-dark-grey); */
-  color: #76767c;
+  .ui-textarea::placeholder {
+    /* CSS vars don't work in ::placeholder in Webkit :( */
+    /* color: var(--text-dark-grey); */
+    color: #76767c;
+  }
 }

--- a/src/core/styles/layout.css
+++ b/src/core/styles/layout.css
@@ -1,19 +1,21 @@
-.ui-standard-container {
-  @apply w-full max-w-screen-xl mx-auto px-24 sm:px-32 md:px-40 lg:px-64;
-}
+@layer components {
+  .ui-standard-container {
+    @apply w-full max-w-screen-xl mx-auto px-24 sm:px-32 md:px-40 lg:px-64;
+  }
 
-.ui-grid-gap {
-  @apply gap-8 sm:gap-16 md:gap-24 xl:gap-32;
-}
+  .ui-grid-gap {
+    @apply gap-8 sm:gap-16 md:gap-24 xl:gap-32;
+  }
 
-.ui-grid-gap-x {
-  @apply gap-x-8 sm:gap-x-16 md:gap-x-24 xl:gap-x-32;
-}
+  .ui-grid-gap-x {
+    @apply gap-x-8 sm:gap-x-16 md:gap-x-24 xl:gap-x-32;
+  }
 
-.ui-grid-px {
-  @apply px-24 sm:px-32 md:px-40 lg:px-64;
-}
+  .ui-grid-px {
+    @apply px-24 sm:px-32 md:px-40 lg:px-64;
+  }
 
-.ui-grid-mx {
-  @apply mx-24 sm:mx-32 md:mx-40 lg:mx-64;
+  .ui-grid-mx {
+    @apply mx-24 sm:mx-32 md:mx-40 lg:mx-64;
+  }
 }

--- a/src/core/styles/properties.css
+++ b/src/core/styles/properties.css
@@ -1,276 +1,278 @@
-:root {
-  /* Neutral colors */
-  --color-neutral-000: #ffffff;
-  --color-neutral-100: #f8fafc;
-  --color-neutral-200: #f4f8fb;
-  --color-neutral-300: #edf1f7;
-  --color-neutral-400: #e2e7ef;
-  --color-neutral-500: #c6ced9;
-  --color-neutral-600: #adb6c2;
-  --color-neutral-700: #89929f;
-  --color-neutral-800: #667085;
-  --color-neutral-900: #39414e;
-  --color-neutral-1000: #2b303b;
-  --color-neutral-1100: #202531;
-  --color-neutral-1200: #141924;
-  --color-neutral-1300: #03020d;
+@layer base {
+  :root {
+    /* Neutral colors */
+    --color-neutral-000: #ffffff;
+    --color-neutral-100: #f8fafc;
+    --color-neutral-200: #f4f8fb;
+    --color-neutral-300: #edf1f7;
+    --color-neutral-400: #e2e7ef;
+    --color-neutral-500: #c6ced9;
+    --color-neutral-600: #adb6c2;
+    --color-neutral-700: #89929f;
+    --color-neutral-800: #667085;
+    --color-neutral-900: #39414e;
+    --color-neutral-1000: #2b303b;
+    --color-neutral-1100: #202531;
+    --color-neutral-1200: #141924;
+    --color-neutral-1300: #03020d;
 
-  /* Ably orange */
-  --color-orange-100: #fff5f1;
-  --color-orange-200: #ffe3d8;
-  --color-orange-300: #ffc4ae;
-  --color-orange-400: #ff9c79;
-  --color-orange-500: #ff723f;
-  --color-orange-600: #ff5416;
-  --color-orange-700: #ff2739;
-  --color-orange-800: #e40000;
-  --color-orange-900: #b82202;
-  --color-orange-1000: #751500;
-  --color-orange-1100: #2a0b00;
+    /* Ably orange */
+    --color-orange-100: #fff5f1;
+    --color-orange-200: #ffe3d8;
+    --color-orange-300: #ffc4ae;
+    --color-orange-400: #ff9c79;
+    --color-orange-500: #ff723f;
+    --color-orange-600: #ff5416;
+    --color-orange-700: #ff2739;
+    --color-orange-800: #e40000;
+    --color-orange-900: #b82202;
+    --color-orange-1000: #751500;
+    --color-orange-1100: #2a0b00;
 
-  /* Secondary colours */
-  --color-yellow-100: #fffbef;
-  --color-yellow-200: #fff0ba;
-  --color-yellow-300: #ffe27c;
-  --color-yellow-400: #ffd43d;
-  --color-yellow-500: #f8c100;
-  --color-yellow-600: #e8a700;
-  --color-yellow-700: #ac8600;
-  --color-yellow-800: #654f00;
-  --color-yellow-900: #291c01;
-  --color-green-100: #f1fff1;
-  --color-green-200: #b8ffbb;
-  --color-green-300: #80ff85;
-  --color-green-400: #08ff13;
-  --color-green-500: #00e80b;
-  --color-green-600: #00c008;
-  --color-green-700: #008e06;
-  --color-green-800: #005303;
-  --color-green-900: #002a02;
-  --color-blue-100: #f1fbff;
-  --color-blue-200: #b8eaff;
-  --color-blue-300: #80d9ff;
-  --color-blue-400: #4ad4ff;
-  --color-blue-500: #2cc0ff;
-  --color-blue-600: #00a5ec;
-  --color-blue-700: #0284cd;
-  --color-blue-800: #004b75;
-  --color-blue-900: #001b2a;
-  --color-violet-100: #f7f2fe;
-  --color-violet-200: #d8bcfb;
-  --color-violet-300: #b986f8;
-  --color-violet-400: #9951f5;
-  --color-violet-500: #7a1bf2;
-  --color-violet-600: #5f0bc9;
-  --color-violet-700: #460894;
-  --color-violet-800: #2d055e;
-  --color-violet-900: #130228;
-  --color-pink-100: #fff1fc;
-  --color-pink-200: #ffb8f1;
-  --color-pink-300: #ff80e6;
-  --color-pink-400: #ff47db;
-  --color-pink-500: #ff17d2;
-  --color-pink-600: #d400ab;
-  --color-pink-700: #9c007e;
-  --color-pink-800: #630050;
-  --color-pink-900: #2a0022;
+    /* Secondary colours */
+    --color-yellow-100: #fffbef;
+    --color-yellow-200: #fff0ba;
+    --color-yellow-300: #ffe27c;
+    --color-yellow-400: #ffd43d;
+    --color-yellow-500: #f8c100;
+    --color-yellow-600: #e8a700;
+    --color-yellow-700: #ac8600;
+    --color-yellow-800: #654f00;
+    --color-yellow-900: #291c01;
+    --color-green-100: #f1fff1;
+    --color-green-200: #b8ffbb;
+    --color-green-300: #80ff85;
+    --color-green-400: #08ff13;
+    --color-green-500: #00e80b;
+    --color-green-600: #00c008;
+    --color-green-700: #008e06;
+    --color-green-800: #005303;
+    --color-green-900: #002a02;
+    --color-blue-100: #f1fbff;
+    --color-blue-200: #b8eaff;
+    --color-blue-300: #80d9ff;
+    --color-blue-400: #4ad4ff;
+    --color-blue-500: #2cc0ff;
+    --color-blue-600: #00a5ec;
+    --color-blue-700: #0284cd;
+    --color-blue-800: #004b75;
+    --color-blue-900: #001b2a;
+    --color-violet-100: #f7f2fe;
+    --color-violet-200: #d8bcfb;
+    --color-violet-300: #b986f8;
+    --color-violet-400: #9951f5;
+    --color-violet-500: #7a1bf2;
+    --color-violet-600: #5f0bc9;
+    --color-violet-700: #460894;
+    --color-violet-800: #2d055e;
+    --color-violet-900: #130228;
+    --color-pink-100: #fff1fc;
+    --color-pink-200: #ffb8f1;
+    --color-pink-300: #ff80e6;
+    --color-pink-400: #ff47db;
+    --color-pink-500: #ff17d2;
+    --color-pink-600: #d400ab;
+    --color-pink-700: #9c007e;
+    --color-pink-800: #630050;
+    --color-pink-900: #2a0022;
 
-  /* GUI colours */
-  /* Note: The ‘Light and ‘Dark’ refers to the colour of the background on which the colour is used. */
-  --color-gui-blue-default-light: #006edc;
-  --color-gui-blue-hover-light: #0862b9;
-  --color-gui-blue-active-light: #074095;
-  --color-gui-blue-default-dark: #4da6ff;
-  --color-gui-blue-hover-dark: #2894ff;
-  --color-gui-blue-active-dark: #0080ff;
-  --color-gui-blue-focus: #80b9f2;
-  --color-gui-unavailable: #a8a8a8;
-  --color-gui-success-green: #11cb24;
-  --color-gui-error-red: #fb0c0c;
-  --color-gui-focus: #80b9f2;
-  --color-gui-focus-outline: #80b9f2;
-  --color-gui-visited: #4887c2;
+    /* GUI colours */
+    /* Note: The ‘Light and ‘Dark’ refers to the colour of the background on which the colour is used. */
+    --color-gui-blue-default-light: #006edc;
+    --color-gui-blue-hover-light: #0862b9;
+    --color-gui-blue-active-light: #074095;
+    --color-gui-blue-default-dark: #4da6ff;
+    --color-gui-blue-hover-dark: #2894ff;
+    --color-gui-blue-active-dark: #0080ff;
+    --color-gui-blue-focus: #80b9f2;
+    --color-gui-unavailable: #a8a8a8;
+    --color-gui-success-green: #11cb24;
+    --color-gui-error-red: #fb0c0c;
+    --color-gui-focus: #80b9f2;
+    --color-gui-focus-outline: #80b9f2;
+    --color-gui-visited: #4887c2;
 
-  /* Colours replaced by neutral colours */
-  --color-white: var(--color-neutral-000);
-  --color-extra-light-grey: var(--color-neutral-100);
-  --color-light-grey: var(--color-neutral-200);
-  --color-mid-grey: var(--color-neutral-500);
-  --color-dark-grey: var(--color-neutral-800);
-  --color-charcoal-grey: var(--color-neutral-1000);
-  --color-cool-black: var(--color-neutral-1300);
+    /* Colours replaced by neutral colours */
+    --color-white: var(--color-neutral-000);
+    --color-extra-light-grey: var(--color-neutral-100);
+    --color-light-grey: var(--color-neutral-200);
+    --color-mid-grey: var(--color-neutral-500);
+    --color-dark-grey: var(--color-neutral-800);
+    --color-charcoal-grey: var(--color-neutral-1000);
+    --color-cool-black: var(--color-neutral-1300);
 
-  /* Colours replaced by orange colours */
-  --color-active-orange: var(--color-orange-600);
-  --color-bright-red: var(--color-orange-700);
-  --color-red-orange: var(--color-orange-800);
+    /* Colours replaced by orange colours */
+    --color-active-orange: var(--color-orange-600);
+    --color-bright-red: var(--color-orange-700);
+    --color-red-orange: var(--color-orange-800);
 
-  /* Colours replaced by secondary colours */
-  --color-electric-cyan: var(--color-blue-400);
-  --color-zingy-green: var(--color-green-400);
-  --color-jazzy-pink: var(--color-pink-500);
+    /* Colours replaced by secondary colours */
+    --color-electric-cyan: var(--color-blue-400);
+    --color-zingy-green: var(--color-green-400);
+    --color-jazzy-pink: var(--color-pink-500);
 
-  /* Colours replaced by GUI colours */
-  --color-gui-default: var(--color-gui-blue-default-light);
-  --color-gui-hover: var(--color-gui-blue-hover-light);
-  --color-gui-active: var(--color-gui-blue-active-light);
-  --color-gui-error: var(--color-gui-error-red);
-  --color-gui-success: var(--color-gui-success-green);
-  --color-gui-default-dark: var(--color-gui-blue-default-dark);
-  --color-gui-hover-dark: var(--color-gui-blue-hover-dark);
-  --color-gui-active-dark: var(--color-gui-blue-active-dark);
+    /* Colours replaced by GUI colours */
+    --color-gui-default: var(--color-gui-blue-default-light);
+    --color-gui-hover: var(--color-gui-blue-hover-light);
+    --color-gui-active: var(--color-gui-blue-active-light);
+    --color-gui-error: var(--color-gui-error-red);
+    --color-gui-success: var(--color-gui-success-green);
+    --color-gui-default-dark: var(--color-gui-blue-default-dark);
+    --color-gui-hover-dark: var(--color-gui-blue-hover-dark);
+    --color-gui-active-dark: var(--color-gui-blue-active-dark);
 
-  /* code syntax: theme */
-  --syntax-black: var(--color-neutral-1300);
-  --syntax-dark-grey: var(--color-neutral-800);
-  --syntax-mid-grey: var(--color-neutral-500);
-  --syntax-light-grey: var(--color-neutral-200);
-  --syntax-extra-light-grey: var(--color-neutral-100);
-  --syntax-orange: #e78c45;
-  --syntax-yellow: #e7c547;
-  --syntax-blue: #3490ec;
-  --syntax-green: #b9ca4a;
-  --syntax-red: #d54e53;
-  --syntax-lilac: #bb87d3;
+    /* code syntax: theme */
+    --syntax-black: var(--color-neutral-1300);
+    --syntax-dark-grey: var(--color-neutral-800);
+    --syntax-mid-grey: var(--color-neutral-500);
+    --syntax-light-grey: var(--color-neutral-200);
+    --syntax-extra-light-grey: var(--color-neutral-100);
+    --syntax-orange: #e78c45;
+    --syntax-yellow: #e7c547;
+    --syntax-blue: #3490ec;
+    --syntax-green: #b9ca4a;
+    --syntax-red: #d54e53;
+    --syntax-lilac: #bb87d3;
 
-  /* flat colors for social icons */
-  --icon-color-linkedin: #1269bf;
-  --icon-color-twitter: #2caae1;
-  --icon-color-glassdoor: #0baa41;
-  --icon-color-github: #000000;
-  --icon-color-discord: #5865f2;
-  --icon-color-stackoverflow: #f48024;
-  --icon-color-youtube: #ff0000;
+    /* flat colors for social icons */
+    --icon-color-linkedin: #1269bf;
+    --icon-color-twitter: #2caae1;
+    --icon-color-glassdoor: #0baa41;
+    --icon-color-github: #000000;
+    --icon-color-discord: #5865f2;
+    --icon-color-stackoverflow: #f48024;
+    --icon-color-youtube: #ff0000;
 
-  --gradient-active-orange: linear-gradient(
-    61.2deg,
-    var(--color-active-orange) 10.46%,
-    #fe5215 38.63%,
-    #fc4a13 54.38%,
-    #f73c10 67.07%,
-    #f1280a 78.13%,
-    #e90f04 88.02%,
-    var(--color-red-orange) 92.73%
-  );
+    --gradient-active-orange: linear-gradient(
+      61.2deg,
+      var(--color-active-orange) 10.46%,
+      #fe5215 38.63%,
+      #fc4a13 54.38%,
+      #f73c10 67.07%,
+      #f1280a 78.13%,
+      #e90f04 88.02%,
+      var(--color-red-orange) 92.73%
+    );
 
-  /* Used for smooth transitions from gradient to non-gradient backgrounds */
-  --gradient-transparent: linear-gradient(
-    0deg,
-    rgba(255, 255, 255, 0),
-    rgba(255, 255, 255, 0)
-  );
+    /* Used for smooth transitions from gradient to non-gradient backgrounds */
+    --gradient-transparent: linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 0)
+    );
 
-  --gradient-hot-pink: linear-gradient(
-    80.2deg,
-    var(--color-orange-700) 0%,
-    var(--color-jazzy-pink) 100%
-  );
+    --gradient-hot-pink: linear-gradient(
+      80.2deg,
+      var(--color-orange-700) 0%,
+      var(--color-jazzy-pink) 100%
+    );
 
-  --fs-title-xl: 3rem;
-  --fs-title: 2.75rem;
-  --fs-title-xs: 2.5rem;
-  --fs-h1-xl: 2.5rem;
-  --fs-h1: 2.25rem;
-  --fs-h1-xs: 2rem;
+    --fs-title-xl: 3rem;
+    --fs-title: 2.75rem;
+    --fs-title-xs: 2.5rem;
+    --fs-h1-xl: 2.5rem;
+    --fs-h1: 2.25rem;
+    --fs-h1-xs: 2rem;
 
-  --fs-h2-xl: 2.125rem;
-  --fs-h2: 2rem;
-  --fs-h2-xs: 1.75rem;
+    --fs-h2-xl: 2.125rem;
+    --fs-h2: 2rem;
+    --fs-h2-xs: 1.75rem;
 
-  --fs-h3: 1.5rem;
-  --fs-h4: 1.25rem;
-  --fs-h5: 1rem;
+    --fs-h3: 1.5rem;
+    --fs-h4: 1.25rem;
+    --fs-h5: 1rem;
 
-  --fs-p1: 1rem;
-  --fs-p2: 0.938rem;
-  --fs-p3: 0.875rem;
-  --fs-standfirst-xl: 2.25rem;
-  --fs-standfirst: 1.5rem;
-  --fs-sub-header: 1.125rem;
-  --fs-sub-header-xs: 1.063rem;
-  --fs-overline1: 1rem;
-  --fs-overline2: 0.875rem;
-  --fs-btn1: 1rem;
-  --fs-btn2: 0.938rem;
-  --fs-btn3: 0.875rem;
-  --fs-menu1: 1rem;
-  --fs-menu2: 0.938rem;
-  --fs-menu3: 0.875rem;
-  --fs-quote: 1.25rem;
-  --fs-code: 0.938rem;
-  --fs-code2: 0.813rem;
+    --fs-p1: 1rem;
+    --fs-p2: 0.938rem;
+    --fs-p3: 0.875rem;
+    --fs-standfirst-xl: 2.25rem;
+    --fs-standfirst: 1.5rem;
+    --fs-sub-header: 1.125rem;
+    --fs-sub-header-xs: 1.063rem;
+    --fs-overline1: 1rem;
+    --fs-overline2: 0.875rem;
+    --fs-btn1: 1rem;
+    --fs-btn2: 0.938rem;
+    --fs-btn3: 0.875rem;
+    --fs-menu1: 1rem;
+    --fs-menu2: 0.938rem;
+    --fs-menu3: 0.875rem;
+    --fs-quote: 1.25rem;
+    --fs-code: 0.938rem;
+    --fs-code2: 0.813rem;
 
-  --lh-dense: 1;
-  --lh-tight: 1.125;
-  --lh-snug: 1.15;
-  --lh-min-normal: 1.2;
-  --lh-normal: 1.25;
-  --lh-relaxed: 1.45;
-  --lh-extra-relaxed: 1.6;
+    --lh-dense: 1;
+    --lh-tight: 1.125;
+    --lh-snug: 1.15;
+    --lh-min-normal: 1.2;
+    --lh-normal: 1.25;
+    --lh-relaxed: 1.45;
+    --lh-extra-relaxed: 1.6;
 
-  --ls-tighten-0_025: -0.025em;
-  --ls-tighten-0_02: -0.02em;
-  --ls-tighten-0_015: -0.015em;
-  --ls-tighten-0_01: -0.01em;
-  --ls-tighten-0_005: -0.005em;
-  --ls-tighten-0_0025: -0.0025em;
-  --ls-tighten-0_0015: -0.0015em;
-  --ls-widen-0_1: 0.1em;
-  --ls-widen-0_16: 0.16em;
-  --ls-widen-0_15: 0.15em;
+    --ls-tighten-0_025: -0.025em;
+    --ls-tighten-0_02: -0.02em;
+    --ls-tighten-0_015: -0.015em;
+    --ls-tighten-0_01: -0.01em;
+    --ls-tighten-0_005: -0.005em;
+    --ls-tighten-0_0025: -0.0025em;
+    --ls-tighten-0_0015: -0.0015em;
+    --ls-widen-0_1: 0.1em;
+    --ls-widen-0_16: 0.16em;
+    --ls-widen-0_15: 0.15em;
 
-  --spacing-0: 0px;
-  --spacing-1: 1px;
-  --spacing-2: 0.125rem;
-  --spacing-4: 0.25rem;
-  --spacing-6: 0.375rem;
-  --spacing-8: 0.5rem;
-  --spacing-12: 0.75rem;
-  --spacing-14: 0.875rem;
-  --spacing-16: 1rem;
-  --spacing-20: 1.25rem;
-  --spacing-24: 1.5rem;
-  --spacing-32: 2rem;
-  --spacing-36: 2.25rem;
-  --spacing-40: 2.5rem;
-  --spacing-48: 3rem;
-  --spacing-64: 4rem;
-  --spacing-72: 4.5rem;
-  --spacing-80: 5rem;
-  --spacing-88: 5.5rem;
-  --spacing-96: 6rem;
-  --spacing-128: 8rem;
-  --spacing-160: 10rem;
-  --spacing-256: 16rem;
+    --spacing-0: 0px;
+    --spacing-1: 1px;
+    --spacing-2: 0.125rem;
+    --spacing-4: 0.25rem;
+    --spacing-6: 0.375rem;
+    --spacing-8: 0.5rem;
+    --spacing-12: 0.75rem;
+    --spacing-14: 0.875rem;
+    --spacing-16: 1rem;
+    --spacing-20: 1.25rem;
+    --spacing-24: 1.5rem;
+    --spacing-32: 2rem;
+    --spacing-36: 2.25rem;
+    --spacing-40: 2.5rem;
+    --spacing-48: 3rem;
+    --spacing-64: 4rem;
+    --spacing-72: 4.5rem;
+    --spacing-80: 5rem;
+    --spacing-88: 5.5rem;
+    --spacing-96: 6rem;
+    --spacing-128: 8rem;
+    --spacing-160: 10rem;
+    --spacing-256: 16rem;
 
-  --spacing-btn-small: 0.875rem 1.25rem; /* 14px 16px */
-  --spacing-btn-xsmall: 0.875rem 1rem; /* 14px 16px */
-  --spacing-btn: 0.875rem 1.5rem; /* 14px 24px */
-  --spacing-btn-large: 0.875rem 1.75rem; /* 14px 28px */
-  --spacing-menu-row: 0.625rem 0.5rem 0.6875rem; /* 10px 8px 11px */
-  --spacing-menu-row-snug: 0.4375rem 0.5rem 0.375rem; /* 7px 8px 6px */
-  --spacing-menu-row-title: 0.6875rem 0.5rem; /* 11px 8px */
-  --spacing-media: 0.5rem; /* 8px */
-  --spacing-input: 0.8125rem 1rem 0.75rem; /* 13px 16px 12px */
-  --spacing-overline: 0.6875rem 0; /* 11px 0 */
-  --spacing-chip-xsmall: 0.375rem 0.5rem; /* 6px 8px */
-  --spacing-chip-small: 0.5rem 0.75rem; /* 8px 12px */
-  --spacing-chip: 0.75rem 1rem; /* 6px 8px */
-  --spacing-chip-large: 1rem 1.25rem; /* 16px 20px */
-  --spacing-inline-code: 0.375rem 0.5rem; /* 6px 8px */
+    --spacing-btn-small: 0.875rem 1.25rem; /* 14px 16px */
+    --spacing-btn-xsmall: 0.875rem 1rem; /* 14px 16px */
+    --spacing-btn: 0.875rem 1.5rem; /* 14px 24px */
+    --spacing-btn-large: 0.875rem 1.75rem; /* 14px 28px */
+    --spacing-menu-row: 0.625rem 0.5rem 0.6875rem; /* 10px 8px 11px */
+    --spacing-menu-row-snug: 0.4375rem 0.5rem 0.375rem; /* 7px 8px 6px */
+    --spacing-menu-row-title: 0.6875rem 0.5rem; /* 11px 8px */
+    --spacing-media: 0.5rem; /* 8px */
+    --spacing-input: 0.8125rem 1rem 0.75rem; /* 13px 16px 12px */
+    --spacing-overline: 0.6875rem 0; /* 11px 0 */
+    --spacing-chip-xsmall: 0.375rem 0.5rem; /* 6px 8px */
+    --spacing-chip-small: 0.5rem 0.75rem; /* 8px 12px */
+    --spacing-chip: 0.75rem 1rem; /* 6px 8px */
+    --spacing-chip-large: 1rem 1.25rem; /* 16px 20px */
+    --spacing-inline-code: 0.375rem 0.5rem; /* 6px 8px */
 
-  /* In components, when looking at implementing viewport margin and spacing between elements,
+    /* In components, when looking at implementing viewport margin and spacing between elements,
        the values in the comments can be used as guide as they represent the grid the elements (should) sit on.
        alternatively, look for ui-grid-* helpers. */
-  --bp-xs: 428px; /* gutters 8px, side-margin 24px */
-  --bp-sm: 768px; /* gutters 16px, side-margin 32px */
-  --bp-md: 1040px; /* gutters 24px, side-margin 40px, meganav desktop */
-  --bp-lg: 1280px; /* gutters 24px, side-margin 64px */
-  --bp-xl: 1440px; /* gutters 32px, side-margin 64px */
+    --bp-xs: 428px; /* gutters 8px, side-margin 24px */
+    --bp-sm: 768px; /* gutters 16px, side-margin 32px */
+    --bp-md: 1040px; /* gutters 24px, side-margin 40px, meganav desktop */
+    --bp-lg: 1280px; /* gutters 24px, side-margin 64px */
+    --bp-xl: 1440px; /* gutters 32px, side-margin 64px */
 
-  /* Page stacking context. If components create new stacking contexts z-index values should be defined within them. */
-  --stacking-context-page-meganav: 100;
+    /* Page stacking context. If components create new stacking contexts z-index values should be defined within them. */
+    --stacking-context-page-meganav: 100;
 
-  /* Expose component values for cross-component usage */
-  --ui-meganav-height: 4rem;
+    /* Expose component values for cross-component usage */
+    --ui-meganav-height: 4rem;
+  }
 }

--- a/src/core/styles/text.css
+++ b/src/core/styles/text.css
@@ -1,166 +1,168 @@
-.ui-text-title {
-  @apply font-sans font-extrabold text-cool-black;
-  @apply text-title-xs xs:text-title xl:text-title-xl;
-  @apply tracking-tighten-0.015 xs:tracking-tighten-0.02 xl:tracking-tighten-0.02;
-}
+@layer components {
+  .ui-text-title {
+    @apply font-sans font-extrabold text-cool-black;
+    @apply text-title-xs xs:text-title xl:text-title-xl;
+    @apply tracking-tighten-0.015 xs:tracking-tighten-0.02 xl:tracking-tighten-0.02;
+  }
 
-.ui-text-h1 {
-  @apply font-sans font-extrabold text-cool-black;
-  @apply text-h1-xs xs:text-h1 xl:text-h1-xl;
-  @apply tracking-tighten-0.0125 xs:tracking-tighten-0.015;
-}
+  .ui-text-h1 {
+    @apply font-sans font-extrabold text-cool-black;
+    @apply text-h1-xs xs:text-h1 xl:text-h1-xl;
+    @apply tracking-tighten-0.0125 xs:tracking-tighten-0.015;
+  }
 
-.ui-text-h2 {
-  @apply font-sans font-extrabold text-cool-black;
-  @apply text-h2-xs xs:text-h2 xl:text-h2-xl;
-  @apply tracking-tighten-0.015 xs:tracking-tighten-0.01;
-}
+  .ui-text-h2 {
+    @apply font-sans font-extrabold text-cool-black;
+    @apply text-h2-xs xs:text-h2 xl:text-h2-xl;
+    @apply tracking-tighten-0.015 xs:tracking-tighten-0.01;
+  }
 
-.ui-text-h3 {
-  @apply font-sans font-extrabold text-cool-black;
-  @apply text-h3;
-  @apply tracking-tighten-0.005;
-}
+  .ui-text-h3 {
+    @apply font-sans font-extrabold text-cool-black;
+    @apply text-h3;
+    @apply tracking-tighten-0.005;
+  }
 
-.ui-text-h4 {
-  @apply font-sans font-extrabold text-cool-black;
-  @apply text-h4;
-  @apply tracking-tighten-0.0015;
-}
+  .ui-text-h4 {
+    @apply font-sans font-extrabold text-cool-black;
+    @apply text-h4;
+    @apply tracking-tighten-0.0015;
+  }
 
-.ui-text-h5 {
-  @apply font-sans font-extrabold text-cool-black;
-  @apply text-h5;
-  @apply tracking-tighten-0.0025;
-}
+  .ui-text-h5 {
+    @apply font-sans font-extrabold text-cool-black;
+    @apply text-h5;
+    @apply tracking-tighten-0.0025;
+  }
 
-.ui-text-p1 {
-  @apply font-sans font-medium text-charcoal-grey;
-  @apply text-p1;
-}
+  .ui-text-p1 {
+    @apply font-sans font-medium text-charcoal-grey;
+    @apply text-p1;
+  }
 
-.ui-text-p2 {
-  @apply font-sans font-medium text-charcoal-grey;
-  @apply text-p2;
-}
+  .ui-text-p2 {
+    @apply font-sans font-medium text-charcoal-grey;
+    @apply text-p2;
+  }
 
-.ui-text-p3 {
-  @apply font-sans font-medium text-charcoal-grey;
-  @apply text-p3;
-}
+  .ui-text-p3 {
+    @apply font-sans font-medium text-charcoal-grey;
+    @apply text-p3;
+  }
 
-.ui-text-standfirst {
-  @apply font-sans font-light text-active-orange;
-  @apply text-standfirst xl:text-standfirst-xl;
-  @apply tracking-tighten-0.025 xl:tracking-tighten-0.015;
-}
+  .ui-text-standfirst {
+    @apply font-sans font-light text-active-orange;
+    @apply text-standfirst xl:text-standfirst-xl;
+    @apply tracking-tighten-0.025 xl:tracking-tighten-0.015;
+  }
 
-.ui-text-quote {
-  @apply font-sans font-normal text-cool-black;
-  @apply text-quote leading-normal;
-  @apply tracking-tighten-0.0015;
-}
+  .ui-text-quote {
+    @apply font-sans font-normal text-cool-black;
+    @apply text-quote leading-normal;
+    @apply tracking-tighten-0.0015;
+  }
 
-.ui-text-sub-header {
-  @apply font-sans font-semibold text-neutral-800;
-  @apply text-sub-header-xs xs:text-sub-header leading-normal;
-}
+  .ui-text-sub-header {
+    @apply font-sans font-semibold text-neutral-800;
+    @apply text-sub-header-xs xs:text-sub-header leading-normal;
+  }
 
-.ui-text-overline1 {
-  @apply font-mono font-medium text-active-orange uppercase;
-  @apply text-overline1 leading-normal;
-  @apply tracking-widen-0.16;
-}
+  .ui-text-overline1 {
+    @apply font-mono font-medium text-active-orange uppercase;
+    @apply text-overline1 leading-normal;
+    @apply tracking-widen-0.16;
+  }
 
-.ui-text-overline2 {
-  @apply font-mono font-medium text-active-orange uppercase;
-  @apply text-overline2 leading-normal;
-  @apply tracking-widen-0.16;
-}
+  .ui-text-overline2 {
+    @apply font-mono font-medium text-active-orange uppercase;
+    @apply text-overline2 leading-normal;
+    @apply tracking-widen-0.16;
+  }
 
-.ui-text-menu1 {
-  @apply font-sans font-medium text-cool-black;
-  @apply text-menu1 leading-snug;
-}
+  .ui-text-menu1 {
+    @apply font-sans font-medium text-cool-black;
+    @apply text-menu1 leading-snug;
+  }
 
-.ui-text-menu2 {
-  @apply font-sans font-medium text-cool-black;
-  @apply text-menu2 leading-snug;
-}
+  .ui-text-menu2 {
+    @apply font-sans font-medium text-cool-black;
+    @apply text-menu2 leading-snug;
+  }
 
-.ui-text-menu3 {
-  @apply font-sans font-medium text-cool-black;
-  @apply text-menu3 leading-snug;
-}
+  .ui-text-menu3 {
+    @apply font-sans font-medium text-cool-black;
+    @apply text-menu3 leading-snug;
+  }
 
-.ui-text-code {
-  @apply font-mono font-normal text-code;
-}
+  .ui-text-code {
+    @apply font-mono font-normal text-code;
+  }
 
-.ui-text-code2 {
-  @apply font-mono font-normal text-code2;
-}
+  .ui-text-code2 {
+    @apply font-mono font-normal text-code2;
+  }
 
-.ui-text-code-inline {
-  @apply font-mono font-normal text-code text-charcoal-grey bg-light-grey p-inline-code rounded-sm mx-1;
-}
+  .ui-text-code-inline {
+    @apply font-mono font-normal text-code text-charcoal-grey bg-light-grey p-inline-code rounded-sm mx-1;
+  }
 
-.ui-unordered-list {
-  @apply text-p1 font-medium text-charcoal-grey;
-  @apply ml-32 my-16;
-  @apply list-disc;
-}
+  .ui-unordered-list {
+    @apply text-p1 font-medium text-charcoal-grey;
+    @apply ml-32 my-16;
+    @apply list-disc;
+  }
 
-.ui-ordered-list {
-  @apply text-p1 font-medium text-charcoal-grey;
-  @apply ml-32 my-16;
-  @apply list-decimal;
-}
+  .ui-ordered-list {
+    @apply text-p1 font-medium text-charcoal-grey;
+    @apply ml-32 my-16;
+    @apply list-decimal;
+  }
 
-.ui-ordered-list li,
-.ui-unordered-list li {
-  @apply mb-8;
-}
+  .ui-ordered-list li,
+  .ui-unordered-list li {
+    @apply mb-8;
+  }
 
-.ui-unordered-list li > *:last-of-type:not(ul):not(ol),
-.ui-ordered-list li > *:last-of-type:not(ul):not(ol) {
-  margin-bottom: 0;
-}
+  .ui-unordered-list li > *:last-of-type:not(ul):not(ol),
+  .ui-ordered-list li > *:last-of-type:not(ul):not(ol) {
+    margin-bottom: 0;
+  }
 
-.ui-unordered-list ul {
-  @apply ml-24 my-8 list-circle;
-}
+  .ui-unordered-list ul {
+    @apply ml-24 my-8 list-circle;
+  }
 
-.ui-ordered-list ol {
-  @apply ml-24 my-16 list-decimal;
-}
+  .ui-ordered-list ol {
+    @apply ml-24 my-16 list-decimal;
+  }
 
-.ui-unordered-list ul ul {
-  @apply list-square my-8;
-}
+  .ui-unordered-list ul ul {
+    @apply list-square my-8;
+  }
 
-.ui-unordered-list ul ul {
-  @apply my-8;
-}
+  .ui-unordered-list ul ul {
+    @apply my-8;
+  }
 
-.ui-link {
-  @apply text-gui-default;
-  @apply hover:text-gui-hover active:text-gui-active disabled:text-gui-unavailable;
-  @apply focus:text-gui-default focus:outline-gui-focus;
-  @apply no-underline;
-}
+  .ui-link {
+    @apply text-gui-default;
+    @apply hover:text-gui-hover active:text-gui-active disabled:text-gui-unavailable;
+    @apply focus:text-gui-default focus:outline-gui-focus;
+    @apply no-underline;
+  }
 
-.ui-link-neutral {
-  @apply hover:text-dark-grey active:text-cool-black disabled:text-gui-unavailable;
-  @apply focus:text-charcoal-grey;
-  @apply underline;
-}
+  .ui-link-neutral {
+    @apply hover:text-dark-grey active:text-cool-black disabled:text-gui-unavailable;
+    @apply focus:text-charcoal-grey;
+    @apply underline;
+  }
 
-/* focus:outline-gui-focus-neutral does not get created under Tailwind 3.3.5, not sure why */
-.ui-link-neutral:focus {
-  outline: 2px solid var(--color-neutral-000);
-}
+  /* focus:outline-gui-focus-neutral does not get created under Tailwind 3.3.5, not sure why */
+  .ui-link-neutral:focus {
+    outline: 2px solid var(--color-neutral-000);
+  }
 
-.ui-figcaption {
-  @apply font-mono text-p3 text-neutral-800;
+  .ui-figcaption {
+    @apply font-mono text-p3 text-neutral-800;
+  }
 }

--- a/src/core/utils/syntax-highlighter.css
+++ b/src/core/utils/syntax-highlighter.css
@@ -1,67 +1,74 @@
-@import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,600;0,700;1,600;1,700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@100;200;300;400;500;600;700;800&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&display=swap");
+@tailwind base;
+@tailwind components;
 
-.hljs {
-  background: var(--syntax-black);
-  color: var(--syntax-light-grey);
+@layer base {
+  @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,600;0,700;1,600;1,700&display=swap");
+  @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@100;200;300;400;500;600;700;800&display=swap");
+  @import url("https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&display=swap");
 }
 
-.hljs-emphasis {
-  @apply italic;
-}
+@layer components {
+  .hljs {
+    background: var(--syntax-black);
+    color: var(--syntax-light-grey);
+  }
 
-.hljs-strong {
-  @apply font-bold;
-}
+  .hljs-emphasis {
+    @apply italic;
+  }
 
-.hljs-comment,
-.hljs-quote {
-  color: var(--syntax-dark-grey);
-}
+  .hljs-strong {
+    @apply font-bold;
+  }
 
-.hljs-variable,
-.hljs-template-variable,
-.hljs-tag,
-.hljs-name,
-.hljs-selector-id,
-.hljs-selector-class,
-.hljs-regexp,
-.hljs-deletion {
-  color: var(--syntax-red);
-}
+  .hljs-comment,
+  .hljs-quote {
+    color: var(--syntax-dark-grey);
+  }
 
-.hljs-number,
-.hljs-built_in,
-.hljs-literal,
-.hljs-type,
-.hljs-params,
-.hljs-meta,
-.hljs-link {
-  color: var(--syntax-orange);
-}
+  .hljs-variable,
+  .hljs-template-variable,
+  .hljs-tag,
+  .hljs-name,
+  .hljs-selector-id,
+  .hljs-selector-class,
+  .hljs-regexp,
+  .hljs-deletion {
+    color: var(--syntax-red);
+  }
 
-.hljs-attribute {
-  color: var(--syntax-yellow);
-}
+  .hljs-number,
+  .hljs-built_in,
+  .hljs-literal,
+  .hljs-type,
+  .hljs-params,
+  .hljs-meta,
+  .hljs-link {
+    color: var(--syntax-orange);
+  }
 
-.hljs-string,
-.hljs-symbol,
-.hljs-bullet,
-.hljs-addition {
-  color: var(--syntax-green);
-}
+  .hljs-attribute {
+    color: var(--syntax-yellow);
+  }
 
-.hljs-title,
-.hljs-section {
-  color: var(--syntax-blue);
-}
+  .hljs-string,
+  .hljs-symbol,
+  .hljs-bullet,
+  .hljs-addition {
+    color: var(--syntax-green);
+  }
 
-.hljs-keyword,
-.hljs-selector-tag {
-  color: var(--syntax-lilac);
-}
+  .hljs-title,
+  .hljs-section {
+    color: var(--syntax-blue);
+  }
 
-.hljs-subst {
-  color: var(--syntax-mid-grey);
+  .hljs-keyword,
+  .hljs-selector-tag {
+    color: var(--syntax-lilac);
+  }
+
+  .hljs-subst {
+    color: var(--syntax-mid-grey);
+  }
 }

--- a/src/core/utils/syntax-highlighter.css
+++ b/src/core/utils/syntax-highlighter.css
@@ -1,6 +1,3 @@
-@tailwind base;
-@tailwind components;
-
 @layer base {
   @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,600;0,700;1,600;1,700&display=swap");
   @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@100;200;300;400;500;600;700;800&display=swap");


### PR DESCRIPTION
## Jira Ticket Link / Motivation

https://ably.atlassian.net/browse/WEB-3702

## Summary of changes

As part of the Ably UI rewrite to incorporate Storybook and ditch Rails, the Tailwind "layer" directives were removed to solve issues with rendering components directly in Storybook. Turns out, we depend upon layer directives much more than I initially thought, and removing them means that CSS selector prioritisation is all out of whack in apps that use `ably-ui` classes, leading to large visual regressions.

This PR reinstates the layer directives to how they were before the Storybook rewrite, but with a shifted compromise - dedicated component CSS files must now be imported within the global CSS file (or wherever the `tailwindcss/base` et al imports are), instead of imported within the component themselves (example here is within [.storybook/styles.css](https://github.com/ably/ably-ui/compare/compare-page-iterations?expand=1#diff-fea3edddbfc8c8286686f5e8273cf20c4b1a3814b78ecf13574fdbf67ce42ecf)). I think this is a suitable compromise.

## How do you manually test this?

Use the latest `ably-ui` 14 dev package in Voltaire, navigate around, check that TW utility overrides on Ably UI classes works correctly. An example of this is a `text-white` naturally overriding the `color` in `ui-text-p1`, instead of having to elevate `text-white` to `!text-white`.

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
