### PR TITLE
fix: Use cn for Tooltip to ensure proper classname ordering.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "16.0.2",
+  "version": "16.0.3",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Table/__snapshots__/Table.stories.tsx.snap
+++ b/src/core/Table/__snapshots__/Table.stories.tsx.snap
@@ -63,7 +63,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 1
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -143,7 +143,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 2
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -223,7 +223,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 3
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -303,7 +303,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 4
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -383,7 +383,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 5
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -474,7 +474,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 1
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -554,7 +554,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 2
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -634,7 +634,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 3
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -714,7 +714,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 4
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -794,7 +794,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 5
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -885,7 +885,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 1
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -965,7 +965,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 2
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -1045,7 +1045,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 3
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -1125,7 +1125,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 4
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "
@@ -1205,7 +1205,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
           >
             Label 5
           </a>
-          <div class="inline-flex ml-8 ">
+          <div class="inline-flex ml-8">
             <button type="button"
                     aria-describedby="tooltip"
                     class="p-0 relative focus:outline-none h-[1rem] "

--- a/src/core/Tooltip.tsx
+++ b/src/core/Tooltip.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 import { createPortal } from "react-dom";
 import Icon from "./Icon";
+import cn from "./utils/cn";
 
 type TooltipProps = {
   triggerElement?: ReactNode;
@@ -139,7 +140,7 @@ const Tooltip = ({
   };
 
   return (
-    <div {...rest} className={`inline-flex ml-8 ${rest?.className ?? ""}`}>
+    <div {...rest} className={cn("inline-flex ml-8", rest?.className)}>
       <button
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={(event) => {
@@ -179,9 +180,14 @@ const Tooltip = ({
                 boxShadow: "4px 4px 15px rgba(0, 0, 0, 0.2)",
               }}
               {...tooltipProps}
-              className={`bg-neutral-1000 dark:bg-neutral-300 text-neutral-200 dark:text-neutral-1000 ui-text-p3 font-medium p-16 ${interactive ? "" : "pointer-events-none"} rounded-lg absolute ${
-                tooltipProps?.className ?? ""
-              } ${fadeOut ? "animate-[tooltipExit_0.25s_ease-in-out]" : "animate-[tooltipEntry_0.25s_ease-in-out]"}`}
+              className={cn(
+                "bg-neutral-1000 dark:bg-neutral-300 text-neutral-200 dark:text-neutral-1000 ui-text-p3 font-medium p-16",
+                { "pointer-events-none": !interactive },
+                "rounded-lg absolute",
+                tooltipProps?.className,
+                { "animate-[tooltipExit_0.25s_ease-in-out]": fadeOut },
+                { "animate-[tooltipEntry_0.25s_ease-in-out]": !fadeOut },
+              )}
             >
               <div className="max-w-[240px] w-auto">{children}</div>
             </div>,

--- a/src/core/Tooltip/__snapshots__/Tooltip.stories.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/Tooltip.stories.tsx.snap
@@ -9,7 +9,7 @@ exports[`Components/Tooltip Central smoke-test 1`] = `
     light
   </div>
   <div class="w-256 h-256 bg-neutral-1300 flex items-center justify-center m-24 border mx-auto rounded-lg">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] "
@@ -25,7 +25,7 @@ exports[`Components/Tooltip Central smoke-test 1`] = `
   </div>
   <div class="w-256 h-256 flex items-center justify-center m-24 border mx-auto rounded-lg">
     <div theme="light"
-         class="inline-flex ml-8 "
+         class="inline-flex ml-8"
     >
       <button type="button"
               aria-describedby="tooltip"
@@ -52,7 +52,7 @@ exports[`Components/Tooltip Interactive smoke-test 1`] = `
     light
   </div>
   <div class="w-256 h-256 bg-neutral-1300 flex items-center justify-center m-24 border mx-auto rounded-lg">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] "
@@ -68,7 +68,7 @@ exports[`Components/Tooltip Interactive smoke-test 1`] = `
   </div>
   <div class="w-256 h-256 flex items-center justify-center m-24 border mx-auto rounded-lg">
     <div theme="light"
-         class="inline-flex ml-8 "
+         class="inline-flex ml-8"
     >
       <button type="button"
               aria-describedby="tooltip"
@@ -95,7 +95,7 @@ exports[`Components/Tooltip LeftBound smoke-test 1`] = `
     light
   </div>
   <div class="w-256 h-256 bg-neutral-1300 flex items-center m-24 border mx-auto rounded-lg">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] "
@@ -111,7 +111,7 @@ exports[`Components/Tooltip LeftBound smoke-test 1`] = `
   </div>
   <div class="w-256 h-256 flex items-center m-24 border mx-auto rounded-lg">
     <div theme="light"
-         class="inline-flex ml-8 "
+         class="inline-flex ml-8"
     >
       <button type="button"
               aria-describedby="tooltip"

--- a/src/core/styles/__snapshots__/Button.stories.tsx.snap
+++ b/src/core/styles/__snapshots__/Button.stories.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Components/Button Primary smoke-test 1`] = `
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-16">
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -15,7 +15,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -27,7 +27,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -39,7 +39,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -53,7 +53,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -69,7 +69,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -85,7 +85,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -101,7 +101,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -119,7 +119,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -135,7 +135,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -151,7 +151,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -167,7 +167,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -185,7 +185,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -198,7 +198,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -211,7 +211,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -224,7 +224,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -244,7 +244,7 @@ exports[`Components/Button Primary smoke-test 1`] = `
 exports[`Components/Button Priority smoke-test 1`] = `
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-16">
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -256,7 +256,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -268,7 +268,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -280,7 +280,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -294,7 +294,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -310,7 +310,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -326,7 +326,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -342,7 +342,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -360,7 +360,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -376,7 +376,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -392,7 +392,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -408,7 +408,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -426,7 +426,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -439,7 +439,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -452,7 +452,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -465,7 +465,7 @@ exports[`Components/Button Priority smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -517,7 +517,7 @@ exports[`Components/Button ReactComponent smoke-test 1`] = `
 exports[`Components/Button Secondary smoke-test 1`] = `
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-16">
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -529,7 +529,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -541,7 +541,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -553,7 +553,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -567,7 +567,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -583,7 +583,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -599,7 +599,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -615,7 +615,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -633,7 +633,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -649,7 +649,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -665,7 +665,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -681,7 +681,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         </svg>
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -699,7 +699,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
     </div>
   </div>
   <div class="flex flex-col gap-16">
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -712,7 +712,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Large
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -725,7 +725,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Regular
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"
@@ -738,7 +738,7 @@ exports[`Components/Button Secondary smoke-test 1`] = `
         Small
       </button>
     </div>
-    <div class="inline-flex ml-8 ">
+    <div class="inline-flex ml-8">
       <button type="button"
               aria-describedby="tooltip"
               class="p-0 relative focus:outline-none h-[1rem] h-[60px]"


### PR DESCRIPTION
## Jira Ticket Link / Motivation

Related for this ticket - WEB-4131 I need to cascade the style for  tooltip to `ml-4`

## Summary of changes
Use `cn` function to merge classnames and fix order of priority in `Tooltip` component

## How do you manually test this?

make sure all the Tooltip are still working fine

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 16.0.3, reflecting minor maintenance improvements.
- **Refactor**
  - Enhanced the tooltip's styling logic for more consistent appearance and smoother animations in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->