### PR TITLE
[WEB-3926] Fix reactivity of Accordion default props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.1.8",
+  "version": "15.1.9",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.1.9-dev.072d2b86",
+  "version": "15.1.9-dev.2e749917",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.1.9",
+  "version": "15.1.9-dev.072d2b86",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Accordion.tsx
+++ b/src/core/Accordion.tsx
@@ -155,7 +155,11 @@ const Accordion = ({
       : indexValues.filter((_, index) =>
           options?.defaultOpenIndexes?.includes(index),
         );
-  }, [options?.defaultOpenIndexes, options?.fullyOpen, data.length]);
+  }, [
+    JSON.stringify(options?.defaultOpenIndexes),
+    options?.fullyOpen,
+    data.length,
+  ]);
 
   const [openRowValues, setOpenRowValues] = useState<string | string[]>(
     openIndexes,

--- a/src/core/Accordion/Accordion.stories.tsx
+++ b/src/core/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { useState } from "react";
 import Accordion, { AccordionProps } from "../Accordion";
 import { IconName } from "../Icon/types";
 import { accordionThemes } from "./types";
@@ -133,16 +133,39 @@ export const StickyHeaders = {
 };
 
 export const WithDefaultOpenSections = {
-  render: () =>
-    AccordionPresentation({
-      data: data,
-      options: { defaultOpenIndexes: [1] },
-    }),
+  render: () => {
+    const [openIndexes, setOpenIndexes] = useState([1]);
+
+    const randomizeOpenIndexes = () => {
+      const randomIndexes = Array.from(
+        { length: Math.floor(Math.random() * 3) + 1 },
+        () => Math.floor(Math.random() * 5),
+      );
+      setOpenIndexes(randomIndexes);
+    };
+
+    return (
+      <div>
+        {AccordionPresentation({
+          data: data,
+          options: { defaultOpenIndexes: openIndexes },
+        })}{" "}
+        <button onClick={randomizeOpenIndexes} className="ui-button-primary-xs">
+          Randomize default open sections: (currently:{" "}
+          {Array.from(new Set(openIndexes))
+            .map((index) => index + 1)
+            .sort()
+            .join(", ")}
+          )
+        </button>
+      </div>
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          "The sections that correspond to the supplied indexes will be open by default. (e.g. `[1]` will open the second section). Set with `defaultOpenIndexes` on `options`.",
+          "The sections that correspond to the supplied indexes will be open by default. (e.g. `[1]` will open the second section). Set with `defaultOpenIndexes` on `options`. To demonstrate, use the button to randomize the open sections.",
       },
     },
   },

--- a/src/core/Icon.tsx
+++ b/src/core/Icon.tsx
@@ -69,7 +69,7 @@ const Icon = ({
       size,
       color,
       additionalCSS,
-      additionalAttributes,
+      JSON.stringify(additionalAttributes),
       lightSecondaryColor,
       darkSecondaryColor,
     ],


### PR DESCRIPTION
## Jira Ticket Link / Motivation

`Accordion` is the foundational component behind the new left hand nav in docs. In docs, we automatically open the row containing the section of the page you're currently on, and for this we need to leverage the browser's location API. This works fine in dev, but in the built site we need to calculate this at runtime as we don't have `window` at build time.

This means that `Accordion` needs to react to changes in `defaultOpenIndexes` at runtime (as on initial page load the value will be `undefined`, and then stateful after the component has mounted), which it currently does not - it only takes the first value, meaning that all rows are collapsed when we have a default open one in mind. This PR addresses this.

## Summary of changes

This PR converts members of React hook dependency arrays (i.e. in `useMemo`, `useCallback`) to be primitive values in `Accordion` and `Icon`. This is a straight up bug fix as dependency arrays don't diff objects/arrays.

It also makes the state of `Accordion` internally controlled instead of uncontrolled so that we can bind its state to the incoming `options.defaultOpenIndexes` prop. Radix's default mode is for the component to be uncontrolled and have defaults set by `defaultValue` instead of `value`.

## How do you manually test this?

I've [prepared an example in Storybook](https://ably.github.io/ably-ui/?path=/story/components-accordion--with-default-open-sections) where you can toggle default open rows. Functionality can also be verified as still working by accessing the other `Accordion` stories.

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced state management and functionality for the Accordion component, including support for auto-closing rows and randomizing open sections in stories.
  
- **Bug Fixes**
	- Improved handling of secondary colors in the Icon component for better error management.

- **Documentation**
	- Updated documentation for the Accordion stories to reflect new features and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->