### PR TITLE
[WEB-3840] Fix Tailwind `src` paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ["./src/**/*.{js,json,css,ts,tsx,mdx}"],
+  content: ["./src/**/*.{js,ts,tsx,mdx}"],
   safelist: [
     "w-1/2",
     "w-1/3",

--- a/tailwind.extend.js
+++ b/tailwind.extend.js
@@ -3,22 +3,17 @@ const path = require("path");
 
 const ablyUiConfigPath = path.dirname(require.resolve("./tailwind.config.js"));
 
-const ablyUItailwindConfig = (extend) => {
-  // Create absolute paths to templates in AblyUI
-  const addPurgeContentPaths = () => {
-    const paths = ["*.html.erb", "*", "*.js", "*.json"].map((fileGlob) =>
-      path.join(ablyUiConfigPath, "src", "**", fileGlob),
-    );
-
-    return paths;
-  };
-
+const ablyUITailwindConfig = (extend) => {
+  // Create absolute paths to built assets (core, reset) in AblyUI, set as content source
   const configWithPlugin = {
     ...ablyUIConfig,
-    content: addPurgeContentPaths(),
+    content: [
+      path.join(ablyUiConfigPath, "core", "**", "*.js"),
+      path.join(ablyUiConfigPath, "reset", "**", "*.js"),
+    ],
   };
 
   return extend(configWithPlugin);
 };
 
-module.exports = ablyUItailwindConfig;
+module.exports = ablyUITailwindConfig;


### PR DESCRIPTION
## Summary of changes

`ably-ui` 14.0.6 introduced a problem, in that when `src` was omitted from the bundle - the host Tailwind setup in a given app wouldn't have visibility over `ably-ui` assets, due to the package Tailwind config referencing an `src` directory that was no longer there.

This PR extends the list of sources for Tailwind to take into account, and also revises the file types included (the Tailwind docs recommend that `.css` shouldn't be one of them, for instance).

## How do you manually test this?

Hard to test. I tested this by pulling version [14.1.1-dev.bdcfda0](https://www.npmjs.com/package/@ably/ui/v/14.1.1-dev.bdcfda0) into `voltaire` and ensuring that the compare pages weren't visually borked.

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
