### PR TITLE
[WEB-4082] Allow forwardRef on Accordion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.3.5",
+  "version": "15.3.6",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Accordion.tsx
+++ b/src/core/Accordion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo, useState } from "react";
+import React, { ReactNode, useMemo, useState, forwardRef } from "react";
 import {
   AccordionContent,
   AccordionItem,
@@ -138,68 +138,75 @@ const AccordionRow = ({
   );
 };
 
-const Accordion = ({
-  data,
-  theme = "transparent",
-  icons = {
-    closed: { name: "icon-gui-plus-outline" },
-    open: { name: "icon-gui-minus-outline" },
+const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
+  (
+    {
+      data,
+      theme = "transparent",
+      icons = {
+        closed: { name: "icon-gui-plus-outline" },
+        open: { name: "icon-gui-minus-outline" },
+      },
+      options,
+      ...props
+    },
+    ref,
+  ) => {
+    const openIndexes = useMemo(() => {
+      const indexValues = data.map((_, i) => `accordion-item-${i}`);
+      return options?.fullyOpen
+        ? indexValues
+        : indexValues.filter((_, index) =>
+            options?.defaultOpenIndexes?.includes(index),
+          );
+    }, [options?.defaultOpenIndexes, options?.fullyOpen, data.length]);
+
+    const [openRowValues, setOpenRowValues] = useState<string | string[]>(
+      openIndexes,
+    );
+    const innerAccordion = data.map((item, index) => (
+      <AccordionRow
+        key={item.name}
+        name={item.name}
+        rowIcon={item.icon}
+        toggleIcons={icons}
+        theme={theme}
+        options={options}
+        index={index}
+        onClick={() => {
+          item.onClick?.(index);
+        }}
+        openRowValues={openRowValues}
+      >
+        {item.content}
+      </AccordionRow>
+    ));
+
+    return (
+      <div ref={ref} {...props}>
+        {options?.autoClose ? (
+          <RadixAccordion
+            type="single"
+            collapsible
+            defaultValue={openIndexes[0]}
+            onValueChange={(values) => setOpenRowValues(values)}
+          >
+            {innerAccordion}
+          </RadixAccordion>
+        ) : (
+          <RadixAccordion
+            type="multiple"
+            defaultValue={openIndexes}
+            onValueChange={(values) => setOpenRowValues(values)}
+          >
+            {innerAccordion}
+          </RadixAccordion>
+        )}
+      </div>
+    );
   },
-  options,
-  ...props
-}: AccordionProps) => {
-  const openIndexes = useMemo(() => {
-    const indexValues = data.map((_, i) => `accordion-item-${i}`);
-    return options?.fullyOpen
-      ? indexValues
-      : indexValues.filter((_, index) =>
-          options?.defaultOpenIndexes?.includes(index),
-        );
-  }, [options?.defaultOpenIndexes, options?.fullyOpen, data.length]);
+);
 
-  const [openRowValues, setOpenRowValues] = useState<string | string[]>(
-    openIndexes,
-  );
-  const innerAccordion = data.map((item, index) => (
-    <AccordionRow
-      key={item.name}
-      name={item.name}
-      rowIcon={item.icon}
-      toggleIcons={icons}
-      theme={theme}
-      options={options}
-      index={index}
-      onClick={() => {
-        item.onClick?.(index);
-      }}
-      openRowValues={openRowValues}
-    >
-      {item.content}
-    </AccordionRow>
-  ));
-
-  return (
-    <div {...props}>
-      {options?.autoClose ? (
-        <RadixAccordion
-          type="single"
-          collapsible
-          defaultValue={openIndexes[0]}
-          onValueChange={(values) => setOpenRowValues(values)}
-        >
-          {innerAccordion}
-        </RadixAccordion>
-      ) : (
-        <RadixAccordion
-          type="multiple"
-          defaultValue={openIndexes}
-          onValueChange={(values) => setOpenRowValues(values)}
-        >
-          {innerAccordion}
-        </RadixAccordion>
-      )}
-    </div>
-  );
-};
+Accordion.displayName = "Accordion";
 
 export default Accordion;


### PR DESCRIPTION
Small one.

We have a bug on the new docs nav where the left sidebar content wraps undesirably when the browser shows scrollbar regions by default (i.e. on Windows, macOS in certain a11y modes). 

We have some styling on the left sidebar which compensates for a dynamic scrollbar region (i.e. what you get when using a trackpad), but we need to switch this out when scrollbars are permanently visible. In order to determine the visibility of scrollbars, we need to pass a ref to the outer element of the Accordion component and do some JS calcs (can't be done in CSS), and the way to do that in the case of a package-supplied component such as this is to use `forwardRef` to pass a ref prop to the outer div.

This PR wraps `Accordion` in a call to `forwardRef` to set this up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the product version to 15.3.6-dev.

- **New Features**
	- Enhanced the Accordion component to support improved external integration, offering greater flexibility for advanced interactions while maintaining its familiar functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->