### PR TITLE
chore: update playwright to 1.49.1, test-runner to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "http-server": "14.1.1",
     "msw": "2.6.1",
     "msw-storybook-addon": "^2.0.2",
+    "playwright": "^1.49.1",
     "prettier": "^3.2.5",
     "react-syntax-highlighter": "^15.6.1",
     "storybook": "^8.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6590,12 +6590,26 @@ playwright-core@1.44.1, playwright-core@>=1.2.0:
   resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz"
   integrity sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==
 
+playwright-core@1.49.1:
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.49.1.tgz#32c62f046e950f586ff9e35ed490a424f2248015"
+  integrity sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==
+
 playwright@^1.14.0:
   version "1.44.1"
   resolved "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz"
   integrity sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==
   dependencies:
     playwright-core "1.44.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
+playwright@^1.49.1:
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.49.1.tgz#830266dbca3008022afa7b4783565db9944ded7c"
+  integrity sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==
+  dependencies:
+    playwright-core "1.49.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Jira Ticket Link / Motivation

`ably-ui` CI jobs break under Ubuntu 24.04, because the version of Playwright Storybook includes with its latest version of `test-runner` references deps that are no longer available under that version of Ubuntu.

This is a problem now because `ubuntu-latest` on Github Actions has phased over to 24.04 over Christmas.

## Summary of changes

This PR updates `test-runner` (didn't solve the problem but there's no downside to doing it) and adds an explicit dependency on `playwright` to ensure the correct version is installed.

We can remove this explicit Playwright dependency when `test-runner` catches up.

## How do you manually test this?

The lint job below passes - that's the primary indicator that this is working.

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Storybook test runner to the latest version (0.21.0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->