### PR TITLE
[WEB-3878] Handle window resizing in Expander

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.3.2",
+  "version": "14.3.3",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Expander.tsx
+++ b/src/core/Expander.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren, useEffect, useRef, useState } from "react";
+import throttle from "lodash.throttle";
 
 type ExpanderProps = {
   heightThreshold?: number;
@@ -20,11 +21,14 @@ const Expander = ({
 }: PropsWithChildren<ExpanderProps>) => {
   const innerRef = useRef<HTMLDivElement>(null);
   const [showControls, setShowControls] = useState(false);
+  const [contentHeight, setContentHeight] = useState<number>(heightThreshold);
   const [height, setHeight] = useState<number | "auto">(heightThreshold);
   const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
-    const contentHeight = innerRef.current?.clientHeight ?? heightThreshold;
+    if (innerRef.current) {
+      setContentHeight(innerRef.current.clientHeight);
+    }
 
     if (contentHeight < heightThreshold) {
       setHeight("auto");
@@ -35,7 +39,20 @@ const Expander = ({
     }
 
     setShowControls(contentHeight >= heightThreshold);
-  }, [heightThreshold, expanded]);
+  }, [contentHeight, heightThreshold, expanded]);
+
+  useEffect(() => {
+    const onResize = throttle(() => {
+      if (innerRef.current) {
+        setContentHeight(innerRef.current.clientHeight);
+      }
+    }, 250);
+
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+    };
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary of changes

Fixes some responsive behaviour with the `Expander` component, allowing the height calculations to run again when the window is resized (we would get some undesirable effects before this where the expander would expand too far, or not enough, because the content has changed height as a result of a resize).

## How do you manually test this?

Pull down, open up in Storybook, select the "Long Content" story under "Expander", make sure that the expander controls react as you would expect when you resize the window in and out (it should always sit at the full height of the content when expanded, no gaps).

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
