### PR TITLE
[WEB-4297] fix: allow custom scrollpoints for meganav

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "16.0.3",
+  "version": "16.0.4",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Meganav.tsx
+++ b/src/core/Meganav.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from "react";
-import Header, { HeaderSessionState } from "./Header";
+import Header, { HeaderSessionState, ThemedScrollpoint } from "./Header";
 import Flyout from "./Flyout";
 import { menuItemsForHeader } from "./Meganav/data";
 import { MeganavMobile } from "./Meganav/MeganavMobile";
@@ -27,9 +27,15 @@ export type MeganavProps = {
   sessionState: HeaderSessionState;
   notice?: MeganavNoticeBannerProps;
   theme?: string;
+  themedScrollpoints?: ThemedScrollpoint[];
 };
 
-const Meganav = ({ sessionState, notice, theme }: MeganavProps) => {
+const Meganav = ({
+  sessionState,
+  notice,
+  theme,
+  themedScrollpoints,
+}: MeganavProps) => {
   const [noticeHeight, setNoticeHeight] = React.useState(0);
   const mobileNavItems = useMemo(
     () =>
@@ -38,6 +44,25 @@ const Meganav = ({ sessionState, notice, theme }: MeganavProps) => {
         .map(({ name, link, content }) => ({ name, link, content })),
     [],
   );
+
+  const defaultThemedScrollpoints = [
+    {
+      id: "meganav",
+      className: "ui-theme-light !bg-transparent !border-none",
+    },
+    {
+      id: "meganav-theme-dark",
+      className: "ui-theme-dark !bg-transparent !border-none",
+    },
+    {
+      id: "main",
+      className: "ui-theme-light bg-neutral-000 dark:bg-neutral-1300 border-b",
+    },
+    {
+      id: "main-theme-dark",
+      className: "ui-theme-dark bg-neutral-000 dark:bg-neutral-1300 border-b",
+    },
+  ];
 
   useEffect(() => {
     const observeNoticeResize = () => {
@@ -75,26 +100,7 @@ const Meganav = ({ sessionState, notice, theme }: MeganavProps) => {
           headerLinks={[{ href: "/contact", label: "Contact us" }]}
           headerLinksClassName="md:gap-x-24 "
           sessionState={sessionState}
-          themedScrollpoints={[
-            {
-              id: "meganav",
-              className: "ui-theme-light !bg-transparent !border-none",
-            },
-            {
-              id: "meganav-theme-dark",
-              className: "ui-theme-dark !bg-transparent !border-none",
-            },
-            {
-              id: "main",
-              className:
-                "ui-theme-light bg-neutral-000 dark:bg-neutral-1300 border-b",
-            },
-            {
-              id: "main-theme-dark",
-              className:
-                "ui-theme-dark bg-neutral-000 dark:bg-neutral-1300 border-b",
-            },
-          ]}
+          themedScrollpoints={themedScrollpoints ?? defaultThemedScrollpoints}
         />
       </div>
     </>


### PR DESCRIPTION
We have a default set of scrollpoints (points in the page where the theme of the header changes) that works for current voltaire pages. Unfortunately, they don't work well for older pages. Since there isn't really a default theme that will work for all cases, this PR allows the means to offer alternative scrollpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the UI package version to a new development release for continued improvements.

- **New Features**
  - Enhanced the navigation component by introducing customizable scrollpoints, allowing for flexible themed navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->