### PR TITLE
[WEB-4122] Fix accordion default selected state, form story checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "14.9.0-dev.4cf104c",
+  "version": "14.9.0-dev.b9c2a3b",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Accordion.tsx
+++ b/src/core/Accordion.tsx
@@ -147,7 +147,18 @@ const Accordion = ({
   options,
   ...props
 }: AccordionProps) => {
-  const [openRowValues, setOpenRowValues] = useState<string | string[]>([]);
+  const openIndexes = useMemo(() => {
+    const indexValues = data.map((_, i) => `accordion-item-${i}`);
+    return options?.fullyOpen
+      ? indexValues
+      : indexValues.filter((_, index) =>
+          options?.defaultOpenIndexes?.includes(index),
+        );
+  }, [options?.defaultOpenIndexes, options?.fullyOpen, data.length]);
+
+  const [openRowValues, setOpenRowValues] = useState<string | string[]>(
+    openIndexes,
+  );
   const innerAccordion = data.map((item, index) => (
     <AccordionRow
       key={item.name}
@@ -165,15 +176,6 @@ const Accordion = ({
       {item.content}
     </AccordionRow>
   ));
-
-  const openIndexes = useMemo(() => {
-    const indexValues = data.map((_, i) => `accordion-item-${i}`);
-    return options?.fullyOpen
-      ? indexValues
-      : indexValues.filter((_, index) =>
-          options?.defaultOpenIndexes?.includes(index),
-        );
-  }, [options?.defaultOpenIndexes, options?.fullyOpen, data.length]);
 
   return (
     <div {...props}>

--- a/src/core/Accordion/Accordion.stories.tsx
+++ b/src/core/Accordion/Accordion.stories.tsx
@@ -100,7 +100,7 @@ export const SelectableHeaders = {
   render: () =>
     AccordionPresentation({
       data: dataWithIcons,
-      options: { selectable: true },
+      options: { selectable: true, defaultOpenIndexes: [0] },
     }),
   parameters: {
     docs: {

--- a/src/core/styles/Forms.stories.tsx
+++ b/src/core/styles/Forms.stories.tsx
@@ -223,7 +223,7 @@ export const Toggles = {
       </div>
       <div className="flex gap-16 items-center">
         <label className="ui-toggle">
-          <input type="checkbox" checked />
+          <input type="checkbox" defaultChecked />
           <span className="ui-toggle-slider" />
         </label>
         <p>Pre-checked</p>


### PR DESCRIPTION
## Jira Ticket Link / Motivation

🐛 

## Summary of changes

The Accordion component's internal state only registered selected item changes after the initial load, which is problematic when an accordion has open items on load. This PR sets the initial state to the default open items, if available.

Also fixes a non-selectable checkbox on the Forms story as reported yesterday.

## How do you manually test this?

Look at the "selectable headers" example in Storybook. The first entry in the accordion is set to be open by default, and the header should be selected.

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `Accordion` component to dynamically manage open states based on provided options.
	- Updated the `SelectableHeaders` story to open the first section of the accordion by default.
	- Modified the `Toggles` export to ensure the "Pre-checked" toggle is checked by default.

- **Bug Fixes**
	- Improved state management in the `Accordion` component for better configurability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->