### PR TITLE
Add basic spacing utilities and fix meganav/slider alignments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.3",
+  "version": "14.0.3-dev.79f1214",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.0.3-dev.79f1214",
+  "version": "14.0.3-dev.7b5c832",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/MeganavItemsMobile.tsx
+++ b/src/core/MeganavItemsMobile.tsx
@@ -37,7 +37,7 @@ const MeganavItemsMobile = ({
   const classNames = `ui-meganav-link ${theme.textColor}`;
 
   return (
-    <ul className="flex md:hidden" data-id="meganav-items-mobile">
+    <ul className="flex md:hidden items-center" data-id="meganav-items-mobile">
       <li>
         {sessionState?.signedIn && sessionState?.logOut ? (
           <SignOutLink absUrl={absUrl} {...sessionState.logOut}>

--- a/src/core/Slider.tsx
+++ b/src/core/Slider.tsx
@@ -183,7 +183,7 @@ const Slider = ({ children, options }: SliderProps) => {
           } pointer-events-auto rounded border border-mid-grey hover:border-active-orange flex justify-center items-center ui-icon-cta ui-icon-cta-left`}
           onClick={prev}
         >
-          <div className="ui-icon-cta-holder flex gap-4">
+          <div className="ui-icon-cta-holder flex w-48">
             <div className="w-full h-full flex-shrink-0 flex items-center justify-center">
               <Icon name="icon-gui-arrow-left" size="1.5rem" />
             </div>
@@ -207,7 +207,7 @@ const Slider = ({ children, options }: SliderProps) => {
           } pointer-events-auto rounded border border-mid-grey hover:border-active-orange justify-center items-center ui-icon-cta ui-icon-cta-right`}
           onClick={next}
         >
-          <div className="ui-icon-cta-holder flex gap-4">
+          <div className="ui-icon-cta-holder flex w-48">
             <div className="w-full h-full flex-shrink-0 flex items-center justify-center">
               <Icon name="icon-gui-arrow-right" size="1.5rem" />
             </div>

--- a/src/core/Slider/component.css
+++ b/src/core/Slider/component.css
@@ -23,10 +23,10 @@
 
   @screen sm {
     .ui-icon-cta-left:hover .ui-icon-cta-holder {
-      transform: translateX(-120%);
+      transform: translateX(-100%);
     }
     .ui-icon-cta-right .ui-icon-cta-holder {
-      transform: translateX(-120%);
+      transform: translateX(-100%);
     }
     .ui-icon-cta-right:hover .ui-icon-cta-holder {
       transform: translateX(0%);

--- a/src/core/styles.components.css
+++ b/src/core/styles.components.css
@@ -33,11 +33,11 @@
     font-size: 8px;
   }
 
-  .ui-spacing {
+  .ui-section-spacing {
     @apply py-80 sm:py-96 md:py-128;
   }
 
-  hr.ui-spacing {
+  .ui-divider-spacing {
     @apply py-40 sm:py-48 md:py-64;
   }
 }

--- a/src/core/styles.components.css
+++ b/src/core/styles.components.css
@@ -38,6 +38,6 @@
   }
 
   .ui-divider-spacing {
-    @apply py-40 sm:py-48 md:py-64;
+    @apply my-20 sm:my-24 md:my-32;
   }
 }

--- a/src/core/styles.components.css
+++ b/src/core/styles.components.css
@@ -32,4 +32,12 @@
     margin-left: 3px;
     font-size: 8px;
   }
+
+  .ui-spacing {
+    @apply py-80 sm:py-96 md:py-128;
+  }
+
+  hr.ui-spacing {
+    @apply py-40 sm:py-48 md:py-64;
+  }
 }


### PR DESCRIPTION
## Jira Ticket Link / Motivation

N/A

## Summary of changes

Additions:
- adds `ui-section-spacing` and `ui-divider-spacing`, two utility classes to represent the standard vertical spacing standards in the design system

Fixes:
- makes the "Login"/"Logout" link on the Meganav vertically centered instead of like this
![Screenshot 2024-06-07 at 15 58 20](https://github.com/ably/ably-ui/assets/1105768/7da34a7d-63fe-43c4-a584-6d78eaf6f8df)
- corrects the horizontal alignment of `Slider` navigation errors

## How do you manually test this?

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
