### PR TITLE
[WEB-4164] Tweak pricing card colours

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.1.13",
+  "version": "15.1.14",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Pricing/data.tsx
+++ b/src/core/Pricing/data.tsx
@@ -17,7 +17,7 @@ export const planData: PricingDataFeature[] = [
     cta: {
       text: "Start for free",
       url: "/sign-up",
-      iconColor: "text-neutral-700 dark:text-neutral-600",
+      iconColor: "text-neutral-600 dark:text-neutral-700",
     },
     sections: [
       {

--- a/src/core/Pricing/data.tsx
+++ b/src/core/Pricing/data.tsx
@@ -73,7 +73,7 @@ export const planData: PricingDataFeature[] = [
     cta: {
       text: "Get started",
       url: "/users/paid_sign_up?package=standard",
-      iconColor: "text-blue-600 dark:text-blue-400",
+      iconColor: "text-gui-blue-default-dark dark:text-gui-blue-default-light",
     },
     sections: [
       {
@@ -128,7 +128,7 @@ export const planData: PricingDataFeature[] = [
     cta: {
       text: "Get started",
       url: "/users/paid_sign_up?package=pro",
-      iconColor: "text-blue-600 dark:text-blue-400",
+      iconColor: "text-gui-blue-default-dark dark:text-gui-blue-default-light",
     },
     sections: [
       {


### PR DESCRIPTION
## Jira Ticket Link / Motivation

Following on from #582, some additional tweaks to move us closer to the designs:

![ Pricing Cards - Docs ⋅ Storybook 2025-01-08 21-40-25](https://github.com/user-attachments/assets/4f28ca23-ba28-4ead-a0c0-73fd2c5a229f)

![ Pricing Cards - Docs ⋅ Storybook 2025-01-08 21-41-44](https://github.com/user-attachments/assets/96e8f65d-283c-403d-90ba-887e0d5c6233)

See the comments on WEB-4164 for the discussion that lead to this PR


## Summary of changes

This pull request includes updates to the `package.json` file and changes to the `planData` in `src/core/Pricing/data.tsx` to modify the icon colors for different CTA buttons.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version number from `15.1.13` to `15.1.14`.

Icon color adjustments:

* [`src/core/Pricing/data.tsx`](diffhunk://#diff-9b28404ee4abc62e52b1dd593e01925ec71d90499c672fecd8239ae3fef17b88L20-R20): Changed `iconColor` for the "Start for free" CTA button to `text-neutral-600 dark:text-neutral-700`.
* [`src/core/Pricing/data.tsx`](diffhunk://#diff-9b28404ee4abc62e52b1dd593e01925ec71d90499c672fecd8239ae3fef17b88L76-R76): Updated `iconColor` for the "Get started" CTA button for the standard package to `text-gui-blue-default-dark dark:text-gui-blue-default-light`.
* [`src/core/Pricing/data.tsx`](diffhunk://#diff-9b28404ee4abc62e52b1dd593e01925ec71d90499c672fecd8239ae3fef17b88L131-R131): Updated `iconColor` for the "Get started" CTA button for the pro package to `text-gui-blue-default-dark dark:text-gui-blue-default-light`.

## How do you manually test this?

📖 

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [x] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [x] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
	- Updated package version to 15.1.14-dev.13b70ad

- **Style**
	- Adjusted icon colors for pricing plan cards:
		- Free plan: Swapped light/dark mode color values
		- Standard and Pro plans: Updated to new color scheme

<!-- end of auto-generated comment: release notes by coderabbit.ai -->