### PR TITLE
[WEB-4185] update Status appearance, consolidate stories

### DIFF
--- a/src/core/Status.tsx
+++ b/src/core/Status.tsx
@@ -10,24 +10,34 @@ type StatusProps = {
   showDescription?: boolean;
 };
 
+export const statusTypes = [
+  "none",
+  "operational",
+  "minor",
+  "major",
+  "critical",
+  "unknown",
+] as const;
+
+export type StatusType = (typeof statusTypes)[number];
+
 export const StatusUrl =
   "https://ntqy1wz94gjv.statuspage.io/api/v2/status.json";
 
 // Our SWR fetcher function
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-const indicatorClass = (indicator?: string) => {
+const indicatorClass = (indicator?: StatusType) => {
   switch (indicator) {
     case "none":
-      return "bg-green-500";
     case "operational":
-      return "bg-green-500";
+      return "bg-gui-success-green";
     case "minor":
       return "bg-yellow-500";
     case "major":
       return "bg-orange-500";
     case "critical":
-      return "bg-orange-800";
+      return "bg-gui-error-red";
     default:
       return "bg-neutral-500";
   }
@@ -44,7 +54,7 @@ export const StatusIcon = ({
   return (
     <span
       className={cn(
-        "inline-flex h-[1rem] aspect-square m-[0.25rem] rounded-full",
+        "inline-flex h-8 aspect-square rounded-full",
         indicatorClass(data?.status?.indicator),
         { "animate-pulse": isLoading || error },
       )}
@@ -78,7 +88,10 @@ const Status = ({
       />
       {showDescription && data?.status?.description && (
         <div className="flex gap-8 ui-text-menu4 font-medium text-neutral-900 group-hover/status:text-neutral-1300 dark:text-neutral-400 dark:group-hover/status:text-neutral-000 transition-colors">
-          <span>{data.status.description}</span>
+          <span>
+            {data.status.description.charAt(0).toUpperCase() +
+              data.status.description.slice(1).toLowerCase()}
+          </span>
           <Icon name="icon-gui-external-link" size="16px" />
         </div>
       )}


### PR DESCRIPTION
This PR makes the following alterations which are useful for `WEB-4082`:
- makes the status indicator light smaller as per design request (8x8 instead of 16x16)
- stylises the status description so that capitalised words after the first word are downcased (i.e. My Big Status becomes My big status)
- adjusts the colours of the indicator to better match the colours we have
- ties up the acceptable status types into a type

Additionally, it consolidates the `Status` stories into two so that we can see all the indicators at once in two stories, one with and one without the description label.