### PR TITLE
[WEB-4025] Assert presence of units in Icon size prop values

### DIFF
--- a/src/core/Icon.tsx
+++ b/src/core/Icon.tsx
@@ -1,12 +1,12 @@
 import React, { CSSProperties } from "react";
 import { defaultIconSecondaryColor } from "./Icon/secondary-colors";
-import { IconName } from "./Icon/types";
+import { IconName, IconSize } from "./Icon/types";
 import { ColorClass } from "./styles/colors/types";
 import { convertTailwindClassToVar } from "./styles/colors/utils";
 
 export type IconProps = {
   name: IconName;
-  size?: string;
+  size?: IconSize;
   color?: ColorClass;
   secondaryColor?: ColorClass;
   additionalCSS?: string;

--- a/src/core/Icon/EncapsulatedIcon.tsx
+++ b/src/core/Icon/EncapsulatedIcon.tsx
@@ -2,13 +2,17 @@ import React from "react";
 import Icon, { IconProps } from "../Icon";
 import useTheming from "../hooks/useTheming";
 import { Theme } from "../styles/colors/types";
+import { IconSize } from "./types";
 
 type EncapsulatedIconProps = {
   theme?: Theme;
   className?: string;
   innerClassName?: string;
-  iconSize?: string;
+  iconSize?: IconSize;
 } & IconProps;
+
+const ICON_SIZE_REDUCTION = 12;
+const ICON_HEIGHT_REDUCTION = 2;
 
 const EncapsulatedIcon = ({
   theme = "dark",
@@ -22,21 +26,31 @@ const EncapsulatedIcon = ({
     baseTheme: "dark",
     theme,
   });
-  const numericalSize = parseInt(size, 10);
-  const numericalIconSize = iconSize
-    ? parseInt(iconSize, 10)
-    : numericalSize - 12;
+  let computedIconSize = size,
+    computedIconHeight = size;
+
+  if (iconSize) {
+    computedIconSize = iconSize;
+  } else if (size.toString().endsWith("px")) {
+    const numericalSize = parseInt(size, 10);
+    computedIconSize = `${numericalSize - ICON_SIZE_REDUCTION}px`;
+    computedIconHeight = `${numericalSize - ICON_HEIGHT_REDUCTION}px`;
+  } else {
+    console.warn(
+      `EncapsulatedIcon: Non-pixel units might not behave as expected`,
+    );
+  }
 
   return (
     <div
       className={`p-1 rounded-lg ${theme === "light" ? "bg-gradient-to-t" : "bg-gradient-to-b"} ${themeColor("from-neutral-900")} ${className ?? ""}`}
-      style={{ width: numericalSize, height: numericalSize }}
+      style={{ width: size, height: size }}
     >
       <div
         className={`flex items-center justify-center rounded-lg ${themeColor("bg-neutral-1100")} ${innerClassName ?? ""}`}
-        style={{ height: numericalSize - 2 }}
+        style={{ height: computedIconHeight }}
       >
-        <Icon size={`${numericalIconSize}`} {...iconProps} />
+        <Icon size={computedIconSize} {...iconProps} />
       </div>
     </div>
   );

--- a/src/core/Icon/types.ts
+++ b/src/core/Icon/types.ts
@@ -16,3 +16,9 @@ export type IconName =
   | (typeof iconNames.other)[number]
   | (typeof iconNames.tech)[number]
   | (typeof iconNames.product)[number];
+
+export type IconSize =
+  | `${number}px`
+  | `${number}em`
+  | `${number}rem`
+  | `calc(${string})`;


### PR DESCRIPTION
## Jira Ticket Link / Motivation

Follows on from [this](https://github.com/ably/ably-ui/pull/525), which fixes the most obvious Icon problems in Firefox by making sure proper units are provided with values given to `size` on `Icon`.

This PR adds some safeguards in to assert this in future, by adding a type to `size` on `Icon`, as well as fixing a subsequent, smaller issue with `EncapsulatedIcon` relating to this.

Example: `<Icon size={16} />` will not work, but `<Icon size='16px' />` will.

## Summary of changes

<!-- Commits should already be describing what you are trying to achieve. If needed, use this space to explain how they connect to achieve criteria from the Motivation. Otherwise, uncomment the below: -->
<!-- See commits for details. -->

## How do you manually test this?

<!-- Provide steps necessary to test these changes locally and/or on a review app. Include links, ENV vars, feature flags to be set and any other necessary setup. -->

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `IconSize` type for more flexible icon size definitions.
	- Enhanced the `EncapsulatedIcon` component to improve icon size handling and type safety.

- **Bug Fixes**
	- Updated the `size` property in the `Icon` component for better type alignment.

- **Documentation**
	- Clarified type definitions for icon properties to ensure consistency and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->