### PR TITLE
chore: add environment to github pages workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
   deploy-storybook:
     name: Deploy Storybook to GH Pages
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -14,6 +14,8 @@ jobs:
     if: ${{ github.event.label.name == 'review' }}
     name: Deploy Storybook to GH Pages
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}


### PR DESCRIPTION
Review env workflow has gone belly up, citing the need for an `environment` variable in the GH workflow. I've added that here, and also altered the environment permissions to allow deployment from any branch to this env, but to require an approval from a member of the web team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the deployment configuration to better define and track preview environments, ensuring that preview URLs are now easily accessible for review and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->