### PR TITLE
[WEB-4440] Move dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file defines who is responsible for different parts of the codebase
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo
+* @ably/team-website

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    reviewers:
-      - "ably/team-website"
     open-pull-requests-limit: 2


### PR DESCRIPTION
## Jira Ticket Link / Motivation

Keeping up with GitHub.

## Summary of changes

This pull request includes updates to repository management files, specifically `.github/CODEOWNERS` and `.github/dependabot.yml`. The changes define default code ownership and adjust Dependabot settings.

Repository management updates:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R5): Added a default code owner (`@ably/team-website`) for the entire repository, along with a comment explaining the purpose of the file.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-L9): Removed the `reviewers` field from the Dependabot configuration, which previously listed `ably/team-website` as reviewers for pull requests.

## How do you manually test this?

Merge and 🙏 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a default code owners file to ensure the designated team is automatically requested for code reviews.
  - Updated Dependabot configuration to remove automatic assignment of reviewers for dependency update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->