### PR TITLE
[WEB-3914] Add viewport-specific visibility options for Header search button

### DIFF
--- a/src/core/Header.tsx
+++ b/src/core/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, ReactNode } from "react";
+import React, { useState, useEffect, useRef, ReactNode, useMemo } from "react";
 import Icon from "./Icon";
 import cn from "./utils/cn";
 import Logo from "./Logo";
@@ -15,28 +15,97 @@ export type ThemedScrollpoint = {
   className: string;
 };
 
+/**
+ * Props for the Header component.
+ */
 export type HeaderProps = {
+  /**
+   * Optional search bar element.
+   */
   searchBar?: ReactNode;
+
+  /**
+   * Optional search button element.
+   */
   searchButton?: ReactNode;
+
+  /**
+   * URL for the logo link.
+   */
   logoHref?: string;
+
+  /**
+   * Array of header links.
+   */
   headerLinks?: {
+    /**
+     * URL for the link.
+     */
     href: string;
+
+    /**
+     * Label for the link.
+     */
     label: string;
+
+    /**
+     * Indicates if the link should open in a new tab.
+     */
     external?: boolean;
   }[];
+
+  /**
+   * Optional desktop navigation element.
+   */
   nav?: ReactNode;
+
+  /**
+   * Optional mobile navigation element.
+   */
   mobileNav?: ReactNode;
+
+  /**
+   * State of the user session.
+   */
   sessionState?: {
+    /**
+     * Indicates if the user is signed in.
+     */
     signedIn: boolean;
+
+    /**
+     * Account information.
+     */
     account: {
+      /**
+       * Links related to the account.
+       */
       links: {
+        /**
+         * Dashboard link information.
+         */
         dashboard: {
+          /**
+           * URL for the dashboard link.
+           */
           href: string;
         };
       };
     };
   };
+
+  /**
+   * Array of themed scrollpoints. The header will change its appearance based on the scrollpoint in view.
+   */
   themedScrollpoints?: ThemedScrollpoint[];
+
+  /**
+   * Visibility setting for the search button.
+   * - "all": Visible on all devices.
+   * - "desktop": Visible only on desktop devices.
+   * - "mobile": Visible only on mobile devices.
+   */
+  searchButtonVisibility?: "all" | "desktop" | "mobile";
 };
 
 const Header: React.FC<HeaderProps> = ({
@@ -48,6 +117,7 @@ const Header: React.FC<HeaderProps> = ({
   mobileNav,
   sessionState,
   themedScrollpoints = [],
+  searchButtonVisibility = "all",
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const [scrollpointClasses, setScrollpointClasses] = useState<string>("");
@@ -99,6 +169,16 @@ const Header: React.FC<HeaderProps> = ({
     return () => window.removeEventListener("scroll", throttledHandleScroll);
   }, [themedScrollpoints]);
 
+  const wrappedSearchButton = useMemo(
+    () =>
+      searchButton ? (
+        <div className="text-neutral-1300 dark:text-neutral-000 flex items-center p-6">
+          {searchButton}
+        </div>
+      ) : null,
+    [searchButton],
+  );
+
   return (
     <>
       <header
@@ -125,7 +205,7 @@ const Header: React.FC<HeaderProps> = ({
             }}
           />
           <div className="flex md:hidden flex-1 items-center justify-end gap-24 h-full">
-            {searchButton}
+            {searchButtonVisibility !== "desktop" ? wrappedSearchButton : null}
             <button
               className="cursor-pointer focus-base rounded flex items-center"
               onClick={() => setShowMenu(!showMenu)}
@@ -150,6 +230,8 @@ const Header: React.FC<HeaderProps> = ({
             <HeaderLinks
               headerLinks={headerLinks}
               sessionState={sessionState}
+              searchButton={wrappedSearchButton}
+              searchButtonVisibility={searchButtonVisibility}
             />
           </div>
         </div>

--- a/src/core/Header/Header.stories.tsx
+++ b/src/core/Header/Header.stories.tsx
@@ -9,7 +9,6 @@ import Icon from "../Icon";
 export default {
   title: "Components/Header",
   component: Header,
-  tags: ["!autodocs"],
 } as Meta;
 
 const Template: StoryFn<HeaderProps> = (args) => <Header {...args} />;
@@ -57,6 +56,7 @@ WithTabMenuNav.args = {
 
 export const WithButtonNav = Template.bind({});
 WithButtonNav.args = {
+  ...baseArgs,
   nav: (
     <div className="flex gap-8">
       {["Products", "Solutions", "Company", "Pricing", "Docs"].map((link) => (

--- a/src/core/Header/HeaderLinks.tsx
+++ b/src/core/Header/HeaderLinks.tsx
@@ -16,20 +16,28 @@ const testSessionState = {
 };
 
 export const HeaderLinks: React.FC<
-  Pick<HeaderProps, "sessionState" | "headerLinks">
-> = ({ sessionState = testSessionState, headerLinks }) => {
+  Pick<
+    HeaderProps,
+    "sessionState" | "headerLinks" | "searchButtonVisibility" | "searchButton"
+  >
+> = ({
+  sessionState = testSessionState,
+  headerLinks,
+  searchButtonVisibility,
+  searchButton,
+}) => {
   const signedIn = sessionState.signedIn;
   const headerLinkClasses =
     "ui-text-menu2 md:ui-text-menu3 !font-bold py-16 text-neutral-1300 dark:text-neutral-000 md:text-neutral-1000 dark:md:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 active:text-neutral-1300 dark:active:text-neutral-000 transition-colors";
 
   return (
-    <div className="flex md:items-center flex-col md:flex-row border-t-[1px] border-neutral-300 md:border-t-0 p-12">
+    <div className="flex md:items-center flex-col md:flex-row border-t-[1px] border-neutral-300 md:border-t-0 p-12 gap-12">
       {headerLinks?.map(({ href, label, external }) => (
         <a
           key={href}
           className={cn(
             headerLinkClasses,
-            "flex items-center gap-4 md:mr-16 mt-8 md:mt-0",
+            "flex items-center gap-4 mt-8 md:mt-0",
           )}
           href={href}
           target={external ? "_blank" : undefined}
@@ -41,6 +49,7 @@ export const HeaderLinks: React.FC<
           )}
         </a>
       ))}
+      {searchButtonVisibility !== "mobile" ? searchButton : null}
       {signedIn && sessionState.account ? (
         <LinkButton
           href={sessionState.account.links?.dashboard.href}
@@ -51,11 +60,11 @@ export const HeaderLinks: React.FC<
           Dashboard
         </LinkButton>
       ) : (
-        <div className="flex">
+        <div className="flex gap-12">
           <LinkButton
             href="/login"
             variant="secondary"
-            className="mr-12 flex-1 md:flex-none md:ui-button-secondary-xs"
+            className="flex-1 md:flex-none md:ui-button-secondary-xs"
           >
             Login
           </LinkButton>


### PR DESCRIPTION
Adds the means to customise where the search button is placed on `Header`, after a conversation with @aralovelace about different use cases between voltaire and docs.

Also added type docs for the header props.

Will launch in the same version as https://github.com/ably/ably-ui/pull/618

Rabbit summary inbound:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced header component with more flexible search button configuration
  - Added ability to control search button visibility across different device types
  - Improved session state structure with additional account link details

- **Refactor**
  - Updated header and header links components to support new search button properties
  - Optimized search button rendering using memoization

- **Style**
  - Adjusted button layout spacing in header links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->