### PR TITLE
[WEB-4440] chore: instruct dependabot to ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
The march of the patch updates for dev-side dependencies in this repo is relentless, and since it's an internal tool (pretty much) - we don't need to be as on the edge. Hopefully reduces noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency management settings to ignore patch-level updates for all npm packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->