### PR TITLE
Change the Table Supported Icon to solid

### DIFF
--- a/src/core/Table/__snapshots__/Table.stories.tsx.snap
+++ b/src/core/Table/__snapshots__/Table.stories.tsx.snap
@@ -102,9 +102,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -182,9 +182,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -262,9 +262,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -342,9 +342,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -422,9 +422,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -513,9 +513,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -593,9 +593,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -673,9 +673,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -753,9 +753,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -833,9 +833,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -924,9 +924,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -1004,9 +1004,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -1084,9 +1084,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -1164,9 +1164,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>
@@ -1244,9 +1244,9 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
             <span class="sm:order-0">
               <svg class="text-gui-success flex-grow-0 flex-shrink-0"
                    data-testid="supported-icon"
-                   style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-white);"
+                   style="width: 1.5rem; height: 1.5rem;"
               >
-                <use xlink:href="#sprite-icon-gui-check-circled-fill">
+                <use xlink:href="#sprite-icon-gui-check-circle-solid">
                 </use>
               </svg>
             </span>

--- a/src/core/Table/data.tsx
+++ b/src/core/Table/data.tsx
@@ -6,7 +6,7 @@ import Icon from "../Icon";
 
 const Supported = () => (
   <Icon
-    name="icon-gui-check-circled-fill"
+    name="icon-gui-check-circle-solid"
     size="1.5rem"
     color="text-gui-success"
     additionalCSS="flex-grow-0 flex-shrink-0"


### PR DESCRIPTION
## Jira Ticket Link / Motivation

This PR is related to this - https://github.com/ably/voltaire/pull/953 the icons should have same size, thus suggested to replace the icon to `icon-gui-check-circle-solid `

## Summary of changes

This pull request includes updates to the `Table` component to standardize the icon usage across various files. The changes involve replacing the `icon-gui-check-circled-fill` icon with `icon-gui-check-circle-solid` in both the snapshots and the component implementation.

Icon updates:


* [`src/core/Table/data.tsx`](diffhunk://#diff-b5218d6139730c95abb325b9e8f50fe79acd349b53ecfb5f73a27f3599c26874L9-R9): Changed the icon name from `icon-gui-check-circled-fill` to `icon-gui-check-circle-solid` in the `Supported` component.


<!-- See commits for details. -->

## How do you manually test this?

Make sure the icons are same size for supported and unsupported - https://ably.github.io/ably-ui/?path=/docs/components-table--docs

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The Supported status indicator in the table now features a refreshed icon, delivering enhanced visual clarity without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->