### PR TITLE
[WEB-3870] Fix MSW service worker lookup when deployed

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,6 +18,12 @@ const docsContainer = ({ children, context, ...props }) => {
 
 initialize({
   onUnhandledRequest: "bypass",
+  serviceWorker: {
+    url:
+      location.hostname === "ably.github.io"
+        ? "/ably-ui/mockServiceWorker.js"
+        : "/mockServiceWorker.js",
+  },
 });
 
 const preview = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.1.7",
+  "version": "14.1.8",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -82,11 +82,7 @@
     "ui",
     "tailwind",
     "ably",
-    "react",
-    "view-components"
+    "react"
   ],
-  "author": "Ably Real-time Ltd <support@ably.com>",
-  "msw": {
-    "workerDirectory": "public"
-  }
+  "author": "Ably Real-time Ltd <support@ably.com>"
 }


### PR DESCRIPTION
## Jira Ticket Link / Motivation

The stories on the [deployed Storybook](https://ably.github.io/ably-ui/?path=/docs/js-components-featured-link--docs) are broken, because of an MSW service worker asset that gets lost because the URL structure changes.

## Summary of changes

Conditionally changes the URL for the service worker depending on the host. When deployed, we also need to take into account `/ably-ui` in the path (as the URL is `ably.github.ui/ably-ui`)

## How do you manually test this?

Hard to test, only comes into action when released.

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
