### PR TITLE
fix: structure themeColor detection regex correctly, temporarily hardcode non-literal theming arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.7.1",
+  "version": "14.7.2",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/scripts/compute-colors.ts
+++ b/scripts/compute-colors.ts
@@ -13,10 +13,8 @@ const outputPath = path.join(
 const joinedVariants = variants.join("|");
 const joinedPrefixes = prefixes.join("|");
 const joinedColors = colors.join("|");
-const regex = new RegExp(
-  `themeColor\\("((${joinedVariants}${joinedPrefixes})-(${joinedColors})-(000|[1-9]00|1[0-3]00))"\\)`,
-  "g",
-);
+const pattern = `themeColor\\("((?:${joinedVariants}-)(${joinedPrefixes})-(${joinedColors})-(000|[1-9]00|1[0-3]00))"\\)`;
+const regex = new RegExp(pattern, "g");
 
 const findStringInFiles = (dir: string) => {
   const results: string[] = [];

--- a/src/core/Pricing/PricingCards.tsx
+++ b/src/core/Pricing/PricingCards.tsx
@@ -8,6 +8,20 @@ import { IconName } from "../Icon/types";
 import Tooltip from "../Tooltip";
 import useTheming from "../hooks/useTheming";
 
+/**
+  Pricing hack to get all the themes loaded
+
+  themeColor("text-orange-600")
+  themeColor("text-orange-1000")
+  themeColor("text-neutral-000")
+  themeColor("text-neutral-500")
+  themeColor("text-neutral-600")
+  themeColor("text-neutral-700")
+  themeColor("text-neutral-1000")
+  themeColor("text-blue-400")
+  themeColor("text-blue-800")
+ */
+
 export type PricingCardsProps = {
   data: PricingDataFeature[];
   theme?: Theme;
@@ -72,9 +86,18 @@ const PricingCards = ({
 
   const borderClasses = (color?: "neutral" | "blue" | "orange") => {
     const classes: Record<string, { border: ColorClass; bg: ColorClass }> = {
-      neutral: { border: "border-neutral-700", bg: "bg-neutral-700" },
-      blue: { border: "border-blue-600", bg: "bg-blue-600" },
-      orange: { border: "border-orange-600", bg: "bg-orange-600" },
+      neutral: {
+        border: themeColor("border-neutral-700"),
+        bg: themeColor("bg-neutral-700"),
+      },
+      blue: {
+        border: themeColor("border-blue-600"),
+        bg: themeColor("bg-blue-600"),
+      },
+      orange: {
+        border: themeColor("border-orange-600"),
+        bg: themeColor("bg-orange-600"),
+      },
     };
 
     if (color && classes[color]) {
@@ -97,7 +120,7 @@ const PricingCards = ({
             <Fragment key={title.content}>
               {delimiterColumn(index)}
               <div
-                className={`relative border ${themeColor(borderClasses(border?.color)?.border ?? "border-neutral-1100")} ${border?.style ?? ""} flex-1 px-24 py-32 flex flex-col gap-24 rounded-2xl group ${delimiter ? "@[520px]:flex-row @[920px]:flex-col" : ""} min-w-[272px] backdrop-blur`}
+                className={`relative border ${borderClasses(border?.color)?.border ?? themeColor("border-neutral-1100")} ${border?.style ?? ""} flex-1 px-24 py-32 flex flex-col gap-24 rounded-2xl group ${delimiter ? "@[520px]:flex-row @[920px]:flex-col" : ""} min-w-[272px] backdrop-blur`}
                 data-testid={
                   delimiter ? "delimited-pricing-card" : "pricing-card"
                 }
@@ -226,7 +249,7 @@ const PricingCards = ({
                             additionalCSS={`absolute sm:-translate-x-120 sm:opacity-0 sm:group-hover:translate-x-24 duration-300 delay-0 sm:group-hover:delay-100 sm:group-hover:opacity-100 transition-[transform,opacity] font-medium ui-text-p3 ${themeColor("text-neutral-500")} hover:${themeColor("text-neutral-000")} cursor-pointer`}
                             onClick={cta.onClick}
                             iconColor={themeColor(
-                              listItemColors?.foreground ?? "text-white",
+                              listItemColors?.foreground ?? "text-neutral-000",
                             )}
                           >
                             {cta.text}


### PR DESCRIPTION
## Jira Ticket Link / Motivation

There are some regressions as a result of https://github.com/ably/ably-ui/pull/510, as the regex for detecting `themeColor` obviously can't detect cases where the argument to `themeColor` is not the class that needs to be processed for theming. We need to figure this out later but be unblocked for now, so some hard-coded references have been added.

Also the regex didn't group properly and omitted `text` from Tailwind class detection, which didn't help.

## Summary of changes

<!-- Commits should already be describing what you are trying to achieve. If needed, use this space to explain how they connect to achieve criteria from the Motivation. Otherwise, uncomment the below: -->
<!-- See commits for details. -->

## How do you manually test this?

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?
