### PR TITLE
fix: remove Tailwind-dependent CSS imports from non-TSX components

### DIFF
--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -6,6 +6,7 @@
 @import "../src/core/fonts/manrope.css";
 @import "../src/core/styles.css";
 @import "../src/core/ContactFooter/component.css";
+@import "../src/core/Code/component.css";
 @import "../src/core/CookieMessage/component.css";
 @import "../src/core/Flash/component.css";
 @import "../src/core/Footer/component.css";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.2",
+  "version": "14.0.2-dev.7ec9557",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Code/component.js
+++ b/src/core/Code/component.js
@@ -1,5 +1,3 @@
-import "./component.css";
-
 // Note: importing syntax-highlighter here means the component.js file will include
 // all the language dependecies, creating a large a bundle. Prefer using the highlighter serverside.
 import {

--- a/src/core/ContactFooter/component.js
+++ b/src/core/ContactFooter/component.js
@@ -1,3 +1,2 @@
-import "./component.css";
 import toggleChatWidget from "../hubspot-chat-toggle";
 export default () => toggleChatWidget({ dataId: "contact-footer" });


### PR DESCRIPTION
## Summary of changes

The solution for getting Tailwind "layer" directives to work was to remove in-component css imports that also used these directives. I previously got rid of all of the TSX ones, seems the import into `website` exposed some JS ones that were left behind.

This fixes the build issue on `website` when upgrading to `^14.0.0`.

## How do you manually test this?

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
