### PR TITLE
[WEB-4082] Divide header into three equal parts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.4.0",
+  "version": "15.4.1",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Header.tsx
+++ b/src/core/Header.tsx
@@ -108,6 +108,8 @@ export type HeaderProps = {
   searchButtonVisibility?: "all" | "desktop" | "mobile";
 };
 
+const FLEXIBLE_DESKTOP_CLASSES = "hidden md:flex flex-1 items-center h-full";
+
 const Header: React.FC<HeaderProps> = ({
   searchBar,
   searchButton,
@@ -200,20 +202,23 @@ const Header: React.FC<HeaderProps> = ({
         style={{ height: HEADER_HEIGHT }}
       >
         <div className="flex items-center h-full">
-          <Logo
-            href={logoHref}
-            theme="light"
-            additionalLinkAttrs={{
-              className: "flex dark:hidden h-full focus-base rounded mr-32",
-            }}
-          />
-          <Logo
-            href={logoHref}
-            theme="dark"
-            additionalLinkAttrs={{
-              className: "hidden dark:flex h-full focus-base rounded mr-32",
-            }}
-          />
+          <nav className="flex flex-1 h-full items-center">
+            <Logo
+              href={logoHref}
+              theme="light"
+              additionalLinkAttrs={{
+                className: "flex dark:hidden h-full focus-base rounded mr-32",
+              }}
+            />
+            <Logo
+              href={logoHref}
+              theme="dark"
+              additionalLinkAttrs={{
+                className: "hidden dark:flex h-full focus-base rounded mr-32",
+              }}
+            />
+            <div className={FLEXIBLE_DESKTOP_CLASSES}>{nav}</div>
+          </nav>
           <div className="flex md:hidden flex-1 items-center justify-end gap-24 h-full">
             {searchButtonVisibility !== "desktop" ? wrappedSearchButton : null}
             <button
@@ -234,16 +239,18 @@ const Header: React.FC<HeaderProps> = ({
               />
             </button>
           </div>
-          <div className="hidden md:flex flex-1 items-center h-full">
-            {nav}
-            <div className="flex-1 flex justify-center px-16">{searchBar}</div>
-            <HeaderLinks
-              headerLinks={headerLinks}
-              sessionState={sessionState}
-              searchButton={wrappedSearchButton}
-              searchButtonVisibility={searchButtonVisibility}
-            />
-          </div>
+          {searchBar ? (
+            <div className={cn(FLEXIBLE_DESKTOP_CLASSES, "justify-center")}>
+              {searchBar}
+            </div>
+          ) : null}
+          <HeaderLinks
+            className={FLEXIBLE_DESKTOP_CLASSES}
+            headerLinks={headerLinks}
+            sessionState={sessionState}
+            searchButton={wrappedSearchButton}
+            searchButtonVisibility={searchButtonVisibility}
+          />
         </div>
       </header>
       {showMenu ? (

--- a/src/core/Header.tsx
+++ b/src/core/Header.tsx
@@ -9,6 +9,7 @@ import {
 } from "./utils/heights";
 import { HeaderLinks } from "./Header/HeaderLinks";
 import throttle from "lodash.throttle";
+import { Theme } from "./styles/colors/types";
 
 export type ThemedScrollpoint = {
   id: string;
@@ -203,20 +204,19 @@ const Header: React.FC<HeaderProps> = ({
       >
         <div className="flex items-center h-full">
           <nav className="flex flex-1 h-full items-center">
-            <Logo
-              href={logoHref}
-              theme="light"
-              additionalLinkAttrs={{
-                className: "flex dark:hidden h-full focus-base rounded mr-32",
-              }}
-            />
-            <Logo
-              href={logoHref}
-              theme="dark"
-              additionalLinkAttrs={{
-                className: "hidden dark:flex h-full focus-base rounded mr-32",
-              }}
-            />
+            {(["light", "dark"] as Theme[]).map((theme) => (
+              <Logo
+                key={theme}
+                href={logoHref}
+                theme={theme}
+                additionalLinkAttrs={{
+                  className: cn("h-full focus-base rounded mr-32 w-[108px]", {
+                    "flex dark:hidden": theme === "light",
+                    "hidden dark:flex": theme === "dark",
+                  }),
+                }}
+              />
+            ))}
             <div className={FLEXIBLE_DESKTOP_CLASSES}>{nav}</div>
           </nav>
           <div className="flex md:hidden flex-1 items-center justify-end gap-24 h-full">

--- a/src/core/Header/Header.stories.tsx
+++ b/src/core/Header/Header.stories.tsx
@@ -137,3 +137,11 @@ export const WithThemedScrollpoints = {
     </div>
   ),
 };
+
+export const WithSearchBar = Template.bind({});
+WithSearchBar.args = {
+  ...baseArgs,
+  searchBar: (
+    <input type="text" placeholder="Search" className="ui-input w-256" />
+  ),
+};

--- a/src/core/Header/HeaderLinks.tsx
+++ b/src/core/Header/HeaderLinks.tsx
@@ -19,19 +19,27 @@ export const HeaderLinks: React.FC<
   Pick<
     HeaderProps,
     "sessionState" | "headerLinks" | "searchButtonVisibility" | "searchButton"
-  >
+  > & {
+    className?: string;
+  }
 > = ({
   sessionState = testSessionState,
   headerLinks,
   searchButtonVisibility,
   searchButton,
+  className,
 }) => {
   const signedIn = sessionState.signedIn;
   const headerLinkClasses =
     "ui-text-menu2 md:ui-text-menu3 !font-bold py-16 text-neutral-1300 dark:text-neutral-000 md:text-neutral-1000 dark:md:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 active:text-neutral-1300 dark:active:text-neutral-000 transition-colors";
 
   return (
-    <div className="flex md:items-center flex-col md:flex-row border-t-[1px] border-neutral-300 md:border-t-0 p-12 gap-12">
+    <nav
+      className={cn(
+        "flex md:flex-1 md:items-center md:justify-end flex-col md:flex-row border-t-[1px] border-neutral-300 md:border-t-0 p-12 md:p-0 gap-12",
+        className,
+      )}
+    >
       {headerLinks?.map(({ href, label, external }) => (
         <a
           key={href}
@@ -77,6 +85,6 @@ export const HeaderLinks: React.FC<
           </LinkButton>
         </div>
       )}
-    </div>
+    </nav>
   );
 };


### PR DESCRIPTION
The `Header` component, which drives the docs top nav and the upcoming Meganav work, has three sections:
- on the left: the navigable page elements
- in the middle: an optional search bar
- on the right: external links and login buttons

Currently, these sections can be uneven in proportion (as is the case with the docs currently with the left nav hidden until the release of Examples), and since the central search bar partition flexibly fills the available space and centres, this can mean that the search bar is off-centre relative to the page.

<img width="1248" alt="Screenshot 2025-02-18 at 16 53 22" src="https://github.com/user-attachments/assets/de5cc248-2821-4718-b399-830aa71b6935" />


This PR divides the header up into three equal sections (when possible), so that the search bar can be centred without being impacted by the unpredictably sized content either side of it. I came to this after concluding that adding a temporary wedge of a certain width on the left until the examples are ready would be insufficient.

Review link: https://ably.github.io/ably-ui/?path=/story/components-header--with-search-bar

