### PR TITLE
Apply cn to add custom classnames for the Code component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "16.1.3",
+  "version": "16.1.4",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Code.tsx
+++ b/src/core/Code.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-
 import {
   highlightSnippet,
   registerDefaultLanguages,
 } from "./utils/syntax-highlighter";
 import languagesRegistry from "./utils/syntax-highlighter-registry";
+import cn from "./utils/cn";
 
 registerDefaultLanguages(languagesRegistry);
 
@@ -33,14 +33,17 @@ const Code = ({
 
   return (
     <div
-      className={`hljs overflow-auto flex ${padding} ${additionalCSS}`}
+      className={cn("hljs overflow-auto flex", padding, additionalCSS)}
       data-id="code"
     >
       {showLines ? (
         <div>
           {[...Array(lineCount)].map((_, i) => (
             <p
-              className={`mr-24 font-mono text-right text-neutral-800 ${lineCSS ?? ""}`}
+              className={cn(
+                "mr-24 font-mono text-right text-neutral-800",
+                lineCSS,
+              )}
               key={i}
             >
               {i + 1}

--- a/src/core/Code/Code.stories.tsx
+++ b/src/core/Code/Code.stories.tsx
@@ -16,6 +16,7 @@ var channel = ably.channels.get('web-pal');
 channel.subscribe('greeting', function(message) {
   alert(message.data);
 });`,
+    additionalCSS: "bg-neutral-1200 p-16",
   },
 };
 

--- a/src/core/Code/__snapshots__/Code.stories.tsx.snap
+++ b/src/core/Code/__snapshots__/Code.stories.tsx.snap
@@ -1,29 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Code CodeWithLines smoke-test 1`] = `
-<div class="hljs overflow-auto flex p-32 "
+<div class="hljs overflow-auto flex p-32"
      data-id="code"
 >
   <div>
-    <p class="mr-24 font-mono text-right text-neutral-800 ">
+    <p class="mr-24 font-mono text-right text-neutral-800">
       1
     </p>
-    <p class="mr-24 font-mono text-right text-neutral-800 ">
+    <p class="mr-24 font-mono text-right text-neutral-800">
       2
     </p>
-    <p class="mr-24 font-mono text-right text-neutral-800 ">
+    <p class="mr-24 font-mono text-right text-neutral-800">
       3
     </p>
-    <p class="mr-24 font-mono text-right text-neutral-800 ">
+    <p class="mr-24 font-mono text-right text-neutral-800">
       4
     </p>
-    <p class="mr-24 font-mono text-right text-neutral-800 ">
+    <p class="mr-24 font-mono text-right text-neutral-800">
       5
     </p>
-    <p class="mr-24 font-mono text-right text-neutral-800 ">
+    <p class="mr-24 font-mono text-right text-neutral-800">
       6
     </p>
-    <p class="mr-24 font-mono text-right text-neutral-800 ">
+    <p class="mr-24 font-mono text-right text-neutral-800">
       7
     </p>
   </div>
@@ -99,7 +99,7 @@ exports[`Components/Code CodeWithLines smoke-test 1`] = `
 `;
 
 exports[`Components/Code Java smoke-test 1`] = `
-<div class="hljs overflow-auto flex p-32 "
+<div class="hljs overflow-auto flex p-32"
      data-id="code"
 >
   <pre lang="java">
@@ -180,7 +180,7 @@ channel.subscribe(
 `;
 
 exports[`Components/Code Javascript smoke-test 1`] = `
-<div class="hljs overflow-auto flex p-32 "
+<div class="hljs overflow-auto flex bg-neutral-1200 p-16"
      data-id="code"
 >
   <pre lang="javascript">
@@ -255,7 +255,7 @@ exports[`Components/Code Javascript smoke-test 1`] = `
 `;
 
 exports[`Components/Code Kotlin smoke-test 1`] = `
-<div class="hljs overflow-auto flex p-32 "
+<div class="hljs overflow-auto flex p-32"
      data-id="code"
 >
   <pre lang="kotlin">
@@ -310,7 +310,7 @@ exports[`Components/Code Kotlin smoke-test 1`] = `
 `;
 
 exports[`Components/Code Swift smoke-test 1`] = `
-<div class="hljs overflow-auto flex p-32 "
+<div class="hljs overflow-auto flex p-32"
      data-id="code"
 >
   <pre lang="swift">


### PR DESCRIPTION

## Jira Ticket Link / Motivation

WEB-3925

## Summary of changes

Integrate the `cn` utility in the `Code` component to properly handle and merge Tailwind class names.

<!-- See commits for details. -->

## How do you manually test this?

Go to Story and look for the Code component and check the `Javascript` story, if the Additional classnames ` bg-neutral-1200 p-16` are working

## Reviewer Tasks (optional)

<!-- If there is something specific you need reviewers to have a look at, something that might not be immediately clear, use this section to guide them along. -->

## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved class name handling in the code display component for more consistent styling.
  - Updated the JavaScript code example with additional background and padding styles.

- **Chores**
  - Bumped package version to 16.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->