### PR TITLE
[WEB-4346] UI section collapse

### DIFF
--- a/src/core/styles.components.css
+++ b/src/core/styles.components.css
@@ -34,6 +34,12 @@
     @apply my-20 sm:my-24 md:my-32;
   }
 
+  .ui-section-spacing-collapse {
+    /* This removes the spacing between adjacent .ui-section-spacing classes,
+       in a way that handles margin collapsing as well (hence not an exact opposite) */
+    @apply -my-4 sm:-my-8 md:-my-16;
+  }
+
   .ui-content-spacing {
     @apply my-10 sm:my-12 md:my-16;
   }


### PR DESCRIPTION
## Jira Ticket Link / Motivation

A requirement for the flexible template, where we would optionally want to collapse the space between two components that have `.ui-section-spacing` applied. This new class is essentially the inverse of the original, effectively cancelling it out while handling margin collapsing as well.

## Summary of changes

This pull request includes a version bump for the `@ably/ui` package and the addition of a new CSS utility class for spacing adjustments.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `17.3.0` to `17.3.1`.

### CSS Enhancements:
* [`src/core/styles.components.css`](diffhunk://#diff-54fa215638a72ae09602b3d0288ee3a7206ba5706ab5db267683ef2805cd3f40R37-R40): Added a new utility class `.ui-section-spacing-collapse` for negative vertical margins across different breakpoints.

## How do you manually test this?

Voltaire PR 1048 makes use of it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new utility class to help reduce or collapse vertical spacing between sections for improved layout control.

- **Chores**
  - Updated the application version to a new development build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->