### PR TITLE
[WEB-4086] chore: add SegmentedControl component and stories, bump package to 15.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "15.7.0",
+  "version": "15.8.0",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",
@@ -77,7 +77,7 @@
     "start": "vite --port 5000",
     "storybook": "yarn build && storybook dev -p 6006",
     "build-storybook": "yarn build && storybook build --quiet -o preview",
-    "test": "yarn test:storybook && yarn test:vitest",
+    "test": "yarn test:storybook && yarn test:vitest run",
     "test:storybook": "npx concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"yarn build-storybook && yarn http-server preview --port 6007 --silent\" \"wait-on tcp:6007 && yarn test-storybook --url http://127.0.0.1:6007\"",
     "test:update-snapshots": "npx concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"yarn build-storybook && yarn http-server preview --port 6007 --silent\" \"wait-on tcp:6007 && yarn test-storybook -u --url http://127.0.0.1:6007\"",
     "test:vitest": "vitest --environment=jsdom --dir=src"

--- a/src/core/SegmentedControl.tsx
+++ b/src/core/SegmentedControl.tsx
@@ -1,0 +1,133 @@
+import React, { PropsWithChildren } from "react";
+import cn from "./utils/cn";
+import Icon from "./Icon";
+import type { IconName, IconSize } from "./Icon/types";
+
+export type SegmentedControlSize = "md" | "sm" | "xs";
+
+export type SegmentedControlProps = {
+  className?: string;
+  rounded?: boolean;
+  leftIcon?: IconName;
+  rightIcon?: IconName;
+  active?: boolean;
+  variant?: "default" | "subtle" | "strong";
+  size?: SegmentedControlSize;
+  onClick?: () => void;
+  disabled?: boolean;
+};
+
+const SegmentedControl: React.FC<PropsWithChildren<SegmentedControlProps>> = ({
+  className,
+  rounded = false,
+  leftIcon,
+  rightIcon,
+  active = false,
+  variant = "default",
+  size = "md",
+  children,
+  onClick,
+  disabled,
+}) => {
+  const colorStyles = {
+    default: {
+      active: "bg-neutral-200 dark:bg-neutral-1100",
+      inactive:
+        "bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200",
+    },
+    subtle: {
+      active: "bg-neutral-000 dark:bg-neutral-1000",
+      inactive:
+        "bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100",
+    },
+    strong: {
+      active: "bg-neutral-1000 dark:bg-neutral-300",
+      inactive:
+        "bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100",
+    },
+  };
+
+  const contentColorStyles = {
+    default: {
+      active: "text-neutral-1300 dark:text-neutral-000",
+      inactive:
+        "text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000",
+    },
+    subtle: {
+      active: "text-neutral-1300 dark:text-neutral-000",
+      inactive:
+        "text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000",
+    },
+    strong: {
+      active: "text-neutral-000 dark:text-neutral-1300",
+      inactive:
+        "text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000",
+    },
+  };
+
+  const sizeStyles = {
+    md: cn("h-48 p-12 gap-[10px]", rounded && "px-[18px]"),
+    sm: cn("h-40 p-[9px] gap-[9px]", rounded && "px-[14px]"),
+    xs: cn("h-36 p-8 gap-8", rounded && "px-12"),
+  };
+
+  const textStyles = {
+    md: "ui-text-menu2",
+    sm: "ui-text-menu3",
+    xs: "ui-text-menu4",
+  };
+
+  const iconSizes: Record<SegmentedControlSize, IconSize> = {
+    md: "23px",
+    sm: "22px",
+    xs: "20px",
+  };
+
+  const activeKey = active ? "active" : "inactive";
+
+  return (
+    <div
+      onClick={!disabled ? onClick : undefined}
+      onKeyDown={(e) => {
+        if ((e.key === "Enter" || e.key === " ") && !disabled && onClick) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className={cn(
+        "focus-base flex items-center justify-center cursor-pointer select-none transition-colors",
+        colorStyles[variant][activeKey],
+        contentColorStyles[variant][activeKey],
+        sizeStyles[size],
+        textStyles[size],
+        disabled &&
+          "cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit",
+        rounded ? "rounded-full" : "rounded-lg",
+        className,
+      )}
+      tabIndex={disabled ? -1 : 0}
+      role="button"
+      aria-pressed={active}
+      aria-disabled={disabled}
+    >
+      {leftIcon && (
+        <Icon name={leftIcon} size={iconSizes[size]} aria-hidden="true" />
+      )}
+      <span
+        className={cn(
+          "font-semibold transition-colors",
+          contentColorStyles[variant][activeKey],
+          disabled &&
+            "text-gui-unavailable dark:text-gui-unavailable-dark hover:text-gui-unavailable dark:hover:text-gui-unavailable-dark",
+        )}
+      >
+        {children}
+      </span>
+      {rightIcon && (
+        <Icon name={rightIcon} size={iconSizes[size]} aria-hidden="true" />
+      )}
+    </div>
+  );
+};
+
+export default SegmentedControl;

--- a/src/core/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/core/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import SegmentedControl, {
+  SegmentedControlProps,
+  SegmentedControlSize,
+} from "../SegmentedControl";
+import Badge from "../Badge";
+/**
+ * The SegmentedControl component provides a container for content with optional
+ * rounded corners and icons on either side. It's useful for creating toggle-like
+ * controls, tabs, or any segmented interface element that needs visual distinction.
+ * The component supports customization through props for rounded corners and
+ * icons on the left and/or right sides.
+ */
+const meta: Meta<SegmentedControlProps> = {
+  title: "Components/Segmented Control",
+  component: SegmentedControl,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<SegmentedControlProps>;
+
+const SegmentedControlGrid = (props: SegmentedControlProps) => {
+  const [activeIndex, setActiveIndex] = React.useState(0);
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-8">
+      {["md", "sm", "xs"].map((size) => (
+        <div key={size} className="flex flex-col gap-4">
+          <div className="flex flex-col items-center">
+            <Badge className="mb-8">{size}</Badge>
+          </div>
+          <div
+            key={size}
+            className="flex gap-8 justify-center items-center p-8 border rounded-lg"
+          >
+            {[0, 1].map((index) => (
+              <SegmentedControl
+                key={index}
+                size={size as SegmentedControlSize}
+                active={activeIndex === index}
+                onClick={() => setActiveIndex(index)}
+                {...props}
+              >
+                Option {index + 1}
+              </SegmentedControl>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+/**
+ * The default variant of the SegmentedControl component displays a grid of controls
+ * in three different sizes (md, sm, xs) with the default styling.
+ */
+export const DefaultVariant: Story = {
+  render: () => <SegmentedControlGrid />,
+};
+
+/**
+ * The subtle variant of the SegmentedControl component provides a more appropriate styling
+ * for n100/n1200 backgrounds.
+ */
+export const SubtleVariant: Story = {
+  render: () => (
+    <div className="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-16">
+      <SegmentedControlGrid variant="subtle" />
+    </div>
+  ),
+};
+
+/**
+ * The strong variant of the SegmentedControl component provides more visual contrast
+ * and is displayed against a neutral background to highlight the difference in styling.
+ */
+export const StrongVariant: Story = {
+  render: () => (
+    <div className="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-16">
+      <SegmentedControlGrid variant="strong" />
+    </div>
+  ),
+};
+
+/**
+ * This example shows the SegmentedControl with an icon positioned on the left side
+ * of the text content, demonstrating how icons can enhance visual communication.
+ */
+export const WithLeftIcon: Story = {
+  render: () => <SegmentedControlGrid leftIcon="icon-tech-javascript" />,
+};
+
+/**
+ * This example shows the SegmentedControl with an icon positioned on the right side
+ * of the text content, useful for indicating actions or additional information.
+ */
+export const WithRightIcon: Story = {
+  render: () => <SegmentedControlGrid rightIcon="icon-tech-javascript" />,
+};
+
+/**
+ * The disabled state of the SegmentedControl shows how the component appears when
+ * it's not interactive, with muted colors and a not-allowed cursor.
+ */
+export const Disabled: Story = {
+  render: () => <SegmentedControlGrid disabled />,
+};
+
+/**
+ * This variant shows the SegmentedControl with fully rounded corners (pill shape),
+ * which can be useful for certain design aesthetics or to visually distinguish
+ * different types of controls.
+ */
+export const Rounded: Story = {
+  render: () => <SegmentedControlGrid rounded />,
+};

--- a/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
+++ b/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
@@ -1,0 +1,739 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
+<div class="flex flex-col sm:flex-row gap-8">
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          md
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          sm
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          xs
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components/Segmented Control Disabled smoke-test 1`] = `
+<div class="flex flex-col sm:flex-row gap-8">
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          md
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+           tabindex="-1"
+           role="button"
+           aria-pressed="true"
+           aria-disabled="true"
+      >
+        <span class="font-semibold transition-colors text-gui-unavailable dark:text-gui-unavailable-dark hover:text-gui-unavailable dark:hover:text-gui-unavailable-dark">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+           tabindex="-1"
+           role="button"
+           aria-pressed="false"
+           aria-disabled="true"
+      >
+        <span class="font-semibold transition-colors text-gui-unavailable dark:text-gui-unavailable-dark hover:text-gui-unavailable dark:hover:text-gui-unavailable-dark">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          sm
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+           tabindex="-1"
+           role="button"
+           aria-pressed="true"
+           aria-disabled="true"
+      >
+        <span class="font-semibold transition-colors text-gui-unavailable dark:text-gui-unavailable-dark hover:text-gui-unavailable dark:hover:text-gui-unavailable-dark">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+           tabindex="-1"
+           role="button"
+           aria-pressed="false"
+           aria-disabled="true"
+      >
+        <span class="font-semibold transition-colors text-gui-unavailable dark:text-gui-unavailable-dark hover:text-gui-unavailable dark:hover:text-gui-unavailable-dark">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          xs
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+           tabindex="-1"
+           role="button"
+           aria-pressed="true"
+           aria-disabled="true"
+      >
+        <span class="font-semibold transition-colors text-gui-unavailable dark:text-gui-unavailable-dark hover:text-gui-unavailable dark:hover:text-gui-unavailable-dark">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+           tabindex="-1"
+           role="button"
+           aria-pressed="false"
+           aria-disabled="true"
+      >
+        <span class="font-semibold transition-colors text-gui-unavailable dark:text-gui-unavailable-dark hover:text-gui-unavailable dark:hover:text-gui-unavailable-dark">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components/Segmented Control Rounded smoke-test 1`] = `
+<div class="flex flex-col sm:flex-row gap-8">
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          md
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-48 p-12 gap-[10px] px-[18px] ui-text-menu2 rounded-full"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-48 p-12 gap-[10px] px-[18px] ui-text-menu2 rounded-full"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          sm
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-40 p-[9px] gap-[9px] px-[14px] ui-text-menu3 rounded-full"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-40 p-[9px] gap-[9px] px-[14px] ui-text-menu3 rounded-full"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          xs
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-36 p-8 gap-8 px-12 ui-text-menu4 rounded-full"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-36 p-8 gap-8 px-12 ui-text-menu4 rounded-full"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
+<div class="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-16">
+  <div class="flex flex-col sm:flex-row gap-8">
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col items-center">
+        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+          <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+            md
+          </span>
+        </div>
+      </div>
+      <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-1000 dark:bg-neutral-300 text-neutral-000 dark:text-neutral-1300 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-000 dark:text-neutral-1300">
+            Option 1
+          </span>
+        </div>
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="false"
+        >
+          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+            Option 2
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col items-center">
+        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+          <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+            sm
+          </span>
+        </div>
+      </div>
+      <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-1000 dark:bg-neutral-300 text-neutral-000 dark:text-neutral-1300 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-000 dark:text-neutral-1300">
+            Option 1
+          </span>
+        </div>
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="false"
+        >
+          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+            Option 2
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col items-center">
+        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+          <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+            xs
+          </span>
+        </div>
+      </div>
+      <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-1000 dark:bg-neutral-300 text-neutral-000 dark:text-neutral-1300 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-000 dark:text-neutral-1300">
+            Option 1
+          </span>
+        </div>
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="false"
+        >
+          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+            Option 2
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
+<div class="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-16">
+  <div class="flex flex-col sm:flex-row gap-8">
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col items-center">
+        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+          <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+            md
+          </span>
+        </div>
+      </div>
+      <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1000 text-neutral-1300 dark:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+            Option 1
+          </span>
+        </div>
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="false"
+        >
+          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+            Option 2
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col items-center">
+        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+          <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+            sm
+          </span>
+        </div>
+      </div>
+      <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1000 text-neutral-1300 dark:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+            Option 1
+          </span>
+        </div>
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="false"
+        >
+          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+            Option 2
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col items-center">
+        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+          <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+            xs
+          </span>
+        </div>
+      </div>
+      <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1000 text-neutral-1300 dark:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+            Option 1
+          </span>
+        </div>
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+             tabindex="0"
+             role="button"
+             aria-pressed="false"
+        >
+          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+            Option 2
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
+<div class="flex flex-col sm:flex-row gap-8">
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          md
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <svg class
+             aria-hidden="true"
+             style="width: 23px; height: 23px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <svg class
+             aria-hidden="true"
+             style="width: 23px; height: 23px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          sm
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <svg class
+             aria-hidden="true"
+             style="width: 22px; height: 22px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <svg class
+             aria-hidden="true"
+             style="width: 22px; height: 22px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          xs
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <svg class
+             aria-hidden="true"
+             style="width: 20px; height: 20px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <svg class
+             aria-hidden="true"
+             style="width: 20px; height: 20px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
+<div class="flex flex-col sm:flex-row gap-8">
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          md
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+        <svg class
+             aria-hidden="true"
+             style="width: 23px; height: 23px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-48 p-12 gap-[10px] ui-text-menu2 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+        <svg class
+             aria-hidden="true"
+             style="width: 23px; height: 23px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          sm
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+        <svg class
+             aria-hidden="true"
+             style="width: 22px; height: 22px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-40 p-[9px] gap-[9px] ui-text-menu3 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+        <svg class
+             aria-hidden="true"
+             style="width: 22px; height: 22px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col items-center">
+      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-4 items-center focus-base transition-colors select-none font-semibold px-[10px] py-2 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-8">
+        <span class="whitespace-nowrap tracking-widen-0.04 leading-[20px]">
+          xs
+        </span>
+      </div>
+    </div>
+    <div class="flex gap-8 justify-center items-center p-8 border rounded-lg">
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="true"
+      >
+        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          Option 1
+        </span>
+        <svg class
+             aria-hidden="true"
+             style="width: 20px; height: 20px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+      </div>
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-36 p-8 gap-8 ui-text-menu4 rounded-lg"
+           tabindex="0"
+           role="button"
+           aria-pressed="false"
+      >
+        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          Option 2
+        </span>
+        <svg class
+             aria-hidden="true"
+             style="width: 20px; height: 20px;"
+        >
+          <use xlink:href="#sprite-icon-tech-javascript">
+          </use>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Adds a SegmentedControl component that's needed for the language selector in the rendered Sandpack examples over on docs (pending draft PR - https://github.com/ably/docs/pull/2483). Based on [this](https://www.figma.com/design/u1Yw9J7J2jOmsDI1kDMb60/02---Elements?node-id=2341-309&t=qW37vu1FaNQprXoa-1).

Review: https://ably.github.io/ably-ui/?path=/docs/components-segmented-control--docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package release to version 15.8.0.

- **New Features**
  - Introduced a new interactive segmented control component that offers multiple sizes, customizable icon placement, rounded corners, and supports both active and disabled states.
  - Added interactive demos to showcase various configurations—including default, strong contrast, and different icon arrangements—to help you easily preview the component's capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->