### PR TITLE
[WEB-4025] Add useTheming hook, reduce generated TW classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ yarn-error.log
 .idea/*
 types
 index.d.ts
-computed-colors-*.json
 computed-icons.ts
+computed-colors.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.6.9",
+  "version": "14.7.0",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Icon/EncapsulatedIcon.tsx
+++ b/src/core/Icon/EncapsulatedIcon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Icon, { IconProps } from "../Icon";
-import { determineThemeColor } from "../styles/colors/utils";
-import { ColorClass, Theme } from "../styles/colors/types";
+import useTheming from "../hooks/useTheming";
+import { Theme } from "../styles/colors/types";
 
 type EncapsulatedIconProps = {
   theme?: Theme;
@@ -18,7 +18,10 @@ const EncapsulatedIcon = ({
   innerClassName,
   ...iconProps
 }: EncapsulatedIconProps) => {
-  const t = (color: ColorClass) => determineThemeColor("dark", theme, color);
+  const { themeColor } = useTheming({
+    baseTheme: "dark",
+    theme,
+  });
   const numericalSize = parseInt(size, 10);
   const numericalIconSize = iconSize
     ? parseInt(iconSize, 10)
@@ -26,11 +29,11 @@ const EncapsulatedIcon = ({
 
   return (
     <div
-      className={`p-1 rounded-lg ${theme === "light" ? "bg-gradient-to-t" : "bg-gradient-to-b"} ${t("from-neutral-900")} ${className ?? ""}`}
+      className={`p-1 rounded-lg ${theme === "light" ? "bg-gradient-to-t" : "bg-gradient-to-b"} ${themeColor("from-neutral-900")} ${className ?? ""}`}
       style={{ width: numericalSize, height: numericalSize }}
     >
       <div
-        className={`flex items-center justify-center rounded-lg ${t("bg-neutral-1100")} ${innerClassName ?? ""}`}
+        className={`flex items-center justify-center rounded-lg ${themeColor("bg-neutral-1100")} ${innerClassName ?? ""}`}
         style={{ height: numericalSize - 2 }}
       >
         <Icon size={`${numericalIconSize}`} {...iconProps} />

--- a/src/core/Pricing/PricingCards.tsx
+++ b/src/core/Pricing/PricingCards.tsx
@@ -1,12 +1,12 @@
 import React, { Fragment, useEffect, useRef, useState } from "react";
 import throttle from "lodash.throttle";
 import type { PricingDataFeature } from "./types";
-import { determineThemeColor } from "../styles/colors/utils";
 import { ColorClass, Theme } from "../styles/colors/types";
 import Icon from "../Icon";
 import FeaturedLink from "../FeaturedLink";
 import { IconName } from "../Icon/types";
 import Tooltip from "../Tooltip";
+import useTheming from "../hooks/useTheming";
 
 export type PricingCardsProps = {
   data: PricingDataFeature[];
@@ -45,8 +45,10 @@ const PricingCards = ({
     };
   }, []);
 
-  // work out a dynamic theme colouring, using dark theme colouring as the base
-  const t = (color: ColorClass) => determineThemeColor("dark", theme, color);
+  const { themeColor } = useTheming({
+    baseTheme: "dark",
+    theme,
+  });
 
   const delimiterColumn = (index: number) =>
     delimiter && index % 2 === 1 ? (
@@ -57,7 +59,7 @@ const PricingCards = ({
           <Icon
             name={delimiter}
             size="20"
-            additionalCSS={t("text-neutral-500")}
+            additionalCSS={themeColor("text-neutral-500")}
           />
         ) : null}
       </div>
@@ -95,7 +97,7 @@ const PricingCards = ({
             <Fragment key={title.content}>
               {delimiterColumn(index)}
               <div
-                className={`relative border ${t(borderClasses(border?.color)?.border ?? "border-neutral-1100")} ${border?.style ?? ""} flex-1 px-24 py-32 flex flex-col gap-24 rounded-2xl group ${delimiter ? "@[520px]:flex-row @[920px]:flex-col" : ""} min-w-[272px] backdrop-blur`}
+                className={`relative border ${themeColor(borderClasses(border?.color)?.border ?? "border-neutral-1100")} ${border?.style ?? ""} flex-1 px-24 py-32 flex flex-col gap-24 rounded-2xl group ${delimiter ? "@[520px]:flex-row @[920px]:flex-col" : ""} min-w-[272px] backdrop-blur`}
                 data-testid={
                   delimiter ? "delimited-pricing-card" : "pricing-card"
                 }
@@ -108,7 +110,7 @@ const PricingCards = ({
                   </div>
                 ) : null}
                 <div
-                  className={`absolute z-0 top-0 left-0 w-full h-full rounded-2xl ${t("bg-neutral-1300")} ${!delimiter ? `${t("group-hover:bg-neutral-1200")} group-hover:opacity-100` : ""} transition-[colors,opacity] opacity-25`}
+                  className={`absolute z-0 top-0 left-0 w-full h-full rounded-2xl ${themeColor("bg-neutral-1300")} ${!delimiter ? `${themeColor("group-hover:bg-neutral-1200")} group-hover:opacity-100` : ""} transition-[colors,opacity] opacity-25`}
                 ></div>
                 <div
                   className={`relative z-10 flex flex-col gap-24 ${delimiter ? "@[520px]:flex-1 @[920px]:flex-none" : ""}`}
@@ -116,7 +118,7 @@ const PricingCards = ({
                   <div>
                     <div className="flex items-center mb-12">
                       <p
-                        className={`${title.className ?? ""} ${t(title.color ?? "text-neutral-000")}`}
+                        className={`${title.className ?? ""} ${themeColor(title.color ?? "text-neutral-000")}`}
                       >
                         {title.content}
                       </p>
@@ -130,7 +132,7 @@ const PricingCards = ({
                       ) : null}
                     </div>
                     <p
-                      className={`ui-text-p1 ${description.className ?? ""} ${t(description.color ?? "text-neutral-000")} min-h-20`}
+                      className={`ui-text-p1 ${description.className ?? ""} ${themeColor(description.color ?? "text-neutral-000")} min-h-20`}
                       style={{ height: descriptionHeight }}
                     >
                       <span ref={(el) => (descriptionsRef.current[index] = el)}>
@@ -142,18 +144,20 @@ const PricingCards = ({
                     className={`flex items-end gap-8 ${delimiter ? "@[520px]:flex-col @[520px]:items-start @[920px]:flex-row @[920px]:items-end" : ""}`}
                   >
                     <p
-                      className={`ui-text-title font-medium tracking-tight leading-none ${t("text-neutral-000")}`}
+                      className={`ui-text-title font-medium tracking-tight leading-none ${themeColor("text-neutral-000")}`}
                     >
                       {price.amount}
                     </p>
-                    <div className={`ui-text-p3 ${t("text-neutral-000")}`}>
+                    <div
+                      className={`ui-text-p3 ${themeColor("text-neutral-000")}`}
+                    >
                       {price.content}
                     </div>
                   </div>
                   {cta ? (
                     <div className="group">
                       <FeaturedLink
-                        additionalCSS={`text-center ui-btn ${t("bg-neutral-000")} ${t("text-neutral-1300")} hover:text-neutral-000 px-24 !py-12 ${cta.className ?? ""} cursor-pointer`}
+                        additionalCSS={`text-center ui-btn ${themeColor("bg-neutral-000")} ${themeColor("text-neutral-1300")} hover:text-neutral-000 px-24 !py-12 ${cta.className ?? ""} cursor-pointer`}
                         url={cta.url}
                         onClick={cta.onClick}
                         disabled={cta.disabled}
@@ -163,7 +167,9 @@ const PricingCards = ({
                     </div>
                   ) : delimiter ? null : (
                     <div className="flex items-center justify-center h-48 w-full">
-                      <hr className={`${t("border-neutral-800")} w-64`} />
+                      <hr
+                        className={`${themeColor("border-neutral-800")} w-64`}
+                      />
                     </div>
                   )}
                 </div>
@@ -171,7 +177,7 @@ const PricingCards = ({
                   {sections.map(({ title, items, listItemColors, cta }) => (
                     <div key={title} className="flex flex-col gap-12">
                       <p
-                        className={`${t("text-neutral-500")} font-mono uppercase text-overline2 tracking-[0.16em]`}
+                        className={`${themeColor("text-neutral-500")} font-mono uppercase text-overline2 tracking-[0.16em]`}
                       >
                         {title}
                       </p>
@@ -180,12 +186,12 @@ const PricingCards = ({
                           Array.isArray(item) ? (
                             <div
                               key={item[0]}
-                              className={`flex justify-between gap-16 px-8 -mx-8 ${index === 0 ? "py-8" : "py-4"} ${index > 0 && index % 2 === 0 ? `${t("bg-blue-900")} rounded-md` : ""}`}
+                              className={`flex justify-between gap-16 px-8 -mx-8 ${index === 0 ? "py-8" : "py-4"} ${index > 0 && index % 2 === 0 ? `${themeColor("bg-blue-900")} rounded-md` : ""}`}
                             >
                               {item.map((subItem, subIndex) => (
                                 <span
                                   key={subItem}
-                                  className={`ui-text-p3 ${index === 0 ? "font-bold" : "font-medium"} ${t("text-neutral-300")} ${subIndex % 2 === 1 ? "text-right" : ""}`}
+                                  className={`ui-text-p3 ${index === 0 ? "font-bold" : "font-medium"} ${themeColor("text-neutral-300")} ${subIndex % 2 === 1 ? "text-right" : ""}`}
                                 >
                                   {subItem}
                                 </span>
@@ -196,14 +202,16 @@ const PricingCards = ({
                               {listItemColors ? (
                                 <Icon
                                   name="icon-gui-check-circled-fill"
-                                  color={t(listItemColors.background)}
-                                  secondaryColor={t(listItemColors.foreground)}
+                                  color={themeColor(listItemColors.background)}
+                                  secondaryColor={themeColor(
+                                    listItemColors.foreground,
+                                  )}
                                   size="16"
                                   additionalCSS="mt-2"
                                 />
                               ) : null}
                               <div
-                                className={`flex-1 ${listItemColors ? "ui-text-p3" : "ui-text-p2"} font-medium ${t("text-neutral-300")}`}
+                                className={`flex-1 ${listItemColors ? "ui-text-p3" : "ui-text-p2"} font-medium ${themeColor("text-neutral-300")}`}
                               >
                                 {item}
                               </div>
@@ -215,16 +223,16 @@ const PricingCards = ({
                         <div className="relative -mx-24 flex items-center h-40 overflow-x-hidden">
                           <FeaturedLink
                             url={cta.url}
-                            additionalCSS={`absolute sm:-translate-x-120 sm:opacity-0 sm:group-hover:translate-x-24 duration-300 delay-0 sm:group-hover:delay-100 sm:group-hover:opacity-100 transition-[transform,opacity] font-medium ui-text-p3 ${t("text-neutral-500")} hover:${t("text-neutral-000")} cursor-pointer`}
+                            additionalCSS={`absolute sm:-translate-x-120 sm:opacity-0 sm:group-hover:translate-x-24 duration-300 delay-0 sm:group-hover:delay-100 sm:group-hover:opacity-100 transition-[transform,opacity] font-medium ui-text-p3 ${themeColor("text-neutral-500")} hover:${themeColor("text-neutral-000")} cursor-pointer`}
                             onClick={cta.onClick}
-                            iconColor={t(
+                            iconColor={themeColor(
                               listItemColors?.foreground ?? "text-white",
                             )}
                           >
                             {cta.text}
                           </FeaturedLink>
                           <div
-                            className={`absolute sm:translate-x-24 sm:opacity-100 sm:group-hover:translate-x-120 sm:group-hover:opacity-0 duration-200 delay-100 sm:group-hover:delay-0 transition-[transform,opacity] leading-6 tracking-widen-0.15 font-light text-p3 ${t("text-neutral-800")}`}
+                            className={`absolute sm:translate-x-24 sm:opacity-100 sm:group-hover:translate-x-120 sm:group-hover:opacity-0 duration-200 delay-100 sm:group-hover:delay-0 transition-[transform,opacity] leading-6 tracking-widen-0.15 font-light text-p3 ${themeColor("text-neutral-800")}`}
                           >
                             •••
                           </div>

--- a/src/core/ProductTile.tsx
+++ b/src/core/ProductTile.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import EncapsulatedIcon from "./Icon/EncapsulatedIcon";
 import FeaturedLink from "./FeaturedLink";
 import { ProductName, products } from "./ProductTile/data";
-import { ColorClass } from "./styles/colors/types";
-import { determineThemeColor } from "./styles/colors/utils";
+import useTheming from "./hooks/useTheming";
 
 type ProductTileProps = {
   name: ProductName;
@@ -20,14 +19,15 @@ const ProductTile = ({
   className,
   onClick,
 }: ProductTileProps) => {
+  const { themeColor } = useTheming({
+    baseTheme: "dark",
+    theme: selected ? "light" : "dark",
+  });
   const { icon, label, description, link, unavailable } = products[name] ?? {};
-
-  const t = (color: ColorClass) =>
-    determineThemeColor("dark", selected ? "light" : "dark", color);
 
   return (
     <div
-      className={`rounded-lg p-12 flex flex-col gap-8 transition-colors ${t("bg-neutral-1200")} ${selected ? "" : "hover:bg-neutral-1100"} ${className ?? ""}`}
+      className={`rounded-lg p-12 flex flex-col gap-8 transition-colors ${themeColor("bg-neutral-1200")} ${selected ? "" : "hover:bg-neutral-1100"} ${className ?? ""}`}
       onClick={onClick}
     >
       <div className="flex gap-12 items-center">
@@ -38,12 +38,12 @@ const ProductTile = ({
           className={`flex ${unavailable ? "flex-row items-center gap-4" : "flex-col justify-center"} `}
         >
           <p
-            className={`${unavailable ? "ui-text-p2" : "ui-text-p3"} ${t("text-neutral-300")} font-medium`}
+            className={`${unavailable ? "ui-text-p2" : "ui-text-p3"} ${themeColor("text-neutral-300")} font-medium`}
           >
             Ably{" "}
           </p>
           <p
-            className={`ui-text-p2 ${t("text-neutral-000")} font-bold ${unavailable ? "" : "mt-[-3px]"}`}
+            className={`ui-text-p2 ${themeColor("text-neutral-000")} font-bold ${unavailable ? "" : "mt-[-3px]"}`}
           >
             {label}
           </p>
@@ -63,7 +63,7 @@ const ProductTile = ({
       </p>
       {selected && link ? (
         <FeaturedLink
-          additionalCSS={`ui-btn-secondary bg-transparent hover:bg-transparent w-full hover:text-neutral-1300 mt-8 text-center inline-block ${t("text-neutral-000")}`}
+          additionalCSS={`ui-btn-secondary bg-transparent hover:bg-transparent w-full hover:text-neutral-1300 mt-8 text-center inline-block ${themeColor("text-neutral-000")}`}
           iconColor="text-orange-600"
           url={link}
         >

--- a/src/core/Tooltip.tsx
+++ b/src/core/Tooltip.tsx
@@ -11,8 +11,8 @@ import React, {
 } from "react";
 import { createPortal } from "react-dom";
 import Icon from "./Icon";
-import { ColorClass, Theme } from "./styles/colors/types";
-import { determineThemeColor } from "./styles/colors/utils";
+import useTheming from "./hooks/useTheming";
+import { Theme } from "./styles/colors/types";
 
 type TooltipProps = {
   triggerElement?: ReactNode;
@@ -38,8 +38,10 @@ const Tooltip = ({
   const reference = useRef<HTMLButtonElement>(null);
   const floating = useRef<HTMLDivElement>(null);
   const fadeOutTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const t = (color: ColorClass) => determineThemeColor("light", theme, color);
+  const { themeColor } = useTheming({
+    baseTheme: "light",
+    theme,
+  });
 
   useEffect(() => {
     if (open) {
@@ -164,7 +166,7 @@ const Tooltip = ({
         {triggerElement ?? (
           <Icon
             name="icon-gui-info"
-            color={`${t("text-neutral-800")}`}
+            color={`${themeColor("text-neutral-800")}`}
             size="1rem"
           />
         )}
@@ -185,7 +187,7 @@ const Tooltip = ({
                 boxShadow: "4px 4px 15px rgba(0, 0, 0, 0.2)",
               }}
               {...tooltipProps}
-              className={`${t("bg-neutral-1000")} ${t("text-neutral-200")} ui-text-p3 font-medium p-16 ${interactive ? "" : "pointer-events-none"} rounded-lg absolute ${
+              className={`${themeColor("bg-neutral-1000")} ${themeColor("text-neutral-200")} ui-text-p3 font-medium p-16 ${interactive ? "" : "pointer-events-none"} rounded-lg absolute ${
                 tooltipProps?.className ?? ""
               } ${fadeOut ? "animate-[tooltipExit_0.25s_ease-in-out]" : "animate-[tooltipEntry_0.25s_ease-in-out]"}`}
             >

--- a/src/core/hooks/useTheming.tsx
+++ b/src/core/hooks/useTheming.tsx
@@ -1,0 +1,25 @@
+import { useCallback } from "react";
+import { ColorClass, Theme } from "../styles/colors/types";
+import { invertTailwindClassVariant } from "../styles/colors/utils";
+
+type UseThemingProps = {
+  baseTheme?: Theme;
+  theme?: Theme;
+};
+
+const useTheming = ({
+  baseTheme = "dark",
+  theme = "dark",
+}: UseThemingProps) => {
+  const themeColor = useCallback(
+    (color: ColorClass) =>
+      theme === baseTheme ? color : invertTailwindClassVariant(color),
+    [baseTheme, theme],
+  );
+
+  return {
+    themeColor,
+  };
+};
+
+export default useTheming;

--- a/src/core/styles/colors/Colors.stories.tsx
+++ b/src/core/styles/colors/Colors.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { colorNames } from "./types";
-import { determineThemeColor } from "./utils";
+import { colorRoles } from "./types";
 import Icon from "../../Icon";
+import useTheming from "../../hooks/useTheming";
 
 export default {
   title: "CSS/Colors",
@@ -47,7 +47,7 @@ const varToValues = (color: string) => {
 export const NeutralColors = {
   render: () => (
     <div className="flex flex-wrap gap-24">
-      {colorSet([...colorNames.neutral])}
+      {colorSet([...colorRoles.neutral])}
     </div>
   ),
   parameters: {
@@ -62,7 +62,7 @@ export const NeutralColors = {
 export const OrangeColors = {
   render: () => (
     <div className="flex flex-wrap gap-24">
-      {colorSet([...colorNames.orange])}
+      {colorSet([...colorRoles.orange])}
     </div>
   ),
   parameters: {
@@ -77,7 +77,7 @@ export const OrangeColors = {
 export const SecondaryColors = {
   render: () => (
     <div className="flex flex-wrap gap-24">
-      {colorSet([...colorNames.secondary])}
+      {colorSet([...colorRoles.secondary])}
     </div>
   ),
   parameters: {
@@ -91,7 +91,7 @@ export const SecondaryColors = {
 
 export const GUIColors = {
   render: () => (
-    <div className="flex flex-wrap gap-24">{colorSet([...colorNames.gui])}</div>
+    <div className="flex flex-wrap gap-24">{colorSet([...colorRoles.gui])}</div>
   ),
   parameters: {
     docs: {
@@ -104,25 +104,29 @@ export const GUIColors = {
 };
 
 export const DynamicTheming = {
-  render: () => (
-    <div className="flex items-center">
-      <div className="flex flex-wrap gap-24">
-        {colorSet(["orange-300"], "bg-orange-300")}
+  render: () => {
+    const { themeColor } = useTheming({
+      baseTheme: "dark",
+      theme: "light",
+    });
+
+    return (
+      <div className="flex items-center">
+        <div className="flex flex-wrap gap-24">
+          {colorSet(["orange-300"], "bg-orange-300")}
+        </div>
+        <Icon name="icon-gui-arrow-right" size="48" additionalCSS="m-16"></Icon>
+        <div className="flex flex-wrap gap-24">
+          {colorSet(["orange-900"], themeColor("bg-orange-300"))}
+        </div>
       </div>
-      <Icon name="icon-gui-arrow-right" size="48" additionalCSS="m-16"></Icon>
-      <div className="flex flex-wrap gap-24">
-        {colorSet(
-          ["orange-900"],
-          determineThemeColor("dark", "light", "bg-orange-300"),
-        )}
-      </div>
-    </div>
-  ),
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          "We can generate alternatives for a color based on the theme. Example usage: `determineThemeColor('dark', 'light', 'bg-orange-300')` - this takes a base theme of 'dark', a target theme of 'light', and the colour to convert.",
+          "We can generate alternatives for a color based on the theme. To do this, pull in the `useTheming` hook and access the `themeColor` function - passing in `baseTheme` and `theme` when you call the hook to provide the context for `themeColor`. Then, wrap any Tailwind color class in `themeColor` to conditionally generate the alternative color, if the target theme differs from the base theme. Any new classes will be generated and fed into Tailwind at build time.",
       },
     },
   },

--- a/src/core/styles/colors/types.ts
+++ b/src/core/styles/colors/types.ts
@@ -19,6 +19,18 @@ export const prefixes = ["text", "bg", "from", "to", "border"] as const;
 
 type ColorClassPrefixes = (typeof prefixes)[number];
 
+export const colors = [
+  "neutral",
+  "orange",
+  "blue",
+  "yellow",
+  "green",
+  "violet",
+  "pink",
+] as const;
+
+export type ColorClassColorGroups = (typeof colors)[number];
+
 export type Theme = "light" | "dark";
 
 export type ColorClass =
@@ -164,24 +176,19 @@ const aliasedColors = [
   "transparent",
 ] as const;
 
-export const colorNames = {
+export const colorRoles = {
   neutral: neutralColors,
   orange: orangeColors,
   secondary: secondaryColors,
   gui: guiColors,
 };
 
-export const numericalColors = [
-  neutralColors,
-  orangeColors,
-  yellowColors,
-  greenColors,
-  blueColors,
-  violetColors,
-  pinkColors,
-];
-
-export type ComputedColors = Record<
-  ColorClass,
-  Partial<Record<Theme, ColorClass>>
->;
+export const colorGroupLengths = {
+  neutral: neutralColors.length,
+  orange: orangeColors.length,
+  blue: blueColors.length,
+  yellow: yellowColors.length,
+  green: greenColors.length,
+  violet: violetColors.length,
+  pink: pinkColors.length,
+};

--- a/src/core/styles/colors/utils.ts
+++ b/src/core/styles/colors/utils.ts
@@ -1,26 +1,28 @@
-import { ColorClass, ComputedColors, Theme } from "./types";
-
-// If missing, run any build script involving build:colors, i.e. yarn storybook
-import computedColorsDark from "./computed-colors-dark.json";
-import computedColorsLight from "./computed-colors-light.json";
+import { ColorClass, ColorClassColorGroups, colorGroupLengths } from "./types";
 
 export const convertTailwindClassToVar = (className: string) =>
   className.replace(/(text|bg|from|to)-([a-z0-9-]+)/gi, "var(--color-$2)");
 
-export const determineThemeColor = (
-  baseTheme: Theme,
-  currentTheme: Theme,
-  color: ColorClass,
-) => {
-  if (baseTheme === currentTheme) {
-    return color;
-  } else if (baseTheme === "light") {
-    return (
-      (computedColorsLight as ComputedColors)[color][currentTheme] || color
-    );
-  } else if (baseTheme === "dark") {
-    return (computedColorsDark as ComputedColors)[color][currentTheme] || color;
+export const invertTailwindClassVariant = (className: string): ColorClass => {
+  const splitMatch = className.split("-");
+  if (splitMatch.length < 3) {
+    throw new Error("Invalid TW class format");
   }
 
-  return color;
+  const color = splitMatch[splitMatch.length - 2];
+  const variant = splitMatch[splitMatch.length - 1];
+  const property = splitMatch.slice(0, splitMatch.length - 1).join("-");
+
+  const numericalVariant = Number(variant.slice(0, -2)) ?? 0;
+  if (isNaN(numericalVariant)) {
+    throw new Error(`Invalid variant value in TW class: ${className}`);
+  }
+
+  const flippedVariant =
+    colorGroupLengths[color as ColorClassColorGroups] -
+    numericalVariant -
+    (color === "neutral" ? 1 : -1);
+  const flippedMatch = `${property}-${flippedVariant}00`;
+
+  return flippedMatch as ColorClass;
 };


### PR DESCRIPTION
## Jira Ticket Link / Motivation

There's been a few swings at getting dynamic theming right across our components, but so far things haven't been quite right in terms of optimisation and the usage of the functionality in the code - this PR aims to address things on both those fronts.

## Summary of changes

Currently, the approach to generating extra Tailwind classes necessitated by dynamic theming has embedded a misunderstanding about Tailwind itself. Turns out, very large lookup tables are ingested by Tailwind wholesale, and result in very large build sizes.

This PR flips the approach by scanning the repo for uses of the `themeColor` helper (previously `t`), and keeping a record of the thematic variants of those classes _only_, meaning we only generate the classes we actually need instead of every possible combination.

This is supported by the restructuring of the dynamic theming logic into a hook called `useTheming`. The advantages of this are twofold:
- it standardises what the theming helper is called. Previously, `t` was a convention but this wasn't reinforced anywhere, which is messy, particularly when you need some consistency when scanning for theme-oriented class names in the code. `useTheming` only gives you `themeColor` back.
- it paves the way for global theming in future, as we can integrate this hook in with an repo-wide context which holds the state for theming across a whole app

## How do you manually test this?

It's a background change so hard to test directly. Look at Storybook and see all the colours work on theme-flipped components (i.e. PricingCards) I guess.

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new theming hook (`useTheming`) to manage theme colors dynamically across components.
	- Enhanced color management with new definitions and structures for color types.

- **Bug Fixes**
	- Removed deprecated `determineThemeColor` function to streamline theme color management.

- **Documentation**
	- Updated documentation for `DynamicTheming` to reflect new usage patterns with the `useTheming` hook.

- **Chores**
	- Incremented version number in `package.json` to indicate a shift to a development version.
	- Modified `.gitignore` to adjust tracking behavior for specific color files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->