### PR TITLE
[WEB-4025] 14.7.6 - fix: explicitly set Icon size units

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.7.5",
+  "version": "14.7.6",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Accordion.tsx
+++ b/src/core/Accordion.tsx
@@ -141,14 +141,14 @@ const AccordionRow = ({
         {...(!isStaticTheme(theme) ? { onClick } : {})}
         className={`flex w-full ${sticky ? "sticky top-0" : ""} focus:outline-none py-16 rounded-lg ui-text-p1 font-bold text-left items-center gap-12 ${isNonTransparentTheme(theme) ? "px-16 mb-16" : ""} ${isStaticTheme(theme) ? "pointer-events-none" : ""} transition-colors ${bgClasses} ${textClass}`}
       >
-        {rowIcon ? <Icon name={rowIcon} color={textClass} size="32" /> : null}
+        {rowIcon ? <Icon name={rowIcon} color={textClass} size="32px" /> : null}
         <span>{name}</span>
         {!selectable ? (
           <span className="flex-1 justify-end flex items-center">
             <Icon
               name={open ? toggleIcons.open.name : toggleIcons.closed.name}
               color={toggleIconColor}
-              size="16"
+              size="16px"
             />{" "}
           </span>
         ) : null}

--- a/src/core/Expander/Expander.stories.tsx
+++ b/src/core/Expander/Expander.stories.tsx
@@ -140,7 +140,7 @@ export const OverriddenControls = {
       controlsOpenedLabel={
         <span className="flex items-center gap-8">
           Away with you, knave.{" "}
-          <Icon color="text-pink-500" size="24" name="icon-gui-warning" />
+          <Icon color="text-pink-500" size="24px" name="icon-gui-warning" />
         </span>
       }
       controlsClosedLabel="Give me more!"

--- a/src/core/Pricing/PricingCards.tsx
+++ b/src/core/Pricing/PricingCards.tsx
@@ -72,7 +72,7 @@ const PricingCards = ({
         {delimiter !== "blank" ? (
           <Icon
             name={delimiter}
-            size="20"
+            size="20px"
             additionalCSS={themeColor("text-neutral-500")}
           />
         ) : null}
@@ -229,7 +229,7 @@ const PricingCards = ({
                                   secondaryColor={themeColor(
                                     listItemColors.foreground,
                                   )}
-                                  size="16"
+                                  size="16px"
                                   additionalCSS="mt-2"
                                 />
                               ) : null}

--- a/src/core/styles/colors/Colors.stories.tsx
+++ b/src/core/styles/colors/Colors.stories.tsx
@@ -115,7 +115,11 @@ export const DynamicTheming = {
         <div className="flex flex-wrap gap-24">
           {colorSet(["orange-300"], "bg-orange-300")}
         </div>
-        <Icon name="icon-gui-arrow-right" size="48" additionalCSS="m-16"></Icon>
+        <Icon
+          name="icon-gui-arrow-right"
+          size="48px"
+          additionalCSS="m-16"
+        ></Icon>
         <div className="flex flex-wrap gap-24">
           {colorSet(["orange-900"], themeColor("bg-orange-300"))}
         </div>


### PR DESCRIPTION
## Jira Ticket Link / Motivation

It was pointed out that pricing page looks like crap on Firefox. This is because of how Firefox handles values provided for inline styling - it needs greater specificity than Chrome. In this particular example, a size of "16" was interpreted as "16px" in Chrome, but as an erroneous value in Firefox, hence the massive icons.

## Summary of changes

Fix the unit definitions for sizes for `Icon`s to fix icon rendering on Firefox.

## How do you manually test this?

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version number of the project to 14.7.6.
  
- **Improvements**
	- Adjusted icon size properties across multiple components for consistency by specifying sizes in pixels (e.g., "32" to "32px").
  
- **Bug Fixes**
	- Enhanced the `PricingCards` component to conditionally apply margin based on the `delimiter` prop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->