### PR TITLE
[WEB-4087] Add sliders and reset icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.1.15",
+  "version": "15.1.16",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/icons/icon-gui-reset.svg
+++ b/src/core/icons/icon-gui-reset.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 15L3 9M3 9L9 3M3 9H15C16.5913 9 18.1174 9.63214 19.2426 10.7574C20.3679 11.8826 21 13.4087 21 15C21 16.5913 20.3679 18.1174 19.2426 19.2426C18.1174 20.3679 16.5913 21 15 21H12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/core/icons/icon-gui-sliders.svg
+++ b/src/core/icons/icon-gui-sliders.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 12H4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M10 12H23" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M20 5L23 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M20 19L23 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M1 5L14 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M1 19H14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="17" cy="5" r="3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="17" cy="19" r="3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="7" cy="12" r="3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Adds icons needed for the Examples index work, `icon-gui-sliders` and `icon-gui-reset`.

This pull request includes a version update to the `package.json` file. The version number has been incremented from `15.1.14` to `15.1.16`.

Changes to `package.json`:

* Updated the `version` field from `15.1.15` to `15.1.16`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version to 15.1.16

<!-- end of auto-generated comment: release notes by coderabbit.ai -->