### PR TITLE
[WEB-4719] Remove product labels from Meganav

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.1.14",
+  "version": "15.1.15",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/MeganavContentProducts.tsx
+++ b/src/core/MeganavContentProducts.tsx
@@ -52,7 +52,7 @@ const MeganavContentProducts = ({
           </li>
           <li>
             <a href={absUrl("/spaces")} className="group ui-meganav-media">
-              <p className="ui-meganav-media-heading">Spaces (Beta)</p>
+              <p className="ui-meganav-media-heading">Spaces</p>
               <p className="ui-meganav-media-copy">
                 Create multi-user collaborative environments.
               </p>
@@ -60,7 +60,7 @@ const MeganavContentProducts = ({
           </li>
           <li>
             <a href={absUrl("/livesync")} className="group ui-meganav-media">
-              <p className="ui-meganav-media-heading">LiveSync (Alpha)</p>
+              <p className="ui-meganav-media-heading">LiveSync</p>
               <p className="ui-meganav-media-copy">
                 Seamlessly sync database changes with frontend clients at scale.
               </p>
@@ -68,7 +68,7 @@ const MeganavContentProducts = ({
           </li>
           <li>
             <a href={absUrl("/chat")} className="group ui-meganav-media">
-              <p className="ui-meganav-media-heading">Chat (Beta)</p>
+              <p className="ui-meganav-media-heading">Chat</p>
               <p className="ui-meganav-media-copy">
                 Deliver highly reliable chat experiences at scale.
               </p>

--- a/src/core/MeganavContentUseCases.tsx
+++ b/src/core/MeganavContentUseCases.tsx
@@ -101,7 +101,7 @@ const MeganavContentUseCases = ({ absUrl }: { absUrl: AbsUrl }) => (
               <Icon name="icon-display-asset-tracking-col" size="2.5rem" />
               <div className="flex flex-col justify-center">
                 <p className="ui-meganav-media-heading">
-                  Asset Tracking (Beta)
+                  Asset Tracking
                 </p>
                 <p className="ui-meganav-media-copy">
                   Track assets in realtime with a solution optimised for last


### PR DESCRIPTION
## Jira Ticket Link / Motivation

WEB-4719

## Summary of changes

Remove `Alpha` and `Beta` labels from Ably product links in the Meganav.

### Copilot Summary

This pull request includes changes to update the version number and remove beta/alpha labels from product names in the navigation menu.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `15.1.14` to `15.1.15`.

Label removal:

* [`src/core/MeganavContentProducts.tsx`](diffhunk://#diff-83a8708f6939ff0f7f2334cc3889216f0a14996dd233070a0c2c0cf30dcdf666L55-R71): Removed "Beta" and "Alpha" labels from the product names "Spaces", "LiveSync", and "Chat".
* [`src/core/MeganavContentUseCases.tsx`](diffhunk://#diff-dd15ad2d1d897b966e77ddbc4696ec6d5a28a0c92ab27ce4db2d5528ba89d2bfL104-R104): Removed "Beta" label from the product name "Asset Tracking".

## How do you manually test this?

* [Review App](https://voltaire-pr-932.herokuapp.com/)
  * Verify Beta and Alpha labels no longer show in Meganav 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
  - Bumped package version from 15.1.14 to 15.1.15

- **UI Improvements**
  - Removed "(Beta)" and "(Alpha)" labels from product names:
    - Spaces
    - LiveSync
    - Chat
    - Asset Tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->