### PR TITLE
[WEB-3571] Compare page iterations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.0-dev.ae75f49",
+  "version": "14.0.0-dev.450e302",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.0-dev.2944826",
+  "version": "14.0.0-dev.ae75f49",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Accordion.tsx
+++ b/src/core/Accordion.tsx
@@ -25,6 +25,7 @@ export type AccordionProps = {
   bottomBorder?: boolean;
   id?: string;
   autoClose?: boolean;
+  className?: string;
 };
 
 const AccordionRow = ({
@@ -104,6 +105,7 @@ const Accordion = ({
   bottomBorder,
   arrowIcon,
   autoClose,
+  className,
 }: AccordionProps) => {
   const [activeIndexes, setActiveIndexes] = useState<number[]>([]);
 
@@ -122,7 +124,7 @@ const Accordion = ({
   };
 
   return (
-    <div className="ui-grid-mx max-w-screen-sm sm:mx-auto" id={id}>
+    <div className={className} id={id}>
       {data.map((item, currentIndex) => {
         return (
           <AccordionRow

--- a/src/core/Expander.tsx
+++ b/src/core/Expander.tsx
@@ -51,7 +51,7 @@ const Expander = ({
           onClick={() => setExpanded(!expanded)}
           onKeyDown={(e) => e.key === "Enter" && setExpanded(!expanded)}
           tabIndex={0}
-          className="mt-16 cursor-pointer font-bold text-gui-blue-default-light hover:text-gui-blue-hover-light active:text-gui-blue-active-light focus:text-gui-blue-focus"
+          className="mt-16 cursor-pointer font-bold text-gui-blue-default-light hover:text-gui-blue-hover-light"
         >
           {expanded ? "View less -" : "View all +"}
         </div>

--- a/src/core/Slider.tsx
+++ b/src/core/Slider.tsx
@@ -18,7 +18,7 @@ interface SliderIndicatorProps {
   isInline?: boolean;
 }
 
-const SLIDE_TRANSITION_LENGTH = 500;
+const SLIDE_TRANSITION_LENGTH = 300;
 
 const SlideIndicator = ({
   numSlides,
@@ -80,21 +80,28 @@ const Slider = ({ children, options }: SliderProps) => {
   );
   const [translationCoefficient, setTranslationCoefficient] = useState(0);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const [slideLock, setSlideLock] = useState(false);
 
   const isInline = options?.controlPosition === "inline";
 
   const next = () => {
-    setActiveIndex((prevIndex) => (prevIndex + 1) % children.length);
-    setTranslationCoefficient(1);
-    resetInterval();
+    if (!slideLock) {
+      setActiveIndex((prevIndex) => (prevIndex + 1) % children.length);
+      setTranslationCoefficient(1);
+      resetInterval();
+      setSlideLock(true);
+    }
   };
 
   const prev = () => {
-    setActiveIndex((prevIndex) =>
-      prevIndex > 0 ? prevIndex - 1 : children.length - 1
-    );
-    setTranslationCoefficient(-1);
-    resetInterval();
+    if (!slideLock) {
+      setActiveIndex((prevIndex) =>
+        prevIndex > 0 ? prevIndex - 1 : children.length - 1
+      );
+      setTranslationCoefficient(-1);
+      resetInterval();
+      setSlideLock(true);
+    }
   };
 
   const resetInterval = () => {
@@ -130,6 +137,7 @@ const Slider = ({ children, options }: SliderProps) => {
     setTimeout(() => {
       setSlides(setupSlides(children, activeIndex));
       setTranslationCoefficient(0);
+      setSlideLock(false);
     }, SLIDE_TRANSITION_LENGTH);
   }, [activeIndex]);
 

--- a/src/core/Table.tsx
+++ b/src/core/Table.tsx
@@ -1,14 +1,6 @@
 import { Table, TableRowHeader, TableHeader, TableBody } from "./Table/Table";
 import { TableRow } from "./Table/TableRow";
-import {
-  TableCell,
-  LabelCell,
-  HeaderCell,
-  CtaCell,
-  Supported,
-  Unsupported,
-  Partial,
-} from "./Table/TableCell";
+import { TableCell, LabelCell, HeaderCell, CtaCell } from "./Table/TableCell";
 
 export default {
   Root: Table,
@@ -20,7 +12,4 @@ export default {
   RowHeader: TableRowHeader,
   Body: TableBody,
   Header: TableHeader,
-  Supported,
-  Unsupported,
-  Partial,
 };

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -49,7 +49,7 @@ export const TableRowHeader = ({
   ...rest
 }: PropsWithChildren<TableHTMLAttributes<HTMLTableRowElement>>) => (
   <tr
-    className={`-ml-24 mt-8 sm:ml-0 sm:mt-0 bg-light-grey sm:sticky z-10 ${
+    className={`-ml-24 mt-8 sm:ml-0 sm:mt-0 sm:sticky z-10 ${
       rest?.className ?? ""
     }`}
   >

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -52,7 +52,6 @@ export const TableRowHeader = ({
     className={`-ml-24 mt-8 sm:ml-0 sm:mt-0 bg-light-grey sm:sticky z-10 ${
       rest?.className ?? ""
     }`}
-    style={{ top: "4rem" }}
   >
     {cloneElement(children as ReactElement, { isRowHeader: true })}
   </tr>

--- a/src/core/Table/TableCell.tsx
+++ b/src/core/Table/TableCell.tsx
@@ -1,38 +1,8 @@
 import React, { PropsWithChildren } from "react";
-import Icon from "../Icon";
 
 type TableCellProps = {
   isRowHeader?: boolean;
 } & React.TdHTMLAttributes<HTMLTableCellElement>;
-
-const Supported = () => (
-  <Icon
-    name="icon-gui-check-circled-fill"
-    size="1.5rem"
-    color="text-gui-success"
-    additionalCSS="flex-grow-0 flex-shrink-0"
-    data-testid="supported-icon"
-  />
-);
-
-const Unsupported = () => (
-  <Icon
-    name="icon-gui-cross-circled-fill"
-    size="1.5rem"
-    color="text-gui-error"
-    additionalCSS="flex-grow-0 flex-shrink-0"
-    data-testid="unsupported-icon"
-  />
-);
-
-const Partial = () => (
-  <Icon
-    name="icon-gui-partial"
-    size="1.5rem"
-    additionalCSS="flex-grow-0 flex-shrink-0"
-    data-testid="partial-icon"
-  />
-);
 
 const LabelCell = ({
   children,
@@ -98,12 +68,4 @@ const CtaCell = ({
   </td>
 );
 
-export {
-  TableCell,
-  LabelCell,
-  HeaderCell,
-  CtaCell,
-  Supported,
-  Unsupported,
-  Partial,
-};
+export { TableCell, LabelCell, HeaderCell, CtaCell };

--- a/src/core/Table/data.tsx
+++ b/src/core/Table/data.tsx
@@ -1,8 +1,28 @@
 import React, { Fragment } from "react";
 
 import Tooltip from "../Tooltip";
-import { Supported, Unsupported } from "./TableCell";
 import Table from "../Table";
+import Icon from "../Icon";
+
+const Supported = () => (
+  <Icon
+    name="icon-gui-check-circled-fill"
+    size="1.5rem"
+    color="text-gui-success"
+    additionalCSS="flex-grow-0 flex-shrink-0"
+    data-testid="supported-icon"
+  />
+);
+
+const Unsupported = () => (
+  <Icon
+    name="icon-gui-cross-circled-fill"
+    size="1.5rem"
+    color="text-gui-error"
+    additionalCSS="flex-grow-0 flex-shrink-0"
+    data-testid="unsupported-icon"
+  />
+);
 
 const testRow = (index) => ({
   label: `Label ${index + 1}`,


### PR DESCRIPTION
## Jira Ticket Link / Motivation

https://ably.atlassian.net/browse/WEB-3571

## Summary of changes

This PR contains a set of relatively miscellaneous changes to `ably-ui` to support the latest (and hopefully for now, last) round of compare page QA iterations on `voltaire`.

The commit messages are fairly descriptive, the changes are mostly around removing pre-styling on components so that there's more flexibility on the usage end. The big thing is that the `Expander` has been modified so that the slide navigation is continuous in either direction, instead of "rewinding" back to the first one (as Design put it). Example below.


https://github.com/ably/ably-ui/assets/1105768/ec3d53b7-dce1-4213-adf3-2492cbd95ba3



## How do you manually test this?

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
