### PR TITLE
[WEB-4440] De-duplicate icon url IDs at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.3.3",
+  "version": "17.3.4",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/CodeSnippet/CodeSnippet.stories.tsx
+++ b/src/core/CodeSnippet/CodeSnippet.stories.tsx
@@ -190,7 +190,7 @@ export const SingleLanguageWithHeader: Story = {
  */
 export const WithDefaultLanguage: Story = {
   render: () => (
-    <CodeSnippet headerRow title="TypeScript Example" lang="typescript">
+    <CodeSnippet headerRow title="TypeScript Example" lang="swift">
       <pre>
         <code className="language-javascript">{CODE_SNIPPETS.javascript}</code>
       </pre>

--- a/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
+++ b/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
@@ -18,7 +18,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r8:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -29,7 +29,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r8:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -60,7 +60,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:r1:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -73,7 +73,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:r1:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -88,7 +88,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r0:"
+              aria-controls="radix-:r2:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -107,7 +107,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:r9:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -118,7 +118,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:r9:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -391,7 +391,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
          class="mr-2"
          style="width: 16px; height: 16px;"
     >
-      <g clip-path="url(#clip0_4810_1924)">
+      <g clip-path="url(#clip0_4810_1924-:r3a:)">
         <path stroke="currentColor"
               stroke-linecap="round"
               stroke-width="3"
@@ -404,7 +404,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
         </path>
       </g>
       <defs>
-        <clipPath id="clip0_4810_1924">
+        <clipPath id="clip0_4810_1924-:r3a:">
           <path fill="#fff"
                 d="M0 0h48v48H0z"
           >
@@ -884,7 +884,7 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
          class="mr-2"
          style="width: 16px; height: 16px;"
     >
-      <g clip-path="url(#clip0_1031_1922)">
+      <g clip-path="url(#clip0_1031_1922-:rb:)">
         <path fill="#F7DF1E"
               d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
         >
@@ -895,7 +895,7 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
         </path>
       </g>
       <defs>
-        <clipPath id="clip0_1031_1922">
+        <clipPath id="clip0_1031_1922-:rb:">
           <path fill="#fff"
                 d="M0 0h48v48H0z"
           >
@@ -1039,7 +1039,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
          class="mr-2"
          style="width: 16px; height: 16px;"
     >
-      <g clip-path="url(#clip0_1031_1922)">
+      <g clip-path="url(#clip0_1031_1922-:rq:)">
         <path fill="#F7DF1E"
               d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
         >
@@ -1050,7 +1050,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
         </path>
       </g>
       <defs>
-        <clipPath id="clip0_1031_1922">
+        <clipPath id="clip0_1031_1922-:rq:">
           <path fill="#fff"
                 d="M0 0h48v48H0z"
           >
@@ -1201,7 +1201,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r2o:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -1212,7 +1212,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r2o:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -1243,7 +1243,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:r2b:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -1256,7 +1256,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:r2b:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -1271,7 +1271,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:rk:"
+              aria-controls="radix-:r2c:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -1290,7 +1290,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:r2p:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -1301,7 +1301,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:r2p:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -1443,7 +1443,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
     </span>
     <button type="button"
             role="combobox"
-            aria-controls="radix-:rl:"
+            aria-controls="radix-:r2e:"
             aria-expanded="false"
             aria-autocomplete="none"
             dir="ltr"
@@ -1511,14 +1511,14 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
              style="width: 22px; height: 22px;"
         >
           <g fill-rule="evenodd"
-             clip-path="url(#clip0_1031_1912)"
+             clip-path="url(#clip0_1031_1912-:r44:)"
              clip-rule="evenodd"
           >
-            <path fill="url(#paint0_linear_1031_1912)"
+            <path fill="url(#paint0_linear_1031_1912-:r44:)"
                   d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
             >
             </path>
-            <path fill="url(#paint1_linear_1031_1912)"
+            <path fill="url(#paint1_linear_1031_1912-:r44:)"
                   d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
             >
             </path>
@@ -1528,7 +1528,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <linearGradient id="paint0_linear_1031_1912"
+            <linearGradient id="paint0_linear_1031_1912-:r44:"
                             x1="2.813"
                             x2="-6.259"
                             y1="-6.259"
@@ -1542,7 +1542,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               >
               </stop>
             </linearGradient>
-            <linearGradient id="paint1_linear_1031_1912"
+            <linearGradient id="paint1_linear_1031_1912-:r44:"
                             x1="4.876"
                             x2="-1.23"
                             y1="-2.365"
@@ -1556,7 +1556,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               >
               </stop>
             </linearGradient>
-            <clipPath id="clip0_1031_1912">
+            <clipPath id="clip0_1031_1912-:r44:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -1587,7 +1587,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:r3n:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -1600,7 +1600,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:r3n:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -1630,7 +1630,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1922)">
+              <g clip-path="url(#clip0_1031_1922-:r3o:)">
                 <path fill="#F7DF1E"
                       d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
                 >
@@ -1641,7 +1641,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1922">
+                <clipPath id="clip0_1031_1922-:r3o:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -1672,18 +1672,18 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <g fill-rule="evenodd"
-                 clip-path="url(#clip0_1031_1963)"
+                 clip-path="url(#clip0_1031_1963-:r3p:)"
                  clip-rule="evenodd"
               >
-                <path fill="url(#paint0_radial_1031_1963)"
+                <path fill="url(#paint0_radial_1031_1963-:r3p:)"
                       d="M23.895 48.218c-7.073 0-12.807-1.112-12.807-2.483s5.734-2.483 12.807-2.483 12.807 1.112 12.807 2.483-5.734 2.483-12.807 2.483"
                 >
                 </path>
-                <path fill="url(#paint1_radial_1031_1963)"
+                <path fill="url(#paint1_radial_1031_1963-:r3p:)"
                       d="M23.895 48.218c-7.073 0-12.807-1.112-12.807-2.483s5.734-2.483 12.807-2.483 12.807 1.112 12.807 2.483-5.734 2.483-12.807 2.483"
                 >
                 </path>
-                <path fill="url(#paint2_linear_1031_1963)"
+                <path fill="url(#paint2_linear_1031_1963-:r3p:)"
                       d="M29.156 33.479c.99 0 1.793.811 1.793 1.815 0 1.007-.803 1.827-1.794 1.827-.987 0-1.793-.82-1.793-1.827 0-1.004.806-1.815 1.794-1.815m5.368-23.046v4.244c0 3.29-2.79 6.059-5.97 6.059h-9.546c-2.614 0-4.778 2.238-4.778 4.857v9.1c0 2.59 2.252 4.113 4.778 4.856 3.025.89 5.926 1.05 9.546 0 2.406-.696 4.778-2.099 4.778-4.856V31.05h-9.546v-1.215H38.11c2.778 0 3.813-1.937 4.78-4.845.997-2.993.954-5.872 0-9.713-.687-2.765-1.998-4.845-4.78-4.845z"
                 >
                 </path>
@@ -1693,7 +1693,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <radialGradient id="paint0_radial_1031_1963"
+                <radialGradient id="paint0_radial_1031_1963-:r3p:"
                                 cx="0"
                                 cy="0"
                                 r="1"
@@ -1707,7 +1707,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                   >
                   </stop>
                 </radialGradient>
-                <radialGradient id="paint1_radial_1031_1963"
+                <radialGradient id="paint1_radial_1031_1963-:r3p:"
                                 cx="0"
                                 cy="0"
                                 r="1"
@@ -1721,7 +1721,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                   >
                   </stop>
                 </radialGradient>
-                <linearGradient id="paint2_linear_1031_1963"
+                <linearGradient id="paint2_linear_1031_1963-:r3p:"
                                 x1="38.828"
                                 x2="30.863"
                                 y1="27.877"
@@ -1735,7 +1735,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                   >
                   </stop>
                 </linearGradient>
-                <clipPath id="clip0_1031_1963">
+                <clipPath id="clip0_1031_1963-:r3p:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -1750,7 +1750,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r11:"
+              aria-controls="radix-:r3q:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -1770,14 +1770,14 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                style="width: 20px; height: 20px;"
           >
             <g fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1912)"
+               clip-path="url(#clip0_1031_1912-:r45:)"
                clip-rule="evenodd"
             >
-              <path fill="url(#paint0_linear_1031_1912)"
+              <path fill="url(#paint0_linear_1031_1912-:r45:)"
                     d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1912)"
+              <path fill="url(#paint1_linear_1031_1912-:r45:)"
                     d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
               >
               </path>
@@ -1787,7 +1787,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1912"
+              <linearGradient id="paint0_linear_1031_1912-:r45:"
                               x1="2.813"
                               x2="-6.259"
                               y1="-6.259"
@@ -1801,7 +1801,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1912"
+              <linearGradient id="paint1_linear_1031_1912-:r45:"
                               x1="4.876"
                               x2="-1.23"
                               y1="-2.365"
@@ -1815,7 +1815,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1912">
+              <clipPath id="clip0_1031_1912-:r45:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -1975,7 +1975,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1922)">
+              <g clip-path="url(#clip0_1031_1922-:rr:)">
                 <path fill="#F7DF1E"
                       d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
                 >
@@ -1986,7 +1986,50 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1922">
+                <clipPath id="clip0_1031_1922-:rr:">
+                  <path fill="#fff"
+                        d="M0 0h48v48H0z"
+                  >
+                  </path>
+                </clipPath>
+              </defs>
+            </svg>
+          </div>
+        </button>
+      </div>
+      <div class="inline-flex ml-0">
+        <button type="button"
+                aria-describedby="tooltip"
+                class="p-0 relative focus:outline-none h-[1rem] "
+        >
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+               tabindex="0"
+               role="button"
+               aria-pressed="false"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="48"
+                 height="48"
+                 fill="none"
+                 viewbox="0 0 48 48"
+                 class
+                 aria-hidden="true"
+                 style="width: 22px; height: 22px;"
+            >
+              <g clip-path="url(#clip0_1031_1977-:rs:)">
+                <path fill="#007ACC"
+                      d="M0 24V0h48v48H0"
+                >
+                </path>
+                <path fill="#fff"
+                      fill-rule="evenodd"
+                      d="M41.568 23.796c-.84-.876-1.776-1.428-3-1.716l.024-.024c-.828-.216-2.808-.288-3.648-.12-2.592.48-4.404 2.16-4.92 4.56-.168.684-.108 2.388.072 3.084.24.804.756 1.776 1.32 2.4.984 1.032 2.04 1.704 4.524 2.76 2.16.96 2.928 1.392 3.312 1.92.276.42.36.672.36 1.224 0 .6-.192 1.032-.636 1.44-1.032.936-3.12 1.044-4.68.24-.516-.288-1.404-1.128-1.8-1.752l-.312-.42-1.356.792-1.8 1.044-.456.288c-.048.084.804 1.368 1.248 1.848 1.128 1.236 2.964 2.196 4.884 2.556.9.156 2.82.18 3.66.036 2.676-.444 4.548-1.8 5.316-3.804.684-1.836.456-4.284-.564-5.844-.9-1.392-2.388-2.364-5.82-3.84-1.86-.816-2.46-1.212-2.784-1.872-.144-.312-.216-.528-.216-.912 0-1.26.96-2.016 2.4-1.92.996.072 1.632.456 2.256 1.344.192.312.384.516.432.48 1.26-.78 3.336-2.184 3.336-2.256-.048-.216-.708-1.056-1.152-1.536M10.524 26.04v-1.956l.036.012v-1.968l8.4-.036c4.62 0 8.424.012 8.424.048.048.024.048.9.048 1.98v1.92h-6.24V43.8h-4.428V26.04z"
+                      clip-rule="evenodd"
+                >
+                </path>
+              </g>
+              <defs>
+                <clipPath id="clip0_1031_1977-:rs:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -2011,20 +2054,53 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1977)">
-            <path fill="#007ACC"
-                  d="M0 24V0h48v48H0"
+          <g fill-rule="evenodd"
+             clip-path="url(#clip0_1031_1912-:r16:)"
+             clip-rule="evenodd"
+          >
+            <path fill="url(#paint0_linear_1031_1912-:r16:)"
+                  d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
             >
             </path>
-            <path fill="#fff"
-                  fill-rule="evenodd"
-                  d="M41.568 23.796c-.84-.876-1.776-1.428-3-1.716l.024-.024c-.828-.216-2.808-.288-3.648-.12-2.592.48-4.404 2.16-4.92 4.56-.168.684-.108 2.388.072 3.084.24.804.756 1.776 1.32 2.4.984 1.032 2.04 1.704 4.524 2.76 2.16.96 2.928 1.392 3.312 1.92.276.42.36.672.36 1.224 0 .6-.192 1.032-.636 1.44-1.032.936-3.12 1.044-4.68.24-.516-.288-1.404-1.128-1.8-1.752l-.312-.42-1.356.792-1.8 1.044-.456.288c-.048.084.804 1.368 1.248 1.848 1.128 1.236 2.964 2.196 4.884 2.556.9.156 2.82.18 3.66.036 2.676-.444 4.548-1.8 5.316-3.804.684-1.836.456-4.284-.564-5.844-.9-1.392-2.388-2.364-5.82-3.84-1.86-.816-2.46-1.212-2.784-1.872-.144-.312-.216-.528-.216-.912 0-1.26.96-2.016 2.4-1.92.996.072 1.632.456 2.256 1.344.192.312.384.516.432.48 1.26-.78 3.336-2.184 3.336-2.256-.048-.216-.708-1.056-1.152-1.536M10.524 26.04v-1.956l.036.012v-1.968l8.4-.036c4.62 0 8.424.012 8.424.048.048.024.048.9.048 1.98v1.92h-6.24V43.8h-4.428V26.04z"
-                  clip-rule="evenodd"
+            <path fill="url(#paint1_linear_1031_1912-:r16:)"
+                  d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
+            >
+            </path>
+            <path fill="#FEFEFE"
+                  d="M27.16 7.155c15.833 10.763 10.71 22.612 10.71 22.612s4.502 5.07 2.691 9.52c0 0-1.863-3.105-4.967-3.105-3.001 0-4.76 3.105-10.814 3.105-13.453 0-19.817-11.228-19.817-11.228 12.113 7.982 20.386 2.328 20.386 2.328-5.465-3.174-17.075-18.316-17.075-18.316 10.12 8.608 14.488 10.865 14.488 10.865-2.615-2.152-9.935-12.676-9.935-12.676 5.857 5.926 17.49 14.177 17.49 14.177 3.317-9.12-3.157-17.282-3.157-17.282"
             >
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1977">
+            <linearGradient id="paint0_linear_1031_1912-:r16:"
+                            x1="2.813"
+                            x2="-6.259"
+                            y1="-6.259"
+                            y2="45.187"
+                            gradientunits="userSpaceOnUse"
+            >
+              <stop stop-color="#FAAE41">
+              </stop>
+              <stop offset="1"
+                    stop-color="#EF3E31"
+              >
+              </stop>
+            </linearGradient>
+            <linearGradient id="paint1_linear_1031_1912-:r16:"
+                            x1="4.876"
+                            x2="-1.23"
+                            y1="-2.365"
+                            y2="35.34"
+                            gradientunits="userSpaceOnUse"
+            >
+              <stop stop-color="#E29F3A">
+              </stop>
+              <stop offset="1"
+                    stop-color="#D43929"
+              >
+              </stop>
+            </linearGradient>
+            <clipPath id="clip0_1031_1912-:r16:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -2033,90 +2109,14 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
           </defs>
         </svg>
         <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
-          TypeScript
+          Swift
         </span>
-      </div>
-      <div class="inline-flex ml-0">
-        <button type="button"
-                aria-describedby="tooltip"
-                class="p-0 relative focus:outline-none h-[1rem] "
-        >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
-               tabindex="0"
-               role="button"
-               aria-pressed="false"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg"
-                 width="48"
-                 height="48"
-                 fill="none"
-                 viewbox="0 0 48 48"
-                 class
-                 aria-hidden="true"
-                 style="width: 22px; height: 22px;"
-            >
-              <g fill-rule="evenodd"
-                 clip-path="url(#clip0_1031_1912)"
-                 clip-rule="evenodd"
-              >
-                <path fill="url(#paint0_linear_1031_1912)"
-                      d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
-                >
-                </path>
-                <path fill="url(#paint1_linear_1031_1912)"
-                      d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
-                >
-                </path>
-                <path fill="#FEFEFE"
-                      d="M27.16 7.155c15.833 10.763 10.71 22.612 10.71 22.612s4.502 5.07 2.691 9.52c0 0-1.863-3.105-4.967-3.105-3.001 0-4.76 3.105-10.814 3.105-13.453 0-19.817-11.228-19.817-11.228 12.113 7.982 20.386 2.328 20.386 2.328-5.465-3.174-17.075-18.316-17.075-18.316 10.12 8.608 14.488 10.865 14.488 10.865-2.615-2.152-9.935-12.676-9.935-12.676 5.857 5.926 17.49 14.177 17.49 14.177 3.317-9.12-3.157-17.282-3.157-17.282"
-                >
-                </path>
-              </g>
-              <defs>
-                <linearGradient id="paint0_linear_1031_1912"
-                                x1="2.813"
-                                x2="-6.259"
-                                y1="-6.259"
-                                y2="45.187"
-                                gradientunits="userSpaceOnUse"
-                >
-                  <stop stop-color="#FAAE41">
-                  </stop>
-                  <stop offset="1"
-                        stop-color="#EF3E31"
-                  >
-                  </stop>
-                </linearGradient>
-                <linearGradient id="paint1_linear_1031_1912"
-                                x1="4.876"
-                                x2="-1.23"
-                                y1="-2.365"
-                                y2="35.34"
-                                gradientunits="userSpaceOnUse"
-                >
-                  <stop stop-color="#E29F3A">
-                  </stop>
-                  <stop offset="1"
-                        stop-color="#D43929"
-                  >
-                  </stop>
-                </linearGradient>
-                <clipPath id="clip0_1031_1912">
-                  <path fill="#fff"
-                        d="M0 0h48v48H0z"
-                  >
-                  </path>
-                </clipPath>
-              </defs>
-            </svg>
-          </div>
-        </button>
       </div>
     </div>
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r7:"
+              aria-controls="radix-:ru:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -2135,20 +2135,53 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_1977)">
-              <path fill="#007ACC"
-                    d="M0 24V0h48v48H0"
+            <g fill-rule="evenodd"
+               clip-path="url(#clip0_1031_1912-:r17:)"
+               clip-rule="evenodd"
+            >
+              <path fill="url(#paint0_linear_1031_1912-:r17:)"
+                    d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
               >
               </path>
-              <path fill="#fff"
-                    fill-rule="evenodd"
-                    d="M41.568 23.796c-.84-.876-1.776-1.428-3-1.716l.024-.024c-.828-.216-2.808-.288-3.648-.12-2.592.48-4.404 2.16-4.92 4.56-.168.684-.108 2.388.072 3.084.24.804.756 1.776 1.32 2.4.984 1.032 2.04 1.704 4.524 2.76 2.16.96 2.928 1.392 3.312 1.92.276.42.36.672.36 1.224 0 .6-.192 1.032-.636 1.44-1.032.936-3.12 1.044-4.68.24-.516-.288-1.404-1.128-1.8-1.752l-.312-.42-1.356.792-1.8 1.044-.456.288c-.048.084.804 1.368 1.248 1.848 1.128 1.236 2.964 2.196 4.884 2.556.9.156 2.82.18 3.66.036 2.676-.444 4.548-1.8 5.316-3.804.684-1.836.456-4.284-.564-5.844-.9-1.392-2.388-2.364-5.82-3.84-1.86-.816-2.46-1.212-2.784-1.872-.144-.312-.216-.528-.216-.912 0-1.26.96-2.016 2.4-1.92.996.072 1.632.456 2.256 1.344.192.312.384.516.432.48 1.26-.78 3.336-2.184 3.336-2.256-.048-.216-.708-1.056-1.152-1.536M10.524 26.04v-1.956l.036.012v-1.968l8.4-.036c4.62 0 8.424.012 8.424.048.048.024.048.9.048 1.98v1.92h-6.24V43.8h-4.428V26.04z"
-                    clip-rule="evenodd"
+              <path fill="url(#paint1_linear_1031_1912-:r17:)"
+                    d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
+              >
+              </path>
+              <path fill="#FEFEFE"
+                    d="M27.16 7.155c15.833 10.763 10.71 22.612 10.71 22.612s4.502 5.07 2.691 9.52c0 0-1.863-3.105-4.967-3.105-3.001 0-4.76 3.105-10.814 3.105-13.453 0-19.817-11.228-19.817-11.228 12.113 7.982 20.386 2.328 20.386 2.328-5.465-3.174-17.075-18.316-17.075-18.316 10.12 8.608 14.488 10.865 14.488 10.865-2.615-2.152-9.935-12.676-9.935-12.676 5.857 5.926 17.49 14.177 17.49 14.177 3.317-9.12-3.157-17.282-3.157-17.282"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1977">
+              <linearGradient id="paint0_linear_1031_1912-:r17:"
+                              x1="2.813"
+                              x2="-6.259"
+                              y1="-6.259"
+                              y2="45.187"
+                              gradientunits="userSpaceOnUse"
+              >
+                <stop stop-color="#FAAE41">
+                </stop>
+                <stop offset="1"
+                      stop-color="#EF3E31"
+                >
+                </stop>
+              </linearGradient>
+              <linearGradient id="paint1_linear_1031_1912-:r17:"
+                              x1="4.876"
+                              x2="-1.23"
+                              y1="-2.365"
+                              y2="35.34"
+                              gradientunits="userSpaceOnUse"
+              >
+                <stop stop-color="#E29F3A">
+                </stop>
+                <stop offset="1"
+                      stop-color="#D43929"
+                >
+                </stop>
+              </linearGradient>
+              <clipPath id="clip0_1031_1912-:r17:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -2157,7 +2190,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
             </defs>
           </svg>
           <span>
-            TypeScript
+            Swift
           </span>
         </div>
         <span aria-hidden="true">
@@ -2210,76 +2243,59 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
           7
         </p>
       </div>
-      <pre lang="typescript">
-        <code class="language-typescript ui-text-code">
+      <pre lang="swift">
+        <code class="language-swift ui-text-code">
           <span class="hljs-keyword">
-            const
+            let
           </span>
-          ably =
-          <span class="hljs-keyword">
-            new
+          ably
+          <span class="hljs-operator">
+            =
           </span>
-          <span class="hljs-title class_">
-            Ably
+          <span class="hljs-type">
+            ARTRealtime
           </span>
-          .
-          <span class="hljs-title class_">
-            Realtime
-          </span>
-          (
+          (key:
           <span class="hljs-string">
-            'API_KEY'
+            "API_KEY"
           </span>
-          );
+          )
           <span class="hljs-keyword">
-            const
+            let
           </span>
-          channel = ably.
-          <span class="hljs-property">
-            channels
+          channel
+          <span class="hljs-operator">
+            =
           </span>
-          .
-          <span class="hljs-title function_">
-            get
-          </span>
-          (
+          ably.channels.get(
           <span class="hljs-string">
-            'channel-name'
+            "channel-name"
           </span>
-          );
+          )
           <span class="hljs-comment">
             // Subscribe to messages on channel
           </span>
-          channel.
-          <span class="hljs-title function_">
-            subscribe
+          channel.subscribe(
+          <span class="hljs-string">
+            "event"
+          </span>
+          ) { message
+          <span class="hljs-keyword">
+            in
+          </span>
+          <span class="hljs-built_in">
+            print
           </span>
           (
           <span class="hljs-string">
-            'event'
-          </span>
-          ,
-          <span class="hljs-function">
-            (
-            <span class="hljs-params">
-              message: Ably.Types.Message
+            "
+            <span class="hljs-subst">
+              \\(message.data)
             </span>
-            ) =&gt;
+            "
           </span>
-          {
-          <span class="hljs-variable language_">
-            console
-          </span>
-          .
-          <span class="hljs-title function_">
-            log
-          </span>
-          (message.
-          <span class="hljs-property">
-            data
-          </span>
-          );
-});
+          )
+}
         </code>
       </pre>
     </div>
@@ -2320,7 +2336,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r27:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -2331,7 +2347,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r27:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -2362,7 +2378,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:r1v:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -2375,7 +2391,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:r1v:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -2390,7 +2406,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:rh:"
+              aria-controls="radix-:r20:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -2409,7 +2425,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:r28:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -2420,7 +2436,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:r28:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -2627,7 +2643,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:rn:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -2638,7 +2654,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:rn:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -2669,7 +2685,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:rd:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -2682,7 +2698,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:rd:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -2713,14 +2729,14 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <g fill-rule="evenodd"
-                 clip-path="url(#clip0_1031_1912)"
+                 clip-path="url(#clip0_1031_1912-:re:)"
                  clip-rule="evenodd"
               >
-                <path fill="url(#paint0_linear_1031_1912)"
+                <path fill="url(#paint0_linear_1031_1912-:re:)"
                       d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
                 >
                 </path>
-                <path fill="url(#paint1_linear_1031_1912)"
+                <path fill="url(#paint1_linear_1031_1912-:re:)"
                       d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
                 >
                 </path>
@@ -2730,7 +2746,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <linearGradient id="paint0_linear_1031_1912"
+                <linearGradient id="paint0_linear_1031_1912-:re:"
                                 x1="2.813"
                                 x2="-6.259"
                                 y1="-6.259"
@@ -2744,7 +2760,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                   >
                   </stop>
                 </linearGradient>
-                <linearGradient id="paint1_linear_1031_1912"
+                <linearGradient id="paint1_linear_1031_1912-:re:"
                                 x1="4.876"
                                 x2="-1.23"
                                 y1="-2.365"
@@ -2758,7 +2774,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                   >
                   </stop>
                 </linearGradient>
-                <clipPath id="clip0_1031_1912">
+                <clipPath id="clip0_1031_1912-:re:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -2773,7 +2789,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r3:"
+              aria-controls="radix-:rf:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -2792,7 +2808,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:ro:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -2803,7 +2819,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:ro:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -2980,7 +2996,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1922)">
+              <g clip-path="url(#clip0_1031_1922-:r19:)">
                 <path fill="#F7DF1E"
                       d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
                 >
@@ -2991,7 +3007,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1922">
+                <clipPath id="clip0_1031_1922-:r19:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -3021,7 +3037,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:r1a:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -3034,7 +3050,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:r1a:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -3049,7 +3065,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:rb:"
+              aria-controls="radix-:r1b:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -3068,36 +3084,36 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_2037)">
-              <path fill="url(#paint0_linear_1031_2037)"
+            <g clip-path="url(#clip0_1031_2037-:r1h:)">
+              <path fill="url(#paint0_linear_1031_2037-:r1h:)"
                     d="M37.174 31.582 9.779 47.849l35.471-2.407 2.732-35.767z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_2037)"
+              <path fill="url(#paint1_linear_1031_2037-:r1h:)"
                     d="M45.308 45.417 42.26 24.375l-8.305 10.966z"
               >
               </path>
-              <path fill="url(#paint2_linear_1031_2037)"
+              <path fill="url(#paint2_linear_1031_2037-:r1h:)"
                     d="m45.35 45.417-22.336-1.753-13.116 4.139z"
               >
               </path>
-              <path fill="url(#paint3_linear_1031_2037)"
+              <path fill="url(#paint3_linear_1031_2037-:r1h:)"
                     d="m9.93 47.808 5.58-18.28-12.28 2.626z"
               >
               </path>
-              <path fill="url(#paint4_linear_1031_2037)"
+              <path fill="url(#paint4_linear_1031_2037-:r1h:)"
                     d="m0 38.285 3.422-6.24-2.768-7.436z"
               >
               </path>
-              <path fill="url(#paint5_linear_1031_2037)"
+              <path fill="url(#paint5_linear_1031_2037-:r1h:)"
                     d="m33.953 35.401-5.134-20.11-14.693 13.773z"
               >
               </path>
-              <path fill="url(#paint6_linear_1031_2037)"
+              <path fill="url(#paint6_linear_1031_2037-:r1h:)"
                     d="M46.817 15.574 32.93 4.23 29.06 16.734z"
               >
               </path>
-              <path fill="url(#paint7_linear_1031_2037)"
+              <path fill="url(#paint7_linear_1031_2037-:r1h:)"
                     d="m40.322.186-8.168 4.515L27 .126z"
               >
               </path>
@@ -3105,11 +3121,11 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                     d="m.47 24.375 2.785 7.9 12.102-2.715 13.815-12.84 3.9-12.385L26.931 0 16.494 3.906c-3.288 3.059-9.67 9.11-9.9 9.225-.227.116-4.213 7.65-6.124 11.244"
               >
               </path>
-              <path fill="url(#paint8_linear_1031_2037)"
+              <path fill="url(#paint8_linear_1031_2037-:r1h:)"
                     d="M10.249 10.183C17.376 3.117 26.564-1.059 30.09 2.5c3.524 3.558-.213 12.203-7.34 19.268-7.128 7.064-16.202 11.469-19.725 7.911-3.526-3.555.097-12.43 7.224-19.495"
               >
               </path>
-              <path fill="url(#paint9_linear_1031_2037)"
+              <path fill="url(#paint9_linear_1031_2037-:r1h:)"
                     d="m9.93 47.8 5.535-18.337 18.386 5.907C27.203 41.603 19.81 46.873 9.93 47.8"
               >
               </path>
@@ -3117,33 +3133,33 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                     d="M0 38.204c.262 9.408 7.05 9.548 9.941 9.631L3.262 32.236z"
               >
               </path>
-              <path fill="url(#paint10_linear_1031_2037)"
+              <path fill="url(#paint10_linear_1031_2037-:r1h:)"
                     d="M3.233 32.255 2.185 44.742c1.978 2.702 4.7 2.937 7.555 2.727-2.065-5.142-6.192-15.422-6.507-15.214"
               >
               </path>
-              <path fill="url(#paint11_linear_1031_2037)"
+              <path fill="url(#paint11_linear_1031_2037-:r1h:)"
                     d="m29.197 16.683 4.72 18.696C39.47 29.54 44.453 23.263 46.894 15.5z"
               >
               </path>
-              <path fill="url(#paint12_radial_1031_2037)"
+              <path fill="url(#paint12_radial_1031_2037-:r1h:)"
                     d="m15.458 29.463 7.4 14.279c4.377-2.374 7.804-5.265 10.942-8.363z"
               >
               </path>
-              <path fill="url(#paint13_linear_1031_2037)"
+              <path fill="url(#paint13_linear_1031_2037-:r1h:)"
                     d="M46.846 15.594c1.89-5.701 2.325-13.88-6.582-15.398l-7.31 4.037z"
               >
               </path>
-              <path fill="url(#paint14_radial_1031_2037)"
+              <path fill="url(#paint14_radial_1031_2037-:r1h:)"
                     d="M29.223 16.713c4.267 2.622 12.867 7.89 13.041 7.987.271.152 3.708-5.796 4.488-9.157z"
               >
               </path>
-              <path fill="url(#paint15_linear_1031_2037)"
+              <path fill="url(#paint15_linear_1031_2037-:r1h:)"
                     d="m32.912 4.265 14.702 2.063C46.83 3.003 44.42.858 40.312.187z"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_2037"
+              <linearGradient id="paint0_linear_1031_2037-:r1h:"
                               x1="51.112"
                               x2="41.001"
                               y1="47.178"
@@ -3167,7 +3183,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_2037"
+              <linearGradient id="paint1_linear_1031_2037-:r1h:"
                               x1="67.988"
                               x2="22.822"
                               y1="-4.343"
@@ -3187,7 +3203,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1031_2037"
+              <linearGradient id="paint2_linear_1031_2037-:r1h:"
                               x1="2787.28"
                               x2="2787.11"
                               y1="559.152"
@@ -3207,7 +3223,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint3_linear_1031_2037"
+              <linearGradient id="paint3_linear_1031_2037-:r1h:"
                               x1="4.959"
                               x2="12.911"
                               y1="34.187"
@@ -3235,7 +3251,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint4_linear_1031_2037"
+              <linearGradient id="paint4_linear_1031_2037-:r1h:"
                               x1="-11.51"
                               x2="1.418"
                               y1="52.752"
@@ -3259,7 +3275,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint5_linear_1031_2037"
+              <linearGradient id="paint5_linear_1031_2037-:r1h:"
                               x1="16.647"
                               x2="17.436"
                               y1="18.967"
@@ -3287,7 +3303,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint6_linear_1031_2037"
+              <linearGradient id="paint6_linear_1031_2037-:r1h:"
                               x1="21.859"
                               x2="22.969"
                               y1="2.592"
@@ -3315,7 +3331,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint7_linear_1031_2037"
+              <linearGradient id="paint7_linear_1031_2037-:r1h:"
                               x1="88.161"
                               x2="89.301"
                               y1="7.302"
@@ -3339,7 +3355,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint8_linear_1031_2037"
+              <linearGradient id="paint8_linear_1031_2037-:r1h:"
                               x1="14.71"
                               x2="51.846"
                               y1="56.193"
@@ -3383,7 +3399,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint9_linear_1031_2037"
+              <linearGradient id="paint9_linear_1031_2037-:r1h:"
                               x1="27.062"
                               x2="17.422"
                               y1="39.083"
@@ -3407,7 +3423,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint10_linear_1031_2037"
+              <linearGradient id="paint10_linear_1031_2037-:r1h:"
                               x1="11.381"
                               x2="-7.149"
                               y1="31.099"
@@ -3431,7 +3447,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint11_linear_1031_2037"
+              <linearGradient id="paint11_linear_1031_2037-:r1h:"
                               x1="48.563"
                               x2="35.215"
                               y1="20.922"
@@ -3451,7 +3467,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint13_linear_1031_2037"
+              <linearGradient id="paint13_linear_1031_2037-:r1h:"
                               x1="49.814"
                               x2="44.46"
                               y1="8.931"
@@ -3471,7 +3487,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint15_linear_1031_2037"
+              <linearGradient id="paint15_linear_1031_2037-:r1h:"
                               x1="10.024"
                               x2="11.64"
                               y1="0.08"
@@ -3495,7 +3511,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <radialGradient id="paint12_radial_1031_2037"
+              <radialGradient id="paint12_radial_1031_2037-:r1h:"
                               cx="0"
                               cy="0"
                               r="1"
@@ -3515,7 +3531,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </radialGradient>
-              <radialGradient id="paint14_radial_1031_2037"
+              <radialGradient id="paint14_radial_1031_2037-:r1h:"
                               cx="0"
                               cy="0"
                               r="1"
@@ -3535,7 +3551,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 >
                 </stop>
               </radialGradient>
-              <clipPath id="clip0_1031_2037">
+              <clipPath id="clip0_1031_2037-:r1h:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -3659,7 +3675,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
                aria-hidden="true"
                style="width: 22px; height: 22px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:r1r:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -3670,7 +3686,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:r1r:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -3701,7 +3717,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
                    aria-hidden="true"
                    style="width: 22px; height: 22px;"
               >
-                <g clip-path="url(#clip0_1031_1977)">
+                <g clip-path="url(#clip0_1031_1977-:r1k:)">
                   <path fill="#007ACC"
                         d="M0 24V0h48v48H0"
                   >
@@ -3714,7 +3730,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
                   </path>
                 </g>
                 <defs>
-                  <clipPath id="clip0_1031_1977">
+                  <clipPath id="clip0_1031_1977-:r1k:">
                     <path fill="#fff"
                           d="M0 0h48v48H0z"
                     >
@@ -3729,7 +3745,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
       <div class="sm:hidden w-full">
         <button type="button"
                 role="combobox"
-                aria-controls="radix-:re:"
+                aria-controls="radix-:r1l:"
                 aria-expanded="false"
                 aria-autocomplete="none"
                 dir="ltr"
@@ -3748,7 +3764,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
                  class
                  style="width: 20px; height: 20px;"
             >
-              <g clip-path="url(#clip0_1031_1922)">
+              <g clip-path="url(#clip0_1031_1922-:r1s:)">
                 <path fill="#F7DF1E"
                       d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
                 >
@@ -3759,7 +3775,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1922">
+                <clipPath id="clip0_1031_1922-:r1s:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -3961,7 +3977,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r33:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -3972,7 +3988,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r33:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -4003,7 +4019,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:r2s:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -4016,7 +4032,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:r2s:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -4031,7 +4047,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:rr:"
+              aria-controls="radix-:r2t:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -4050,7 +4066,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:r34:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -4061,7 +4077,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:r34:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -4233,7 +4249,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r3j:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -4244,7 +4260,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r3j:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -4275,7 +4291,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
-              <g clip-path="url(#clip0_1031_1977)">
+              <g clip-path="url(#clip0_1031_1977-:r3c:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -4288,7 +4304,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                 </path>
               </g>
               <defs>
-                <clipPath id="clip0_1031_1977">
+                <clipPath id="clip0_1031_1977-:r3c:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -4303,7 +4319,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:ru:"
+              aria-controls="radix-:r3d:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -4322,7 +4338,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                class
                style="width: 20px; height: 20px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:r3k:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -4333,7 +4349,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:r3k:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >

--- a/src/core/Icon/__snapshots__/Icon.stories.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.stories.tsx.snap
@@ -483,7 +483,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0)">
+            <g clip-path="url(#clip0-:rf:)">
               <path fill="currentColor"
                     fill-rule="evenodd"
                     d="M7 8.75c-.69 0-1.25.56-1.25 1.25v24h11.345a2 2 0 0 1 1.167.376l1.041.748a2 2 0 0 0 1.167.376h7.06a2 2 0 0 0 1.167-.376l1.04-.748A2 2 0 0 1 30.906 34H42.25V10c0-.69-.56-1.25-1.25-1.25zM4.25 10v24H1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h46a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-3.25V10A2.75 2.75 0 0 0 41 7.25H7A2.75 2.75 0 0 0 4.25 10M46.5 35.5H30.905a.5.5 0 0 0-.292.094l-1.04.748A3.5 3.5 0 0 1 27.53 37h-7.06a3.5 3.5 0 0 1-2.043-.658l-1.04-.748a.5.5 0 0 0-.292-.094H1.5v2h45zM25 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0"
@@ -492,7 +492,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0">
+              <clipPath id="clip0-:rf:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -1029,7 +1029,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_3563_10959)">
+            <g clip-path="url(#clip0_3563_10959-:rt:)">
               <path stroke="#C6CED9"
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -1076,7 +1076,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_3563_10959">
+              <clipPath id="clip0_3563_10959-:rt:">
                 <path fill="#fff"
                       d="M.5.923h48v48H.5z"
                 >
@@ -1570,7 +1570,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_3795_3659)">
+            <g clip-path="url(#clip0_3795_3659-:r16:)">
               <path stroke="#C6CED9"
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -1638,7 +1638,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_3795_3659">
+              <clipPath id="clip0_3795_3659-:r16:">
                 <path fill="#fff"
                       d="M.333.423h48v48h-48z"
                 >
@@ -1891,7 +1891,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_3563_10779)">
+            <g clip-path="url(#clip0_3563_10779-:r1b:)">
               <path stroke="#C6CED9"
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -1920,7 +1920,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_3563_10779">
+              <clipPath id="clip0_3563_10779-:r1b:">
                 <path fill="#fff"
                       d="M.667.423h48v48h-48z"
                 >
@@ -2335,7 +2335,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_2961_1570)">
+            <g clip-path="url(#clip0_2961_1570-:r1i:)">
               <path fill="currentColor"
                     fill-rule="evenodd"
                     d="M23.093 11.916c.56.355 1.525.98 2.083 1.4-.068-.333-.17-.749-.277-1.182-.152-.617-.313-1.267-.394-1.763.246-.24.594-.516.979-.822.423-.336.892-.708 1.324-1.112-.874-.123-2.968-.208-2.968-.208s-.555-1.16-.962-1.983c.083-.193.163-.371.237-.519 0-.524-.02-1.27-.04-1.989-.019-.669-.037-1.315-.037-1.738-6.76-.022-16.982 5.638-18.812 11.339a2.9 2.9 0 0 0 1.374-.467 22.6 22.6 0 0 0 4.325-2.749 11.6 11.6 0 0 1 3.611-2.063c2.748-.826 4.672.23 5.518 3.013.23.928.517 1.844.863 2.732a3.43 3.43 0 0 0 1.206 1.683c.46.342.997.558 1.558.63v.498c2.236-.326 3.885-1.394 4.682-3.62a6 6 0 0 1 .346-.731c1.237-2.462 2.88-3.019 5.353-1.81a33 33 0 0 1 3.71 2.36 17.4 17.4 0 0 0 7.991 3.042 3.8 3.8 0 0 0 1.755-.211A3.9 3.9 0 0 0 48 14.66a16 16 0 0 0-1.445-.167c-.501-.042-.981-.082-1.457-.182a23.5 23.5 0 0 1-9.76-4.683 8.03 8.03 0 0 0-4.304-1.945c-2.105-.185-3.396.58-4.16 2.547-.154.444-.28.901-.405 1.36-.122.442-.244.886-.392 1.321-.522 1.509-1.432 2.597-3.01 2.876.022-1.29.026-2.981.026-3.872m-.352-.223-.082-.051v-4.87l-.128.314c-.215.53-.411 1.015-.52 1.176h-2.946l2.418 1.968-.753 2.732c.208-.125.48-.3.776-.493.398-.257.84-.543 1.235-.776m-.235 20.963q.282.205.56.412-.068.066-.132.137v1.36q.945.722 1.813 1.54c.94.978.924 1.71 0 2.676-.423.438-.873.86-1.319 1.276l-.489.461v1.35c-.698.404-1.528 1.09-1.528 1.978 0 .787.544 1.467 1.034 2.069.186.225.357.444.494.646v.158l.044-.08.014.02.014.02a5.8 5.8 0 0 0 2.39-2.226c.704-1.383-.16-2.367-1.077-3.25.44-.59.94-1.129 1.484-1.63 1.38-1.624 1.352-2.776-.093-4.384-.121-.135-.259-.259-.396-.382a2.8 2.8 0 0 1-.742-.889 14.3 14.3 0 0 1 2.017-1.877 2.4 2.4 0 0 0 .662-.755 2.47 2.47 0 0 0 .192-1.974 2.4 2.4 0 0 0-.502-.874 4.7 4.7 0 0 0-1.512-1.293l-.165-.09-.003-.002c-.22-.106-.453-.22-.475-.645l1.072-.584q.942-.51 1.874-1.04c2.561-1.53 3.144-3.25 2.072-6.004.165-.084.346-.096.528-.101l.026-.002c.211-.01.427-.021.628-.161 0-.134-.07-.256-.146-.39l-.003-.004c-.148-.253-.313-.545-.01-1.023a6.4 6.4 0 0 1 1.796.68l.015.008c.809.396 1.634.802 2.59.757-.053-.338-.27-.538-.484-.734l-.021-.02-.002-.001c-.22-.196-.432-.387-.476-.701.509.1.994.264 1.478.427l.099.034.01.003c.986.342 1.95.676 3.068.463-.193-.262-.447-.444-.698-.624l-.022-.016-.017-.013c-.346-.254-.69-.506-.863-.971.528.095 1.039.219 1.55.343l.014.003c1.452.353 2.871.698 4.526.373l-1.094-.438-.106-.042c-.667-.264-1.27-.503-1.845-.824a64 64 0 0 1-7.276-3.946c-1.968-1.321-3.523-.81-4.59 1.31a37 37 0 0 0-.879 1.821c-.89 1.99-2.566 2.563-4.451 2.693l-.077-.09c-.055-.056-.083-.085-.083-.113l-.132-.506c-2.286-.354-4.155-2.035-4.798-4.289a3.7 3.7 0 0 0-.351-.725 3.37 3.37 0 0 0-1.882-1.745 3.27 3.27 0 0 0-2.537.115 13.3 13.3 0 0 0-2.583 1.405 26 26 0 0 1-5.26 3.148 95 95 0 0 1-1.89.706l-.253.092-.577.214C-.303 23.974.61 31.451 5.798 38.343c3.918 5.183 11.393 8.269 17.092 8.437-.924-.59-2.314-1.709-2.627-2.8-.292-1.028.274-1.691.934-2.461.181-.214.368-.439.55-.675a17 17 0 0 1-1.754-1.5c-1.264-1.417-1.242-2.44-.055-3.953.16-.202.347-.376.534-.55.327-.272.604-.602.818-.973-.307-.551-.796-.9-1.286-1.237a6.6 6.6 0 0 1-.786-.613 2.5 2.5 0 0 1-.626-.776 2.53 2.53 0 0 1 .352-2.832 5.1 5.1 0 0 1 1.681-1.35l.025-.012c.219-.108.447-.222.41-.606a4 4 0 0 0-1.32-.81 13.7 13.7 0 0 1-3.132-2.04c-1.473-1.383-1.528-3.935-.127-4.88a3.45 3.45 0 0 1 2.357-.505c.82.12 1.571.532 2.123 1.163.34.472.755.884 1.225 1.22.385.23.621.652.621 1.107q-1.202 1.891-2.396.062a4 4 0 0 1-.198-.314l-.011-.02c-.26-.42-.518-.838-1.006-1.049-.62-.275-1.242-.37-1.703.225a1.35 1.35 0 0 0 .055 1.749q.35.421.797.736a15.5 15.5 0 0 0 3.006 1.726c.63.203 1.166.633 1.511 1.208l.058 1.084q-.263.166-.528.34c-.404.265-.813.532-1.24.764-1.598.855-1.675 2.102-.236 3.232.518.432 1.055.825 1.59 1.216m.477 13.984-.044-.079-.022-1.94c-.01-.87-.022-1.804-.022-2.698.665.32 1.396.748 1.534 1.546.191 1.148-.505 2-1.038 2.65l-.007.01c-.159.185-.296.36-.4.51m1.237-14.458c-.385.26-.77.521-1.105.84v-5.62q.796.607 1.676 1.075c.343.14.642.371.867.67.226.298.368.653.414 1.028-.311.96-1.072 1.476-1.835 1.995zm-1.572 8.421.005.006h.006l-.011.045zm0 0a49 49 0 0 0-.622-.64c-.329-.334-.658-.669-.972-1.018-.934-1.034-.934-1.911 0-2.951.329-.363.696-.68 1.062-.998q.269-.231.532-.47zm.346-21.784a4.34 4.34 0 0 1 2.094-.067c-.184.482-.463.92-.819 1.288a3.7 3.7 0 0 1-1.253.848 5.15 5.15 0 0 1-.022-2.069m2.16 5.622c.974-.433 1.886-1 2.71-1.687.807-.742.945-1.686.33-2.226a1.58 1.58 0 0 0-1.198-.233 1.6 1.6 0 0 0-1.012.694 7 7 0 0 0-.434.658c-.231.393-.462.776-.918.967-.38.157-.72.045-1.077-.073a2.6 2.6 0 0 0-.594-.152v3.25a13.5 13.5 0 0 1 2.193-1.193z"
@@ -2344,7 +2344,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_2961_1570">
+              <clipPath id="clip0_2961_1570-:r1i:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -2371,7 +2371,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_3518_39132)">
+            <g clip-path="url(#clip0_3518_39132-:r1j:)">
               <path fill="#C6CED9"
                     fill-rule="evenodd"
                     d="M23.093 12.838c.56.356 1.525.98 2.083 1.402-.068-.334-.17-.75-.277-1.183-.152-.617-.313-1.268-.394-1.763.246-.241.594-.517.979-.822.423-.336.892-.709 1.324-1.112-.874-.124-2.968-.208-2.968-.208s-.555-1.16-.962-1.983c.083-.193.163-.371.237-.519 0-.524-.02-1.27-.04-1.989-.019-.669-.037-1.315-.037-1.738C16.278 2.9 6.056 8.56 4.226 14.26a2.9 2.9 0 0 0 1.374-.466 22.6 22.6 0 0 0 4.325-2.75 11.6 11.6 0 0 1 3.611-2.062c2.748-.826 4.672.23 5.518 3.013.23.928.517 1.844.863 2.732a3.43 3.43 0 0 0 1.206 1.683c.46.342.997.558 1.558.63v.498c2.236-.326 3.885-1.394 4.682-3.62q.15-.378.346-.731c1.237-2.462 2.88-3.019 5.353-1.81a33 33 0 0 1 3.71 2.36 17.4 17.4 0 0 0 7.991 3.042 3.8 3.8 0 0 0 1.755-.212A3.9 3.9 0 0 0 48 15.583c-.508-.088-.985-.128-1.445-.167-.501-.041-.981-.081-1.457-.181a23.5 23.5 0 0 1-9.76-4.683 8.03 8.03 0 0 0-4.304-1.945c-2.105-.185-3.396.58-4.16 2.547-.154.444-.28.9-.405 1.36-.122.442-.244.886-.392 1.321-.522 1.509-1.432 2.597-3.01 2.876.022-1.29.026-2.982.026-3.872m-.352-.222-.082-.052V7.695l-.128.314c-.215.53-.411 1.015-.52 1.176h-2.946l2.418 1.968-.753 2.732c.208-.125.48-.3.776-.493.398-.257.84-.543 1.235-.776m-.235 20.963q.282.205.56.412-.068.066-.132.136v1.36q.945.723 1.813 1.541c.94.978.924 1.709 0 2.676-.423.438-.873.86-1.319 1.276l-.489.461v1.35c-.698.404-1.528 1.09-1.528 1.978 0 .787.544 1.467 1.034 2.069.186.224.357.444.494.646v.157l.044-.078.014.02.014.02a5.8 5.8 0 0 0 2.39-2.227c.704-1.383-.16-2.367-1.077-3.25.44-.59.94-1.13 1.484-1.63 1.38-1.624 1.352-2.777-.093-4.384a5 5 0 0 0-.396-.382 2.8 2.8 0 0 1-.742-.889 14.3 14.3 0 0 1 2.017-1.877 2.4 2.4 0 0 0 .662-.756 2.47 2.47 0 0 0 .192-1.973 2.4 2.4 0 0 0-.502-.875 4.7 4.7 0 0 0-1.512-1.293l-.165-.09-.003-.001c-.22-.107-.453-.22-.475-.645l1.072-.585q.942-.509 1.874-1.04c2.561-1.529 3.144-3.249 2.072-6.003.165-.085.346-.096.528-.101l.026-.002c.211-.01.427-.021.628-.162 0-.133-.07-.255-.146-.388l-.003-.005c-.148-.253-.313-.545-.01-1.023a6.4 6.4 0 0 1 1.796.68l.015.007c.809.397 1.634.802 2.59.758-.053-.338-.27-.538-.484-.734l-.021-.02-.002-.001c-.22-.196-.432-.387-.476-.701.509.1.994.264 1.478.427l.099.034.01.003c.986.342 1.95.676 3.068.463-.193-.262-.447-.444-.698-.624l-.022-.017-.017-.012c-.346-.254-.69-.507-.863-.971.528.095 1.039.219 1.55.343l.014.003c1.452.353 2.871.698 4.526.373l-1.094-.438-.106-.042c-.667-.264-1.27-.504-1.845-.824a64 64 0 0 1-7.276-3.946c-1.968-1.321-3.523-.81-4.59 1.31a37 37 0 0 0-.879 1.82c-.89 1.99-2.566 2.564-4.451 2.694l-.077-.09c-.055-.057-.083-.085-.083-.113l-.132-.506c-2.286-.354-4.155-2.035-4.798-4.289a3.7 3.7 0 0 0-.351-.725 3.36 3.36 0 0 0-1.882-1.745 3.27 3.27 0 0 0-2.537.115c-.912.37-1.775.843-2.583 1.405a26 26 0 0 1-5.26 3.148 96 96 0 0 1-1.89.706l-.253.092-.577.214C-.303 24.897.61 32.374 5.798 39.265c3.918 5.183 11.393 8.27 17.092 8.438-.924-.59-2.314-1.709-2.627-2.8-.292-1.028.274-1.691.934-2.461.181-.214.368-.439.55-.675a17 17 0 0 1-1.754-1.5c-1.264-1.418-1.242-2.44-.055-3.953.16-.202.347-.377.534-.55a3.6 3.6 0 0 0 .818-.973c-.307-.551-.796-.9-1.286-1.237a6.6 6.6 0 0 1-.786-.613 2.5 2.5 0 0 1-.626-.776 2.53 2.53 0 0 1 .352-2.833 5.1 5.1 0 0 1 1.681-1.349l.025-.012c.219-.108.447-.222.41-.606a4 4 0 0 0-1.32-.81 13.7 13.7 0 0 1-3.132-2.04c-1.473-1.383-1.528-3.935-.127-4.88a3.45 3.45 0 0 1 2.357-.505c.82.12 1.571.532 2.123 1.163.34.472.755.884 1.225 1.22.385.23.621.652.621 1.107q-1.202 1.891-2.396.062a4 4 0 0 1-.198-.315l-.011-.018c-.26-.421-.518-.84-1.006-1.05-.62-.275-1.242-.37-1.703.225a1.35 1.35 0 0 0 .055 1.748q.35.422.797.737a15.5 15.5 0 0 0 3.006 1.726c.63.203 1.166.632 1.511 1.208l.058 1.084q-.263.166-.528.34c-.404.264-.813.532-1.24.764-1.598.854-1.675 2.102-.236 3.232.518.432 1.055.825 1.59 1.216m.477 13.984-.044-.079-.022-1.94c-.01-.87-.022-1.804-.022-2.698.665.32 1.396.748 1.534 1.546.191 1.148-.505 2-1.038 2.65l-.007.01c-.159.185-.296.359-.4.51m1.237-14.459c-.385.261-.77.522-1.105.84v-5.619q.796.607 1.676 1.075c.343.14.642.371.867.67.226.298.368.653.414 1.027-.311.96-1.072 1.477-1.835 1.996zm-1.572 8.422.005.006h.006l-.011.045zm0 0q-.308-.323-.622-.64c-.329-.335-.658-.67-.972-1.018-.934-1.035-.934-1.911 0-2.951.329-.364.696-.68 1.062-.998q.269-.231.532-.47zm.346-21.784a4.34 4.34 0 0 1 2.094-.067c-.184.482-.463.92-.819 1.288a3.7 3.7 0 0 1-1.253.848 5.15 5.15 0 0 1-.022-2.069m2.16 5.622c.974-.433 1.886-1 2.71-1.687.807-.742.945-1.686.33-2.226a1.58 1.58 0 0 0-1.198-.233 1.6 1.6 0 0 0-1.012.694q-.234.316-.434.658c-.231.393-.462.775-.918.967-.38.157-.72.044-1.077-.073a2.6 2.6 0 0 0-.594-.152v3.249a13.5 13.5 0 0 1 2.193-1.192z"
@@ -2380,7 +2380,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_3518_39132">
+              <clipPath id="clip0_3518_39132-:r1j:">
                 <path fill="#fff"
                       d="M0 .923h48v48H0z"
                 >
@@ -2645,7 +2645,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0)">
+            <g clip-path="url(#clip0-:r1q:)">
               <path fill="currentColor"
                     fill-rule="evenodd"
                     d="M7 8.75c-.69 0-1.25.56-1.25 1.25v24h11.345a2 2 0 0 1 1.167.376l1.041.748a2 2 0 0 0 1.167.376h7.06a2 2 0 0 0 1.167-.376l1.04-.748A2 2 0 0 1 30.906 34H42.25V10c0-.69-.56-1.25-1.25-1.25zM4.25 10v24H1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h46a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-3.25V10A2.75 2.75 0 0 0 41 7.25H7A2.75 2.75 0 0 0 4.25 10M46.5 35.5H30.905a.5.5 0 0 0-.292.094l-1.04.748A3.5 3.5 0 0 1 27.53 37h-7.06a3.5 3.5 0 0 1-2.043-.658l-1.04-.748a.5.5 0 0 0-.292-.094H1.5v2h45zM25 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0"
@@ -2654,7 +2654,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0">
+              <clipPath id="clip0-:r1q:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -3196,7 +3196,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_3563_11119)">
+            <g clip-path="url(#clip0_3563_11119-:r25:)">
               <path fill="#C6CED9"
                     fill-rule="evenodd"
                     d="M40.5 19.923a3 3 0 1 1 6 0 3 3 0 0 1-6 0M26.5 36.923a3 3 0 1 1 6 0 3 3 0 0 1-6 0M3.5 44.923a3 3 0 1 1 6 0 3 3 0 0 1-6 0"
@@ -3251,7 +3251,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_3563_11119">
+              <clipPath id="clip0_3563_11119-:r25:">
                 <path fill="#fff"
                       d="M.5.923h48v48H.5z"
                 >
@@ -3304,14 +3304,14 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0)">
-              <path fill="url(#paint0_linear)"
+            <g clip-path="url(#clip0-:r27:)">
+              <path fill="url(#paint0_linear-:r27:)"
                     fill-rule="evenodd"
                     d="m34.678 25.41 13.48 6.99L24 45.13-.159 32.4 24 19.873l10.327 5.354.194-.106zm-2.468.973L24 22.126l-8.757 4.541 8.446 4.364zm-6.376 5.756 8.517-4.646 9.49 4.92-8.65 4.56zm-4.265.048-8.501-4.392-8.91 4.619 8.644 4.555zm-6.642 5.901 8.787-4.793 9.32 4.814L24 42.87z"
                     clip-rule="evenodd"
               >
               </path>
-              <path fill="url(#paint1_linear)"
+              <path fill="url(#paint1_linear-:r27:)"
                     fill-opacity="0.75"
                     d="M0 26.398 24 14l24 12.398L24 39z"
               >
@@ -3330,7 +3330,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear"
+              <linearGradient id="paint0_linear-:r27:"
                               x1="30"
                               x2="14.478"
                               y1="23"
@@ -3348,7 +3348,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear"
+              <linearGradient id="paint1_linear-:r27:"
                               x1="37.394"
                               x2="12.617"
                               y1="25.84"
@@ -3362,7 +3362,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0">
+              <clipPath id="clip0-:r27:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -3493,7 +3493,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_2889_2903)">
+            <g clip-path="url(#clip0_2889_2903-:r2b:)">
               <circle cx="35.5"
                       cy="13"
                       r="13"
@@ -3562,7 +3562,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_2889_2903">
+              <clipPath id="clip0_2889_2903-:r2b:">
                 <path fill="#fff"
                       d="M.5 0h48v48H.5z"
                 >
@@ -4070,7 +4070,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0)">
+            <g clip-path="url(#clip0-:r2n:)">
               <path fill="currentColor"
                     fill-rule="evenodd"
                     d="M1 6.25a.75.75 0 0 0 0 1.5h.392a3.25 3.25 0 0 1 3.149 2.447l5.699 22.358a2.75 2.75 0 0 0 1.26 5.195H42a.75.75 0 0 0 0-1.5H11.5a1.25 1.25 0 1 1 0-2.5h26.307a6.75 6.75 0 0 0 6.524-5.017l3.726-14.027A2.75 2.75 0 0 0 45.4 11.25H6.357l-.362-1.423A4.75 4.75 0 0 0 1.392 6.25zm5.74 6.5 4.97 19.5h26.097a5.25 5.25 0 0 0 5.075-3.902l3.726-14.027a1.25 1.25 0 0 0-1.209-1.571zM15 43.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3m0 1.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6m23.5-3a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0m1.5 0a3 3 0 1 1-6 0 3 3 0 0 1 6 0"
@@ -4079,7 +4079,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0">
+              <clipPath id="clip0-:r2n:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -5008,14 +5008,14 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_3807_424)"
+            <path fill="url(#paint0_linear_3807_424-:r9k:)"
                   fill-rule="evenodd"
                   d="M72.208 116.222C85.188 101.747 109 72.533 109 53c0-24.853-20.147-45-45-45S19 28.147 19 53c0 19.533 23.811 48.747 36.792 63.222 4.435 4.945 11.98 4.945 16.416 0M64 71c9.941 0 18-8.059 18-18s-8.059-18-18-18-18 8.059-18 18 8.059 18 18 18"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_424"
+              <linearGradient id="paint0_linear_3807_424-:r9k:"
                               x1="64"
                               x2="64"
                               y1="26.421"
@@ -5074,14 +5074,14 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_3636_438)"
+            <path fill="url(#paint0_linear_3636_438-:r9m:)"
                   fill-rule="evenodd"
                   d="M11.5 35c0-12.426 10.074-22.5 22.5-22.5h60c12.426 0 22.5 10.074 22.5 22.5v74.41c0 7.385-8.77 11.257-14.227 6.281l-22.812-20.8a1.5 1.5 0 0 0-1.01-.391H34c-12.426 0-22.5-10.074-22.5-22.5z"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3636_438"
+              <linearGradient id="paint0_linear_3636_438-:r9m:"
                               x1="64"
                               x2="64"
                               y1="29.85"
@@ -5145,7 +5145,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                   height="110"
                   x="9"
                   y="9"
-                  fill="url(#paint0_linear_3807_520)"
+                  fill="url(#paint0_linear_3807_520-:r9o:)"
                   rx="26"
             >
             </rect>
@@ -5157,7 +5157,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_520"
+              <linearGradient id="paint0_linear_3807_520-:r9o:"
                               x1="64"
                               x2="64"
                               y1="27.103"
@@ -5196,7 +5196,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                   height="110"
                   x="9"
                   y="9"
-                  fill="url(#paint0_linear_3807_518)"
+                  fill="url(#paint0_linear_3807_518-:r9p:)"
                   rx="26"
             >
             </rect>
@@ -5208,7 +5208,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_518"
+              <linearGradient id="paint0_linear_3807_518-:r9p:"
                               x1="64"
                               x2="64"
                               y1="27.103"
@@ -5276,14 +5276,14 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_3807_387)"
+            <path fill="url(#paint0_linear_3807_387-:r9r:)"
                   fill-rule="evenodd"
                   d="M13.5 52a2.5 2.5 0 0 0-5 0v25c0 23.472 19.028 42.5 42.5 42.5h64.029c3.353 0 4.787-4.26 2.117-6.288l-50.03-37.985c-2.304-1.75-5.616-.106-5.616 2.788V114.5H51c-20.71 0-37.5-16.79-37.5-37.5zm53-2.015c0 2.894-3.312 4.538-5.617 2.788L10.854 14.788C8.184 12.76 9.618 8.5 12.971 8.5H77c23.472 0 42.5 19.028 42.5 42.5v25a2.5 2.5 0 1 1-5 0V51c0-20.71-16.79-37.5-37.5-37.5H66.5z"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_387"
+              <linearGradient id="paint0_linear_3807_387-:r9r:"
                               x1="64"
                               x2="64"
                               y1="101.232"
@@ -5402,14 +5402,14 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_3807_142)"
+            <path fill="url(#paint0_linear_3807_142-:r9v:)"
                   fill-rule="evenodd"
                   d="M54.48 12.572c3.453-5.551 12.02-3.105 12.02 3.433V41.5h41.302c5.099 0 8.212 5.603 5.519 9.933L73.52 115.428c-3.453 5.551-12.02 3.105-12.02-3.433V86.5H20.198c-5.099 0-8.212-5.603-5.52-9.933z"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_142"
+              <linearGradient id="paint0_linear_3807_142-:r9v:"
                               x1="64"
                               x2="64"
                               y1="27.434"
@@ -5469,12 +5469,12 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_3807_221)"
+            <path fill="url(#paint0_linear_3807_221-:ra1:)"
                   d="M15.318 25.777c-1.762-6.366 4.093-12.221 10.46-10.46l84.559 23.406c7.856 2.174 8.443 13.088.866 16.093L73.036 69.951a5.5 5.5 0 0 0-3.085 3.085l-15.135 38.167c-3.005 7.577-13.919 6.99-16.093-.866z"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_221"
+              <linearGradient id="paint0_linear_3807_221-:ra1:"
                               x1="65.785"
                               x2="65.785"
                               y1="31.716"
@@ -5600,7 +5600,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_123_179)">
+            <g clip-path="url(#clip0_123_179-:r34:)">
               <path fill="#0866FF"
                     d="M24 12c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.628 3.875 10.35 9.101 11.647v-7.98H6.627V12H9.1v-1.58c0-4.084 1.849-5.978 5.859-5.978.76 0 2.072.15 2.608.298v3.324c-.283-.03-.775-.044-1.386-.044-1.967 0-2.728.745-2.728 2.683V12h3.92l-.673 3.667h-3.247v8.245C19.396 23.195 24 18.135 24 12"
               >
@@ -5611,7 +5611,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_123_179">
+              <clipPath id="clip0_123_179-:r34:">
                 <path fill="#fff"
                       d="M0 0h24v24H0z"
                 >
@@ -5638,7 +5638,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_2478_87)">
+            <g clip-path="url(#clip0_2478_87-:r35:)">
               <path fill="currentColor"
                     d="M24 12c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.628 3.875 10.35 9.101 11.647v-7.98H6.627V12H9.1v-1.58c0-4.084 1.849-5.978 5.859-5.978.76 0 2.072.15 2.608.298v3.324c-.283-.03-.775-.044-1.386-.044-1.967 0-2.728.745-2.728 2.683V12h3.92l-.673 3.667h-3.247v8.245C19.396 23.195 24 18.135 24 12"
               >
@@ -5649,7 +5649,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_2478_87">
+              <clipPath id="clip0_2478_87-:r35:">
                 <path fill="#fff"
                       d="M0 0h24v24H0z"
                 >
@@ -6192,16 +6192,16 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_1031_1947)"
+            <path fill="url(#paint0_linear_1031_1947-:r3o:)"
                   d="M23.86 4 3.896 40.543 0 37.812 18.474 4zm.28 0 19.965 36.543L48 37.812 29.525 4h-5.387z"
             >
             </path>
-            <path fill="url(#paint1_linear_1031_1947)"
+            <path fill="url(#paint1_linear_1031_1947-:r3o:)"
                   d="M43.827 40.757 24 25.231 4.172 40.757l4.046 2.834 15.78-12.354L39.78 43.591l4.046-2.834z"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_1031_1947"
+              <linearGradient id="paint0_linear_1031_1947-:r3o:"
                               x1="6.772"
                               x2="40.16"
                               y1="50.299"
@@ -6231,7 +6231,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1947"
+              <linearGradient id="paint1_linear_1031_1947-:r3o:"
                               x1="13.248"
                               x2="32.982"
                               y1="52.695"
@@ -6282,7 +6282,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_1031_1996)"
+            <path fill="url(#paint0_linear_1031_1996-:r3p:)"
                   d="M24.46 42.76c-5.933 0-11.36-2.187-17.053-6.893a1.497 1.497 0 0 1 1.906-2.307c5.134 4.226 9.947 6.2 15.147 6.2 1.48 0 6.293-.253 6.293-3.587V36c0-1.76-.68-3.093-9.746-5.413-10.387-2.587-19-5.814-19-17.92v-.147a1.507 1.507 0 1 1 3 0v.146c0 9.214 5.173 12.08 16.746 15.04 8.294 2.134 12 3.84 12 8.32v.147c0 3.187-2.413 6.587-9.293 6.587"
             >
             </path>
@@ -6290,12 +6290,12 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   d="M24.353 48a31.08 31.08 0 0 1-20.48-8 1.498 1.498 0 0 1 1.96-2.267 28.13 28.13 0 0 0 18.52 7.227c7.694 0 12.294-3.52 12.294-9.333v-.16c0-4.467-1.987-7.254-12.867-10.067C14.193 22.92 7.9 20.68 7.9 12.133V12c0-7.053 5.92-12 14.413-12a29.45 29.45 0 0 1 17.92 6.387 1.508 1.508 0 1 1-1.8 2.4A26.57 26.57 0 0 0 22.313 3C15.487 3 10.9 6.667 10.9 12v.133c0 5.867 3.4 7.72 13.627 10.334 9.573 2.48 15.12 5.333 15.12 12.973v.16c0 7.533-6 12.4-15.294 12.4"
             >
             </path>
-            <path fill="url(#paint1_linear_1031_1996)"
+            <path fill="url(#paint1_linear_1031_1996-:r3p:)"
                   d="M44.033 36.52a1.507 1.507 0 0 1-1.493-1.506v-.147c0-7.707-4.333-11.693-16-14.667-8.533-2.266-12.747-3.56-12.747-8.6v-.16c0-3.08 2.667-6.2 8.44-6.2 4.587 0 9.454 1.827 14.88 5.587a1.516 1.516 0 1 1-1.706 2.507C30.5 9.934 26.193 8.28 22.233 8.28c-3.306 0-5.44 1.254-5.44 3.2v.12c0 2.174.867 3.16 10.507 5.627 10.947 2.853 18.24 6.947 18.24 17.64v.147a1.52 1.52 0 0 1-1.507 1.506"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_1031_1996"
+              <linearGradient id="paint0_linear_1031_1996-:r3p:"
                               x1="17.873"
                               x2="17.873"
                               y1="33.573"
@@ -6310,7 +6310,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1996"
+              <linearGradient id="paint1_linear_1031_1996-:r3p:"
                               x1="29.673"
                               x2="29.673"
                               y1="13.107"
@@ -6372,12 +6372,12 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1997)">
-              <path fill="url(#paint0_linear_1031_1997)"
+            <g clip-path="url(#clip0_1031_1997-:r3r:)">
+              <path fill="url(#paint0_linear_1031_1997-:r3r:)"
                     d="m23.907 10-13.31 24.362L8 32.542 20.316 10zm.186 0 13.31 24.362L40 32.542 27.683 10h-3.591"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1997)"
+              <path fill="url(#paint1_linear_1031_1997-:r3r:)"
                     d="M37.218 34.505 24 24.154 10.782 34.505l2.697 1.889L24 28.158l10.521 8.236z"
               >
               </path>
@@ -6389,7 +6389,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1997"
+              <linearGradient id="paint0_linear_1031_1997-:r3r:"
                               x1="12.515"
                               x2="34.773"
                               y1="40.866"
@@ -6419,7 +6419,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1997"
+              <linearGradient id="paint1_linear_1031_1997-:r3r:"
                               x1="16.832"
                               x2="29.988"
                               y1="42.464"
@@ -6449,7 +6449,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1997">
+              <clipPath id="clip0_1031_1997-:r3r:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -6535,24 +6535,24 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill-rule="evenodd"
-               clip-path="url(#clip0_1887_138)"
+               clip-path="url(#clip0_1887_138-:r3t:)"
                clip-rule="evenodd"
             >
-              <path fill="url(#paint0_linear_1887_138)"
+              <path fill="url(#paint0_linear_1887_138-:r3t:)"
                     d="M26.182 9 48 21.597v5.038L26.182 39.232v-5.038l17.454-10.078L26.182 14.04z"
               >
               </path>
-              <path fill="url(#paint1_linear_1887_138)"
+              <path fill="url(#paint1_linear_1887_138-:r3t:)"
                     d="m26.182 19.078 8.727 5.038-8.727 5.039z"
               >
               </path>
-              <path fill="url(#paint2_linear_1887_138)"
+              <path fill="url(#paint2_linear_1887_138-:r3t:)"
                     d="M21.818 9 0 21.597v5.038l17.454-10.077v20.155l4.364 2.52zm-8.727 15.116-8.728 5.039 8.728 5.038z"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1887_138"
+              <linearGradient id="paint0_linear_1887_138-:r3t:"
                               x1="358.423"
                               x2="363.994"
                               y1="-166.639"
@@ -6562,7 +6562,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 <stop stop-color="#F1007E">
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1887_138"
+              <linearGradient id="paint1_linear_1887_138-:r3t:"
                               x1="358.425"
                               x2="363.997"
                               y1="-166.639"
@@ -6572,7 +6572,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 <stop stop-color="#F1007E">
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1887_138"
+              <linearGradient id="paint2_linear_1887_138-:r3t:"
                               x1="0"
                               x2="21.818"
                               y1="24.116"
@@ -6582,7 +6582,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 <stop stop-color="#6D6D6D">
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1887_138">
+              <clipPath id="clip0_1887_138-:r3t:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -6609,7 +6609,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2042)">
+            <g clip-path="url(#clip0_1031_2042-:r3u:)">
               <path fill="#B0252A"
                     d="M0 0h48v48H0z"
               >
@@ -6620,7 +6620,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2042">
+              <clipPath id="clip0_1031_2042-:r3u:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -6647,7 +6647,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1904)">
+            <g clip-path="url(#clip0_1031_1904-:r3v:)">
               <path fill="#0B5567"
                     d="M40.603 39.917c7.304 5.84 11.983-11.597.345-14.812-9.766-2.706-19.593 1.933-29.44 12.757 0 0 18.189-6.653 29.095 2.055"
               >
@@ -6658,7 +6658,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1904">
+              <clipPath id="clip0_1031_1904-:r3v:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -6717,7 +6717,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_1031_1972)"
+            <path fill="url(#paint0_linear_1031_1972-:r41:)"
                   d="M48 .6H0v48h48z"
             >
             </path>
@@ -6728,7 +6728,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_1031_1972"
+              <linearGradient id="paint0_linear_1031_1972-:r41:"
                               x1="0"
                               x2="48"
                               y1="48.6"
@@ -6933,7 +6933,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1976)">
+            <g clip-path="url(#clip0_1031_1976-:r47:)">
               <path fill="#010101"
                     d="m21.014 47.811-.36.189h-.242c-.699-.364-1.392-.734-2.098-1.085-.67-.334-1-.854-.996-1.61.013-1.992.01-3.984.014-5.976l3.772 1.886c-.005.13-.016.26-.016.391q0 2.836-.004 5.673c0 .178-.045.355-.07.532m-1.849-4.265c-.376-.069-.665.064-.873.381-.51.78.012 2.136.908 2.36.395.1.812-.109.908-.456.037-.031.09-.054.109-.094.393-.79-.187-1.993-1.052-2.191"
               >
@@ -7044,7 +7044,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1976">
+              <clipPath id="clip0_1031_1976-:r47:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -7071,7 +7071,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1978)">
+            <g clip-path="url(#clip0_1031_1978-:r48:)">
               <path fill="#BBE6FB"
                     fill-rule="evenodd"
                     d="M38.346 20.802c.354 3.986-6.12 7.78-14.456 8.473-8.337.694-15.382-1.976-15.735-5.962-.353-3.988 6.12-7.782 14.457-8.475s15.382 1.977 15.734 5.964"
@@ -7137,7 +7137,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1978">
+              <clipPath id="clip0_1031_1978-:r48:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -7164,7 +7164,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g filter="url(#filter0_f_2790_91)">
+            <g filter="url(#filter0_f_2790_91-:r49:)">
               <path fill="#000"
                     fill-opacity="0.57"
                     fill-rule="evenodd"
@@ -7179,7 +7179,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   clip-rule="evenodd"
             >
             </path>
-            <path fill="url(#paint0_linear_2790_91)"
+            <path fill="url(#paint0_linear_2790_91-:r49:)"
                   fill-rule="evenodd"
                   stroke="#D6D6D6"
                   stroke-linejoin="round"
@@ -7188,7 +7188,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   clip-rule="evenodd"
             >
             </path>
-            <path fill="url(#paint1_radial_2790_91)"
+            <path fill="url(#paint1_radial_2790_91-:r49:)"
                   fill-rule="evenodd"
                   d="m12.419 31.166 2.055-7.701L14.33 7.91l-3.855 7.77z"
                   clip-rule="evenodd"
@@ -7206,13 +7206,13 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   clip-rule="evenodd"
             >
             </path>
-            <path fill="url(#paint2_linear_2790_91)"
+            <path fill="url(#paint2_linear_2790_91-:r49:)"
                   fill-rule="evenodd"
                   d="m35.649 31.166-2.017-7.647.075-15.658 3.903 7.818z"
                   clip-rule="evenodd"
             >
             </path>
-            <path fill="url(#paint3_linear_2790_91)"
+            <path fill="url(#paint3_linear_2790_91-:r49:)"
                   fill-rule="evenodd"
                   d="m12.437 31.166 2.036-7.702-.144-15.553-3.855 7.77z"
                   clip-rule="evenodd"
@@ -7224,7 +7224,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   clip-rule="evenodd"
             >
             </path>
-            <path fill="url(#paint4_linear_2790_91)"
+            <path fill="url(#paint4_linear_2790_91-:r49:)"
                   fill-rule="evenodd"
                   stroke="#D6D6D6"
                   stroke-linejoin="round"
@@ -7240,21 +7240,21 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   opacity="0.45"
             >
             </path>
-            <path fill="url(#paint5_linear_2790_91)"
+            <path fill="url(#paint5_linear_2790_91-:r49:)"
                   fill-rule="evenodd"
                   d="m28.53 15.68-7.615 15.486h-8.496L10.475 15.68z"
                   clip-rule="evenodd"
                   opacity="0.3"
             >
             </path>
-            <path fill="url(#paint6_linear_2790_91)"
+            <path fill="url(#paint6_linear_2790_91-:r49:)"
                   fill-rule="evenodd"
                   d="M14.31 7.94h6.303l-.465 2.798h7.704l.678 4.942H10.475z"
                   clip-rule="evenodd"
                   opacity="0.2"
             >
             </path>
-            <g filter="url(#filter1_f_2790_91)"
+            <g filter="url(#filter1_f_2790_91-:r49:)"
                opacity="0.8"
             >
               <path fill="#05F0FF"
@@ -7264,7 +7264,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
             </g>
             <g stroke="#06EFFE"
                stroke-width="0.121"
-               filter="url(#filter2_f_2790_91)"
+               filter="url(#filter2_f_2790_91-:r49:)"
             >
               <path fill="#fff"
                     d="M30.336 25.7c.465 0 .843-1.523.843-3.404 0-1.88-.378-3.404-.843-3.404-.466 0-.843 1.524-.843 3.404s.377 3.405.843 3.405Z"
@@ -7277,7 +7277,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               >
               </path>
             </g>
-            <g filter="url(#filter3_f_2790_91)"
+            <g filter="url(#filter3_f_2790_91-:r49:)"
                opacity="0.8"
             >
               <path fill="#05F0FF"
@@ -7287,7 +7287,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
             </g>
             <g stroke="#06EFFE"
                stroke-width="0.121"
-               filter="url(#filter4_f_2790_91)"
+               filter="url(#filter4_f_2790_91-:r49:)"
             >
               <path fill="#fff"
                     d="M18.069 26.243c.465 0 .843-1.524.843-3.404s-.378-3.404-.843-3.404c-.466 0-.843 1.524-.843 3.404s.377 3.404.843 3.404Z"
@@ -7320,7 +7320,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_2790_91"
+              <linearGradient id="paint0_linear_2790_91-:r49:"
                               x1="15879"
                               x2="7153.25"
                               y1="9886.2"
@@ -7334,7 +7334,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_2790_91"
+              <linearGradient id="paint2_linear_2790_91-:r49:"
                               x1="1335.37"
                               x2="-388.258"
                               y1="7261.33"
@@ -7348,7 +7348,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint3_linear_2790_91"
+              <linearGradient id="paint3_linear_2790_91-:r49:"
                               x1="553.171"
                               x2="2265.4"
                               y1="7245.65"
@@ -7362,7 +7362,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint4_linear_2790_91"
+              <linearGradient id="paint4_linear_2790_91-:r49:"
                               x1="15071.6"
                               x2="4611.8"
                               y1="1674.27"
@@ -7376,7 +7376,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint5_linear_2790_91"
+              <linearGradient id="paint5_linear_2790_91-:r49:"
                               x1="3300.65"
                               x2="3300.65"
                               y1="2961.03"
@@ -7396,7 +7396,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint6_linear_2790_91"
+              <linearGradient id="paint6_linear_2790_91-:r49:"
                               x1="3513.09"
                               x2="3513.09"
                               y1="1479.95"
@@ -7411,7 +7411,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <filter id="filter0_f_2790_91"
+              <filter id="filter0_f_2790_91-:r49:"
                       width="39.961"
                       height="17.552"
                       x="4.02"
@@ -7433,7 +7433,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </feGaussianBlur>
               </filter>
-              <filter id="filter1_f_2790_91"
+              <filter id="filter1_f_2790_91-:r49:"
                       width="3.629"
                       height="9.15"
                       x="28.521"
@@ -7455,7 +7455,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </feGaussianBlur>
               </filter>
-              <filter id="filter2_f_2790_91"
+              <filter id="filter2_f_2790_91-:r49:"
                       width="2.312"
                       height="7.434"
                       x="29.18"
@@ -7477,7 +7477,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </feGaussianBlur>
               </filter>
-              <filter id="filter3_f_2790_91"
+              <filter id="filter3_f_2790_91-:r49:"
                       width="3.629"
                       height="9.15"
                       x="16.254"
@@ -7499,7 +7499,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </feGaussianBlur>
               </filter>
-              <filter id="filter4_f_2790_91"
+              <filter id="filter4_f_2790_91-:r49:"
                       width="2.312"
                       height="7.434"
                       x="16.913"
@@ -7521,7 +7521,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </feGaussianBlur>
               </filter>
-              <radialGradient id="paint1_radial_2790_91"
+              <radialGradient id="paint1_radial_2790_91-:r49:"
                               cx="0"
                               cy="0"
                               r="1"
@@ -7637,7 +7637,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1909)">
+            <g clip-path="url(#clip0_1031_1909-:r4d:)">
               <path fill="#184E90"
                     d="M39.81 13.25C41.04 4.77 36.2.25 26 .25c-4.114 0-8.134 2.512-13.06 7.44L5.693 16.04l9.366-6.23C19.468 5.404 22.915 3.25 26 3.25c9.085 0 12.309 3.492 10.538 11.163l-.424 1.837h4.259c3.237.568 4.627 1.988 4.627 4.5s-1.39 3.932-4.627 4.5H31l-3.361 2.98 12.86.02.247-.02C45.424 27.45 48 24.874 48 20.75s-2.576-6.7-7.254-7.48l-.246-.02z"
               >
@@ -7662,7 +7662,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1909">
+              <clipPath id="clip0_1031_1909-:r4d:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -7689,10 +7689,10 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2018)">
+            <g clip-path="url(#clip0_1031_2018-:r4e:)">
               <rect width="48"
                     height="48"
-                    fill="url(#paint0_linear_1031_2018)"
+                    fill="url(#paint0_linear_1031_2018-:r4e:)"
                     rx="10"
               >
               </rect>
@@ -7700,7 +7700,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     height="18"
                     x="23"
                     y="7"
-                    fill="url(#paint1_linear_1031_2018)"
+                    fill="url(#paint1_linear_1031_2018-:r4e:)"
                     rx="4"
               >
               </rect>
@@ -7708,7 +7708,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     height="18"
                     x="14"
                     y="16"
-                    fill="url(#paint2_linear_1031_2018)"
+                    fill="url(#paint2_linear_1031_2018-:r4e:)"
                     rx="4"
               >
               </rect>
@@ -7716,7 +7716,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     height="18"
                     x="7"
                     y="23"
-                    fill="url(#paint3_linear_1031_2018)"
+                    fill="url(#paint3_linear_1031_2018-:r4e:)"
                     rx="4"
               >
               </rect>
@@ -7764,7 +7764,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </circle>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_2018"
+              <linearGradient id="paint0_linear_1031_2018-:r4e:"
                               x1="24"
                               x2="24"
                               y1="0"
@@ -7778,7 +7778,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_2018"
+              <linearGradient id="paint1_linear_1031_2018-:r4e:"
                               x1="32"
                               x2="32"
                               y1="7"
@@ -7792,7 +7792,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1031_2018"
+              <linearGradient id="paint2_linear_1031_2018-:r4e:"
                               x1="23"
                               x2="23"
                               y1="16"
@@ -7806,7 +7806,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint3_linear_1031_2018"
+              <linearGradient id="paint3_linear_1031_2018-:r4e:"
                               x1="16"
                               x2="16"
                               y1="23"
@@ -7820,7 +7820,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_2018">
+              <clipPath id="clip0_1031_2018-:r4e:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -7875,7 +7875,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1958)">
+            <g clip-path="url(#clip0_1031_1958-:r4g:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z"
@@ -7888,7 +7888,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1958">
+              <clipPath id="clip0_1031_1958-:r4g:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -7945,8 +7945,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1992)">
-              <path fill="url(#paint0_linear_1031_1992)"
+            <g clip-path="url(#clip0_1031_1992-:r4i:)">
+              <path fill="url(#paint0_linear_1031_1992-:r4i:)"
                     d="M48 0H0v48h48z"
               >
               </path>
@@ -7956,7 +7956,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1992"
+              <linearGradient id="paint0_linear_1031_1992-:r4i:"
                               x1="-9.939"
                               x2="57.939"
                               y1="57.939"
@@ -7970,7 +7970,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1992">
+              <clipPath id="clip0_1031_1992-:r4i:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8045,7 +8045,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1925)">
+            <g clip-path="url(#clip0_1031_1925-:r4k:)">
               <path fill="#693CC5"
                     d="M48 0H0v48h48z"
               >
@@ -8060,7 +8060,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1925">
+              <clipPath id="clip0_1031_1925-:r4k:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8087,7 +8087,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1896)">
+            <g clip-path="url(#clip0_1031_1896-:r4l:)">
               <path fill="#CC2264"
                     d="M48 0H0v48h48z"
               >
@@ -8110,7 +8110,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1896">
+              <clipPath id="clip0_1031_1896-:r4l:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8137,8 +8137,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1905)">
-              <path fill="url(#paint0_linear_1031_1905)"
+            <g clip-path="url(#clip0_1031_1905-:r4m:)">
+              <path fill="url(#paint0_linear_1031_1905-:r4m:)"
                     d="M48 0H0v48h48z"
               >
               </path>
@@ -8156,7 +8156,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1905"
+              <linearGradient id="paint0_linear_1031_1905-:r4m:"
                               x1="-11.622"
                               x2="59.623"
                               y1="56.072"
@@ -8170,7 +8170,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1905">
+              <clipPath id="clip0_1031_1905-:r4m:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8197,7 +8197,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1941)">
+            <g clip-path="url(#clip0_1031_1941-:r4n:)">
               <path fill="#232F3D"
                     fill-rule="evenodd"
                     d="M44.317 24a2.77 2.77 0 0 0-2.765-2.77A2.77 2.77 0 0 0 38.786 24a2.77 2.77 0 0 0 2.766 2.77A2.77 2.77 0 0 0 44.317 24m-5.284 5.948c-1.75-.747-3.078-2.258-3.633-4.102h-2.144v10.898c2.41-1.638 4.489-4.069 5.777-6.796m-9.464 8.554V24c0-1.02.824-1.846 1.843-1.846H35.4c.562-1.867 1.917-3.388 3.7-4.125-1.705-4.008-4.972-7.918-8.96-9.308a6.45 6.45 0 0 1-4.181 3.901v26.476c1.219-.105 2.53-.307 3.61-.596m-7.297.588V12.622a6.45 6.45 0 0 1-4.187-3.921c-4.061 1.36-7.451 5.348-9.173 9.33 1.779.739 3.132 2.258 3.692 4.123h3.988c1.02 0 1.844.827 1.844 1.846v14.367c1.043.332 2.444.592 3.836.724m-7.524-2.586V25.846h-2.144c-.556 1.848-1.89 3.364-3.646 4.108 1.252 2.52 3.342 4.88 5.79 6.55m-8.296-9.735A2.77 2.77 0 0 0 9.218 24a2.77 2.77 0 0 0-2.766-2.77A2.77 2.77 0 0 0 3.687 24a2.77 2.77 0 0 0 2.765 2.77M21.35 6.462a2.77 2.77 0 0 0 2.765 2.769 2.77 2.77 0 0 0 2.766-2.77 2.77 2.77 0 0 0-2.765-2.769 2.77 2.77 0 0 0-2.766 2.77M48.004 24a6.47 6.47 0 0 1-5.138 6.325c-1.808 4.602-5.396 8.588-9.61 10.678V48h-3.687v-5.706c-1.186.252-2.45.424-3.61.51V48h-3.687v-5.204c-1.239-.1-2.59-.294-3.836-.597V48h-3.688v-7.206c-4.288-2.22-7.929-6.177-9.641-10.478C2.194 29.694 0 27.1 0 24c0-3.089 2.18-5.67 5.073-6.305 2.041-5.553 6.81-11.257 12.798-12.786.7-2.81 3.223-4.909 6.245-4.909 3.025 0 5.552 2.105 6.247 4.922 6.093 1.604 10.608 7.392 12.57 12.773 2.894.637 5.071 3.218 5.071 6.305"
@@ -8206,7 +8206,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1941">
+              <clipPath id="clip0_1031_1941-:r4n:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8233,8 +8233,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1938)">
-              <path fill="url(#paint0_linear_1031_1938)"
+            <g clip-path="url(#clip0_1031_1938-:r4o:)">
+              <path fill="url(#paint0_linear_1031_1938-:r4o:)"
                     d="M48 0H0v48h48z"
               >
               </path>
@@ -8256,7 +8256,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1938"
+              <linearGradient id="paint0_linear_1031_1938-:r4o:"
                               x1="-9.939"
                               x2="57.939"
                               y1="57.939"
@@ -8270,7 +8270,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1938">
+              <clipPath id="clip0_1031_1938-:r4o:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8297,7 +8297,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2012)">
+            <g clip-path="url(#clip0_1031_2012-:r4p:)">
               <path fill="#D86613"
                     d="M48 0H0v48h48z"
               >
@@ -8312,7 +8312,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2012">
+              <clipPath id="clip0_1031_2012-:r4p:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8339,8 +8339,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_3698_16311)">
-              <path fill="url(#paint0_linear_3698_16311)"
+            <g clip-path="url(#clip0_3698_16311-:r4q:)">
+              <path fill="url(#paint0_linear_3698_16311-:r4q:)"
                     d="M48 .5H0v48h48z"
               >
               </path>
@@ -8358,7 +8358,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_3698_16311"
+              <linearGradient id="paint0_linear_3698_16311-:r4q:"
                               x1="-11.622"
                               x2="59.623"
                               y1="56.572"
@@ -8372,7 +8372,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_3698_16311">
+              <clipPath id="clip0_3698_16311-:r4q:">
                 <path fill="#fff"
                       d="M0 .5h48v48H0z"
                 >
@@ -8463,7 +8463,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1926)">
+            <g clip-path="url(#clip0_1031_1926-:r4t:)">
               <path fill="#0F74C3"
                     d="M1 37h4a1 1 0 0 1 1 1v4h36v-4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v7a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3v-7a1 1 0 0 1 1-1"
               >
@@ -8480,7 +8480,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1926">
+              <clipPath id="clip0_1031_1926-:r4t:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -8811,7 +8811,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2039)">
+            <g clip-path="url(#clip0_1031_2039-:r55:)">
               <path fill="#0078D7"
                     d="M0 6a6 6 0 0 1 6-6h36a6 6 0 0 1 6 6v36a6 6 0 0 1-6 6H6a6 6 0 0 1-6-6z"
               >
@@ -9422,7 +9422,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2039">
+              <clipPath id="clip0_1031_2039-:r55:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9449,7 +9449,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1934)">
+            <g clip-path="url(#clip0_1031_1934-:r56:)">
               <path fill="#50E6FF"
                     d="m46.133 21.333 1.6 1.6a1.63 1.63 0 0 1 0 2.134L36 36.8a.8.8 0 0 1-1.067 0l-1.6-1.6a.8.8 0 0 1 0-1.067zM14.667 34.933l-1.6 1.6a.8.8 0 0 1-1.067 0L.533 25.067a1.63 1.63 0 0 1 0-2.134l1.334-1.6 12.8 12.8c0 .267.266.534 0 .8"
               >
@@ -9458,13 +9458,13 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     d="m12.8 11.467 1.6 1.6a.8.8 0 0 1 0 1.066L2.133 26.4l-1.6-1.6a1.63 1.63 0 0 1 0-2.133L12 11.2a.99.99 0 0 1 .8.267M47.467 24.8l-1.6 1.6-12.534-12.533a.8.8 0 0 1 0-1.067l1.6-1.6a.8.8 0 0 1 1.067 0l11.467 11.467a1.63 1.63 0 0 1 0 2.133"
               >
               </path>
-              <path fill="url(#paint0_linear_1031_1934)"
+              <path fill="url(#paint0_linear_1031_1934-:r56:)"
                     d="M22.133 26.4h-9.6a.59.59 0 0 1-.533-.533V25.6L23.467 2.933c.266 0 .266-.266.533-.266h11.2a.586.586 0 0 1 .533.533v.267L22.4 21.333h13.067a.59.59 0 0 1 .533.534c0 .266 0 .266-.267.266L13.867 44.8c-.267 0-1.6 1.333-1.067-.533z"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1934"
+              <linearGradient id="paint0_linear_1031_1934-:r56:"
                               x1="23.344"
                               x2="23.344"
                               y1="44.504"
@@ -9490,7 +9490,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1934">
+              <clipPath id="clip0_1031_1934-:r56:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9517,7 +9517,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1897)">
+            <g clip-path="url(#clip0_1031_1897-:r57:)">
               <path fill="#0072C6"
                     fill-rule="evenodd"
                     d="M12.075 17.27 26.225 5 10.887 38.945H0zm9.994 7.622 6.039-17.021L48 43.3H11.184l22.464-3.86z"
@@ -9526,7 +9526,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1897">
+              <clipPath id="clip0_1031_1897-:r57:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9553,14 +9553,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2000)">
+            <g clip-path="url(#clip0_1031_2000-:r58:)">
               <path fill="#59B4D9"
                     d="m19.315 35.143 2.693-6.55h5.89c2.16 0 4.066-1.541 4.387-3.678a4.352 4.352 0 0 0-4.29-5.001H8.466l10.85-10.849v4.245h8.647c5.165 0 10.14 4.16 10.882 9.272A10.85 10.85 0 0 1 28.558 35.07l8.879 8.88a24 24 0 1 0-13.682 4.293c2.55.003 5.082-.415 7.496-1.237z"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2000">
+              <clipPath id="clip0_1031_2000-:r58:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9587,7 +9587,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2015)">
+            <g clip-path="url(#clip0_1031_2015-:r59:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z"
@@ -9600,7 +9600,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2015">
+              <clipPath id="clip0_1031_2015-:r59:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9638,7 +9638,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1979)">
+            <g clip-path="url(#clip0_1031_1979-:r5b:)">
               <path fill="#fff"
                     d="M25.694 6.717c4.11.456 7.66 2.09 10.579 5.009s4.554 6.467 5.01 10.58h6.715C47.308 10.539 37.592.713 25.694 0zm0 34.568v6.712C37.376 47.329 47.261 37.675 48 25.693h-6.715c-.456 4.11-2.09 7.659-5.008 10.579s-6.468 4.555-10.578 5.012zM6.717 22.306c.455-4.109 2.088-7.655 5.007-10.577s6.48-4.56 10.584-5.012V.005C10.701.667.742 10.248 0 22.306zM.004 25.694c.67 11.686 10.32 21.565 22.302 22.304v-6.715c-4.11-.456-7.658-2.09-10.578-5.008s-4.555-6.467-5.01-10.58zM13.96 35.64c5.758 5.127 14.697 4.877 20.064.008l-4.012-4.013q-6.019 4.137-12.038-.012zm2.43-17.624-4.045-4.044c-5.35 6.084-4.606 15.07.006 20.034l4.035-4.033a9.66 9.66 0 0 1 .004-11.957m17.655-5.646c-5.586-5.019-14.523-5-20.077-.01l4.01 4.016q6.038-4.152 12.054.007z"
               >
@@ -9661,7 +9661,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1979">
+              <clipPath id="clip0_1031_1979-:r5b:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -9714,7 +9714,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2002)">
+            <g clip-path="url(#clip0_1031_2002-:r5d:)">
               <path fill="#91DC47"
                     fill-rule="evenodd"
                     d="M11.315 24.002c.004-4.293 2.14-8.079 5.395-10.373.712.412 1.36.898 1.89 1.455 1.048 1.07 2.217 3.432 3.029 5.468.208.512.403 1.03.594 1.55-.893 1.816-1.695 3.354-2.401 4.707-1.608 3.084-2.715 5.206-3.257 7.463a12.7 12.7 0 0 1-5.25-10.27m10.917 2.149q.38-.863.775-1.718c1.505 5.359 2.458 8.546 4.162 10.722.259.327.54.612.834.884-1.292.431-2.643.649-4.003.653-1.491 0-2.97-.267-4.37-.78a14 14 0 0 1-.046-1.029c0-.834.086-1.582.227-2.19.39-1.7 1.455-4.357 2.42-6.542"
@@ -9735,7 +9735,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2002">
+              <clipPath id="clip0_1031_2002-:r5d:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9764,7 +9764,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           >
             <g fill="#2151CD"
                fill-rule="evenodd"
-               clip-path="url(#clip0_3578_76)"
+               clip-path="url(#clip0_3578_76-:r5e:)"
                clip-rule="evenodd"
             >
               <path d="M29.396.945a.5.5 0 0 1 .7.097l17.281 22.86a1 1 0 0 1-.013 1.224L30.075 47.003a.5.5 0 0 1-.702.082l-2.746-2.17a.5.5 0 0 1-.082-.702l15.372-19.451a.5.5 0 0 0 .006-.612L26.507 3.756a.5.5 0 0 1 .097-.7z">
@@ -9775,7 +9775,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_3578_76">
+              <clipPath id="clip0_3578_76-:r5e:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9802,46 +9802,46 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1902)">
-              <path fill="url(#paint0_linear_1031_1902)"
+            <g clip-path="url(#clip0_1031_1902-:r5f:)">
+              <path fill="url(#paint0_linear_1031_1902-:r5f:)"
                     d="M12.345 2.623 18 12.825l-5.193 9.348a3 3 0 0 0 0 2.92L18 34.465l-5.655 10.202a6 6 0 0 1-2.539-2.39L.804 26.64a6.02 6.02 0 0 1 0-6.002L9.806 5a6 6 0 0 1 2.54-2.377"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1902)"
+              <path fill="url(#paint1_linear_1031_1902-:r5f:)"
                     d="M12.807 22.185a3 3 0 0 0 0 2.908L18 34.465l-5.655 10.202a6 6 0 0 1-2.539-2.39L.805 26.64c-.716-1.235 3.289-2.712 12.002-4.443z"
                     opacity="0.7"
               >
               </path>
-              <path fill="url(#paint2_linear_1031_1902)"
+              <path fill="url(#paint2_linear_1031_1902-:r5f:)"
                     d="M12.923 3.65 18 12.825l-.843 1.466-4.478-7.582c-1.292-2.112-3.266-1.016-5.736 3.254l.37-.635L9.806 5a6 6 0 0 1 2.516-2.377l.589 1.027z"
                     opacity="0.5"
               >
               </path>
-              <path fill="url(#paint3_linear_1031_1902)"
+              <path fill="url(#paint3_linear_1031_1902-:r5f:)"
                     d="M38.197 5 47.2 20.64a6 6 0 0 1 0 6l-9.002 15.639a6 6 0 0 1-5.193 3h-9.002l11.195-20.185a3 3 0 0 0 0-2.908L24.002 2h9.002a6 6 0 0 1 5.193 3"
               >
               </path>
-              <path fill="url(#paint4_linear_1031_1902)"
+              <path fill="url(#paint4_linear_1031_1902-:r5f:)"
                     d="m32.542 45.21-8.887.08 10.756-20.289a3.12 3.12 0 0 0 0-2.931L23.655 2h2.031l11.288 19.977c.544.96.54 2.137-.012 3.093q-3.644 6.333-7.236 12.695c-2.193 3.855-1.247 6.336 2.816 7.444"
               >
               </path>
-              <path fill="url(#paint5_linear_1031_1902)"
+              <path fill="url(#paint5_linear_1031_1902-:r5f:)"
                     d="M15 45.279c-.924 0-1.847-.22-2.655-.612l11.103-20.024a2.07 2.07 0 0 0 0-2.008L12.345 2.623A6 6 0 0 1 15 2h9.002l11.194 20.185a3 3 0 0 1 0 2.908L24.002 45.28z"
               >
               </path>
-              <path fill="url(#paint6_linear_1031_1902)"
+              <path fill="url(#paint6_linear_1031_1902-:r5f:)"
                     d="M34.412 22.635 22.961 2h1.04l11.194 20.185a3 3 0 0 1 0 2.908L24.002 45.28h-1.04l11.45-20.636a2.07 2.07 0 0 0 0-2.008"
                     opacity="0.6"
               >
               </path>
-              <path fill="url(#paint7_linear_1031_1902)"
+              <path fill="url(#paint7_linear_1031_1902-:r5f:)"
                     d="M23.448 22.635 12.345 2.623c.346-.185.762-.323 1.154-.438 2.447 4.397 6.06 11.067 10.849 20a3 3 0 0 1 0 2.908L13.326 45.048a6 6 0 0 1-.97-.37l11.08-20.023a2.07 2.07 0 0 0 0-2.008z"
                     opacity="0.6"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1902"
+              <linearGradient id="paint0_linear_1031_1902-:r5f:"
                               x1="17.218"
                               x2="-15.151"
                               y1="16.786"
@@ -9855,7 +9855,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1902"
+              <linearGradient id="paint1_linear_1031_1902-:r5f:"
                               x1="23.113"
                               x2="9.051"
                               y1="33.294"
@@ -9870,7 +9870,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1031_1902"
+              <linearGradient id="paint2_linear_1031_1902-:r5f:"
                               x1="7.551"
                               x2="13.12"
                               y1="6.367"
@@ -9885,7 +9885,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint3_linear_1031_1902"
+              <linearGradient id="paint3_linear_1031_1902-:r5f:"
                               x1="46.96"
                               x2="15.568"
                               y1="28.183"
@@ -9899,7 +9899,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint4_linear_1031_1902"
+              <linearGradient id="paint4_linear_1031_1902-:r5f:"
                               x1="-76.237"
                               x2="95.316"
                               y1="314.305"
@@ -9921,7 +9921,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint5_linear_1031_1902"
+              <linearGradient id="paint5_linear_1031_1902-:r5f:"
                               x1="34.562"
                               x2="2.748"
                               y1="27.022"
@@ -9935,7 +9935,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint6_linear_1031_1902"
+              <linearGradient id="paint6_linear_1031_1902-:r5f:"
                               x1="-35.98"
                               x2="95.585"
                               y1="227.826"
@@ -9952,7 +9952,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint7_linear_1031_1902"
+              <linearGradient id="paint7_linear_1031_1902-:r5f:"
                               x1="-72.421"
                               x2="96.615"
                               y1="339.024"
@@ -9969,7 +9969,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1902">
+              <clipPath id="clip0_1031_1902-:r5f:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -9996,7 +9996,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1937)">
+            <g clip-path="url(#clip0_1031_1937-:r5g:)">
               <path fill="#FA2A00"
                     d="M47.878 45.878a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h43.878a2 2 0 0 1 2 2z"
               >
@@ -10007,7 +10007,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1937">
+              <clipPath id="clip0_1031_1937-:r5g:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10035,7 +10035,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#173361"
-               clip-path="url(#clip0_1031_2006)"
+               clip-path="url(#clip0_1031_2006-:r5h:)"
             >
               <path d="M31.339 23.222c-2.15-.065-4.31-.09-6.46-.102 0-2.149-.012-4.31-.076-6.459l-.1-3.675q-.031-.615-.056-1.231c-.038-.815-.073-1.63-.132-2.44H23.48c-.058.81-.094 1.625-.131 2.44q-.026.616-.057 1.23l-.102 3.669c-.025.992-.037 2-.05 2.992v.037c-.117-.272-.232-.533-.355-.814-.283-.657-.564-1.313-.858-1.957l-1.496-3.343q-.303-.641-.601-1.282c-.318-.682-.637-1.365-.97-2.035l-.955.402c.278.822.575 1.638.872 2.456l.356.997 1.323 3.435c.365.94.742 1.883 1.12 2.814-.713-.712-1.445-1.407-2.175-2.112l-2.668-2.526q-.458-.412-.913-.829c-.597-.548-1.197-1.097-1.814-1.631l-.73.73c.47.533.952 1.067 1.436 1.6.343.376.689.751 1.028 1.133l2.525 2.669q1.037 1.097 2.111 2.174l-.631-.265c-.73-.294-1.454-.584-2.187-.869l-3.431-1.305-.996-.356c-.82-.297-1.637-.594-2.459-.872l-.395.96c.69.355 1.39.673 2.09.997q.615.284 1.228.573l3.343 1.496c.649.294 1.305.575 1.956.857l.813.356h-.037c-.994.013-2 .025-2.992.05l-3.668.101q-.615.032-1.231.057c-.815.038-1.63.073-2.44.132v1.03c.81.059 1.625.094 2.44.13q.616.028 1.23.059l3.669.1c1.79.052 3.588.061 5.38.07h1.068c.013 2.147.025 4.305.102 6.452l.112 3.668q.03.615.057 1.231c.037.813.073 1.63.131 2.44h.943c.059-.81.094-1.627.13-2.44q.028-.616.059-1.23l.112-3.669c.037-1.024.051-2.061.064-3.086v-.018l.272.628c.318.74.637 1.475.97 2.208l1.508 3.342c.178.369.356.739.521 1.108.347.739.692 1.479 1.067 2.208l.867-.356c-.239-.711-.491-1.423-.742-2.124-.16-.448-.32-.89-.477-1.343l-1.295-3.431a89 89 0 0 0-1.13-2.89l.56.533c.554.533 1.111 1.078 1.675 1.6l2.668 2.514.817.744c.63.576 1.26 1.154 1.909 1.708l.667-.667c-.573-.662-1.16-1.306-1.744-1.948l-.711-.78-2.512-2.668q-.8-.844-1.601-1.675l-.543-.56 1.068.417q.911.365 1.825.712l3.431 1.295c.427.147.854.302 1.28.457.725.261 1.451.525 2.188.761l.355-.866c-.73-.37-1.467-.712-2.207-1.067q-.56-.26-1.11-.523l-3.343-1.507a130 130 0 0 0-2.846-1.245h.06c1.025-.013 2.06-.025 3.085-.063l3.668-.112q.615-.03 1.231-.058a85 85 0 0 0 2.439-.13v-.943c-.81-.059-1.624-.094-2.439-.132q-.616-.025-1.231-.057z">
               </path>
@@ -10046,7 +10046,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2006">
+              <clipPath id="clip0_1031_2006-:r5h:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10073,7 +10073,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_2566_140)">
+            <g clip-path="url(#clip0_2566_140-:r5i:)">
               <path fill="#F4FFA0"
                     d="M23.853 47.85c13.174 0 23.853-10.711 23.853-23.925S37.027 0 23.853 0 0 10.71 0 23.925s10.68 23.924 23.853 23.924"
               >
@@ -10092,7 +10092,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_2566_140">
+              <clipPath id="clip0_2566_140-:r5i:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10119,7 +10119,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1911)">
+            <g clip-path="url(#clip0_1031_1911-:r5j:)">
               <path fill="#9A4993"
                     d="M45.68 14.1c0-.801-.172-1.524-.526-2.13q-.513-.906-1.539-1.498C37.935 7.198 32.242 3.924 26.562.65c-1.539-.88-3.011-.855-4.536.04C19.764 2.017 8.43 8.512 5.064 10.471 3.671 11.274 3 12.51 3 14.114v19.775c0 .789.17 1.486.5 2.09.342.619.867 1.145 1.564 1.552 3.38 1.96 14.7 8.441 16.962 9.782 1.525.894 3.01.934 4.536.04 5.68-3.287 11.373-6.548 17.053-9.822.71-.407 1.223-.92 1.565-1.551.328-.605.5-1.302.5-2.091z"
               >
@@ -10150,7 +10150,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1911">
+              <clipPath id="clip0_1031_1911-:r5j:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10211,7 +10211,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           >
             <g fill="#03020D"
                fill-rule="evenodd"
-               clip-path="url(#clip0_1031_2010)"
+               clip-path="url(#clip0_1031_2010-:r5l:)"
                clip-rule="evenodd"
             >
               <path d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z">
@@ -10220,7 +10220,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2010">
+              <clipPath id="clip0_1031_2010-:r5l:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10419,7 +10419,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1955)">
+            <g clip-path="url(#clip0_1031_1955-:r5r:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z"
@@ -10432,7 +10432,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1955">
+              <clipPath id="clip0_1031_1955-:r5r:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10460,7 +10460,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1948)"
+               clip-path="url(#clip0_1031_1948-:r5s:)"
             >
               <path d="M24.51 47a1 1 0 0 1-1 1h-.02a1 1 0 0 1-1-1V36.879l-3.783 3.782a1 1 0 0 1-1.414 0l-.02-.02a1 1 0 0 1 0-1.414l5.52-5.52a1 1 0 0 1 1.414 0l5.586 5.586a1 1 0 0 1 0 1.414l-.02.02a1 1 0 0 1-1.414 0L24.51 36.88z">
               </path>
@@ -10480,7 +10480,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1948">
+              <clipPath id="clip0_1031_1948-:r5s:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10533,7 +10533,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2005)">
+            <g clip-path="url(#clip0_1031_2005-:r5u:)">
               <path fill="#05988A"
                     d="M24 0C10.75 0 0 10.75 0 24s10.75 24 24 24 24-10.75 24-24S37.25 0 24 0m-1.25 43.239V28.184h-8.37L26.406 4.762v15.054h8.056z"
               >
@@ -10544,7 +10544,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2005">
+              <clipPath id="clip0_1031_2005-:r5u:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10596,7 +10596,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1964)"
+               clip-path="url(#clip0_1031_1964-:r60:)"
             >
               <path fill-rule="evenodd"
                     d="M24 46c12.15 0 22-9.85 22-22S36.15 2 24 2 2 11.85 2 24s9.85 22 22 22m0 2c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24"
@@ -10607,7 +10607,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1964">
+              <clipPath id="clip0_1031_1964-:r60:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10634,7 +10634,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2016)">
+            <g clip-path="url(#clip0_1031_2016-:r61:)">
               <path fill="#FFA000"
                     d="M24.918 7.643c-.585-1.034-1.522-1.05-2.122 0l-2.309 5.173 4.454 8.99 4.805-4.47z"
               >
@@ -10653,7 +10653,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2016">
+              <clipPath id="clip0_1031_2016-:r61:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10680,7 +10680,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2004)">
+            <g clip-path="url(#clip0_1031_2004-:r62:)">
               <path fill="#FFA000"
                     d="M24.918 7.643c-.585-1.034-1.522-1.05-2.122 0l-2.309 5.173 4.454 8.99 4.805-4.47z"
               >
@@ -10715,7 +10715,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2004">
+              <clipPath id="clip0_1031_2004-:r62:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10742,7 +10742,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1893)">
+            <g clip-path="url(#clip0_1031_1893-:r63:)">
               <path fill="#0D47A1"
                     d="M22.463 42.463 28 48h14.781L29.855 35.074"
               >
@@ -10758,17 +10758,17 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     d="m15.09 35.077 7.38-7.382 7.379 7.38-7.38 7.382z"
               >
               </path>
-              <path fill="url(#paint0_linear_1031_1893)"
+              <path fill="url(#paint0_linear_1031_1893-:r63:)"
                     d="m22.47 42.458 7.379-7.38 1.03 1.03-7.38 7.38z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1893)"
+              <path fill="url(#paint1_linear_1031_1893-:r63:)"
                     d="m22.463 42.463 10.967-3.789-3.575-3.602"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1893"
+              <linearGradient id="paint0_linear_1031_1893-:r63:"
                               x1="25.645"
                               x2="26.676"
                               y1="39.281"
@@ -10785,7 +10785,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1893"
+              <linearGradient id="paint1_linear_1031_1893-:r63:"
                               x1="22.466"
                               x2="33.433"
                               y1="42.463"
@@ -10802,7 +10802,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1893">
+              <clipPath id="clip0_1031_1893-:r63:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -10879,7 +10879,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_3013_13)"
+            <path fill="url(#paint0_linear_3013_13-:r65:)"
                   d="M10.422 43.254.578 26.336a4.25 4.25 0 0 1 0-4.279L10.422 5.14A4.32 4.32 0 0 1 14.156 3h19.688c1.54 0 2.964.816 3.734 2.14l9.844 16.917a4.25 4.25 0 0 1 0 4.28l-9.844 16.917a4.32 4.32 0 0 1-3.734 2.14H14.156a4.32 4.32 0 0 1-3.734-2.14"
             >
             </path>
@@ -10921,7 +10921,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3013_13"
+              <linearGradient id="paint0_linear_3013_13-:r65:"
                               x1="0.037"
                               x2="0.037"
                               y1="3"
@@ -10956,7 +10956,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1998)">
+            <g clip-path="url(#clip0_1031_1998-:r66:)">
               <path fill="#EA4335"
                     d="m31.932 15.653 4.172-4.173.278-1.756C28.78 2.81 16.694 3.594 9.839 11.36c-1.905 2.156-3.316 4.845-4.069 7.623l1.494-.211 8.344-1.376.644-.658c3.71-4.077 9.989-4.625 14.273-1.157z"
               >
@@ -10975,7 +10975,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1998">
+              <clipPath id="clip0_1031_1998-:r66:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11002,7 +11002,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_1031_1898)"
+            <path fill="url(#paint0_linear_1031_1898-:r67:)"
                   d="M10.422 43.568.578 26.518a4.31 4.31 0 0 1 0-4.312l9.844-17.05A4.31 4.31 0 0 1 14.156 3h19.688c1.54 0 2.964.822 3.734 2.156l9.844 17.05a4.31 4.31 0 0 1 0 4.312l-9.844 17.05a4.31 4.31 0 0 1-3.734 2.157H14.156a4.31 4.31 0 0 1-3.734-2.157"
             >
             </path>
@@ -11066,7 +11066,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
             >
             </circle>
             <defs>
-              <linearGradient id="paint0_linear_1031_1898"
+              <linearGradient id="paint0_linear_1031_1898-:r67:"
                               x1="0.037"
                               x2="0.037"
                               y1="3"
@@ -11133,12 +11133,12 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1927)">
-              <path fill="url(#paint0_linear_1031_1927)"
+            <g clip-path="url(#clip0_1031_1927-:r69:)">
+              <path fill="url(#paint0_linear_1031_1927-:r69:)"
                     d="M31.75 3.25h9.75V13h-9.75z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1927)"
+              <path fill="url(#paint1_linear_1031_1927-:r69:)"
                     d="M6 0h16.5v16.5H6z"
               >
               </path>
@@ -11148,7 +11148,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1927"
+              <linearGradient id="paint0_linear_1031_1927-:r69:"
                               x1="31.75"
                               x2="42.853"
                               y1="13"
@@ -11162,7 +11162,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1927"
+              <linearGradient id="paint1_linear_1031_1927-:r69:"
                               x1="6"
                               x2="24.79"
                               y1="16.5"
@@ -11176,7 +11176,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1927">
+              <clipPath id="clip0_1031_1927-:r69:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11203,7 +11203,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1974)">
+            <g clip-path="url(#clip0_1031_1974-:r6a:)">
               <path fill="#FCC414"
                     d="M24.016 44.396c11.307 0 20.473-9.166 20.473-20.473 0-11.308-9.166-20.474-20.473-20.474-11.308 0-20.474 9.166-20.474 20.474s9.166 20.473 20.474 20.473"
               >
@@ -11232,7 +11232,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1974">
+              <clipPath id="clip0_1031_1974-:r6a:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -11260,7 +11260,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1995)"
+               clip-path="url(#clip0_1031_1995-:r6b:)"
             >
               <path fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v6h44V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v8h48V4a4 4 0 0 0-4-4z"
@@ -11276,7 +11276,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1995">
+              <clipPath id="clip0_1031_1995-:r6b:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11304,7 +11304,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1961)"
+               clip-path="url(#clip0_1031_1961-:r6c:)"
             >
               <path fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v6h44V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v8h48V4a4 4 0 0 0-4-4z"
@@ -11320,7 +11320,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1961">
+              <clipPath id="clip0_1031_1961-:r6c:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11348,7 +11348,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_2038)"
+               clip-path="url(#clip0_1031_2038-:r6d:)"
             >
               <path fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v6h44V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v8h48V4a4 4 0 0 0-4-4z"
@@ -11364,7 +11364,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2038">
+              <clipPath id="clip0_1031_2038-:r6d:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11392,7 +11392,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_2025)"
+               clip-path="url(#clip0_1031_2025-:r6e:)"
             >
               <path fill-rule="evenodd"
                     d="M46 24c0-6.075-4.925-11-11-11s-11 4.925-11 11 4.925 11 11 11 11-4.925 11-11m2 0c0-7.18-5.82-13-13-13s-13 5.82-13 13 5.82 13 13 13 13-5.82 13-13"
@@ -11410,7 +11410,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2025">
+              <clipPath id="clip0_1031_2025-:r6e:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -11487,7 +11487,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_2352_19)">
+            <g clip-path="url(#clip0_2352_19-:r6h:)">
               <rect width="48"
                     height="48"
                     fill="#A5B1B7"
@@ -11500,7 +11500,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_2352_19">
+              <clipPath id="clip0_2352_19-:r6h:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11527,7 +11527,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1969)">
+            <g clip-path="url(#clip0_1031_1969-:r6i:)">
               <path fill="#A5B1B7"
                     fill-rule="evenodd"
                     d="M33.777 0c.319 2.809-.838 5.634-2.555 7.663-1.716 2.029-4.528 3.605-7.283 3.396-.38-2.752 1.015-5.628 2.604-7.423C28.315 1.608 31.305.096 33.777 0M27.18 12.987c1.81-.7 4.059-1.57 6.538-1.39 1.584.115 6.085.577 8.998 4.769l-.02.012c-.418.248-5.344 3.17-5.288 9.122.065 7.264 6.519 9.684 6.592 9.711l-.014.044c-.136.431-1.126 3.558-3.388 6.783-2.048 2.928-4.17 5.839-7.518 5.9-1.607.029-2.682-.426-3.8-.898-1.17-.495-2.386-1.01-4.308-1.01-2.015 0-3.288.53-4.514 1.041-1.063.443-2.09.87-3.535.926-3.232.12-5.693-3.162-7.756-6.074-4.217-5.96-7.442-16.842-3.113-24.186 2.15-3.647 5.993-5.96 10.162-6.018 1.8-.033 3.542.641 5.067 1.232 1.165.45 2.204.853 3.045.853.741 0 1.71-.375 2.852-.817"
@@ -11536,7 +11536,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1969">
+              <clipPath id="clip0_1031_1969-:r6i:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11563,7 +11563,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1999)">
+            <g clip-path="url(#clip0_1031_1999-:r6j:)">
               <path fill="#888"
                     fill-rule="evenodd"
                     d="M33.777 0c.319 2.809-.838 5.634-2.555 7.663-1.716 2.029-4.528 3.605-7.283 3.396-.38-2.752 1.015-5.628 2.604-7.423C28.315 1.608 31.305.096 33.777 0M27.18 12.987c1.81-.7 4.059-1.57 6.538-1.39 1.584.115 6.085.577 8.998 4.769l-.02.012c-.418.248-5.344 3.17-5.288 9.122.065 7.264 6.519 9.684 6.592 9.711l-.014.044c-.136.431-1.126 3.558-3.388 6.783-2.048 2.928-4.17 5.839-7.518 5.9-1.607.029-2.682-.426-3.8-.898-1.17-.495-2.386-1.01-4.308-1.01-2.015 0-3.288.53-4.514 1.041-1.063.443-2.09.87-3.535.926-3.232.12-5.693-3.162-7.756-6.074-4.217-5.96-7.442-16.842-3.113-24.186 2.15-3.647 5.993-5.96 10.162-6.018 1.8-.033 3.542.641 5.067 1.232 1.165.45 2.204.853 3.045.853.741 0 1.71-.375 2.852-.817"
@@ -11572,7 +11572,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1999">
+              <clipPath id="clip0_1031_1999-:r6j:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11645,14 +11645,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1940)">
+            <g clip-path="url(#clip0_1031_1940-:r6l:)">
               <path fill="#3177BC"
                     d="M43.792 10.705 26.011.427a3.45 3.45 0 0 0-3.502 0L4.73 10.705C3.681 11.342 3 12.479 3 13.707v20.51c0 1.227.682 2.41 1.728 3L22.51 47.496a3.4 3.4 0 0 0 1.728.455c.591 0 1.228-.182 1.728-.455l17.827-10.232a3.46 3.46 0 0 0 1.728-3.001V13.706a3.46 3.46 0 0 0-1.728-3.001m-9.914 16.872a.72.72 0 0 1 .591.59l.455 4.185c0 .182-.045.409-.182.545a.73.73 0 0 1-.5.228H14.278a.73.73 0 0 1-.5-.228c-.137-.136-.182-.363-.182-.545l.455-4.184a.676.676 0 0 1 .59-.591l5.594-.819v-5.457l-5.593-.864a.725.725 0 0 1-.591-.591l-.455-4.184c0-.182.045-.41.182-.546a.73.73 0 0 1 .5-.227h19.964a.73.73 0 0 1 .5.227c.137.137.182.364.182.546l-.455 4.184a.676.676 0 0 1-.59.59l-5.594.82v5.457z"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1940">
+              <clipPath id="clip0_1031_1940-:r6l:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11679,7 +11679,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1923)"
+            <g clip-path="url(#clip0_1031_1923-:r6m:)"
                clip-rule="evenodd"
             >
               <path fill="#0B6FB6"
@@ -11724,7 +11724,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1923">
+              <clipPath id="clip0_1031_1923-:r6m:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11751,7 +11751,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1922)">
+            <g clip-path="url(#clip0_1031_1922-:r6n:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -11762,7 +11762,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1922">
+              <clipPath id="clip0_1031_1922-:r6n:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11789,7 +11789,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2034)">
+            <g clip-path="url(#clip0_1031_2034-:r6o:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z"
@@ -11802,7 +11802,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2034">
+              <clipPath id="clip0_1031_2034-:r6o:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11829,7 +11829,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_4810_1924)">
+            <g clip-path="url(#clip0_4810_1924-:r6p:)">
               <path stroke="currentColor"
                     stroke-linecap="round"
                     stroke-width="3"
@@ -11842,7 +11842,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_4810_1924">
+              <clipPath id="clip0_4810_1924-:r6p:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11920,7 +11920,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#F07D3C"
-               clip-path="url(#clip0_1031_1931)"
+               clip-path="url(#clip0_1031_1931-:r6r:)"
             >
               <path d="M42.621 11h4.672a.5.5 0 0 1 .353.854L36.061 23.439a1.5 1.5 0 0 0 0 2.122l11.585 11.585a.5.5 0 0 1-.353.854H42.62a1.5 1.5 0 0 1-1.06-.44l-12-12a1.5 1.5 0 0 1 0-2.12l12-12a1.5 1.5 0 0 1 1.06-.44M5.379 11H.707a.5.5 0 0 0-.353.854l11.585 11.585a1.5 1.5 0 0 1 0 2.122L.354 37.146A.5.5 0 0 0 .707 38H5.38a1.5 1.5 0 0 0 1.06-.44l12-12a1.5 1.5 0 0 0 0-2.12l-12-12A1.5 1.5 0 0 0 5.38 11">
               </path>
@@ -11933,7 +11933,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </rect>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1931">
+              <clipPath id="clip0_1031_1931-:r6r:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -11960,22 +11960,22 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1914)">
-              <path fill="url(#paint0_linear_1031_1914)"
+            <g clip-path="url(#clip0_1031_1914-:r6s:)">
+              <path fill="url(#paint0_linear_1031_1914-:r6s:)"
                     d="M24.1 0 0 25.344V48l24.065-24.107L48 0z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1914)"
+              <path fill="url(#paint1_linear_1031_1914-:r6s:)"
                     d="m0 48 24.065-24.107L48 48z"
               >
               </path>
-              <path fill="url(#paint2_linear_1031_1914)"
+              <path fill="url(#paint2_linear_1031_1914-:r6s:)"
                     d="M0 0h24.1L0 25.344z"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1914"
+              <linearGradient id="paint0_linear_1031_1914-:r6s:"
                               x1="14.252"
                               x2="58.919"
                               y1="66.464"
@@ -12003,7 +12003,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1914"
+              <linearGradient id="paint1_linear_1031_1914-:r6s:"
                               x1="36.994"
                               x2="43.459"
                               y1="62.127"
@@ -12023,7 +12023,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1031_1914"
+              <linearGradient id="paint2_linear_1031_1914-:r6s:"
                               x1="6.685"
                               x2="22.686"
                               y1="21.279"
@@ -12043,7 +12043,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1914">
+              <clipPath id="clip0_1031_1914-:r6s:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -12150,8 +12150,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1967)">
-              <path fill="url(#paint0_linear_1031_1967)"
+            <g clip-path="url(#clip0_1031_1967-:r70:)">
+              <path fill="url(#paint0_linear_1031_1967-:r70:)"
                     d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24"
               >
               </path>
@@ -12169,7 +12169,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1967"
+              <linearGradient id="paint0_linear_1031_1967-:r70:"
                               x1="24"
                               x2="24"
                               y1="0"
@@ -12183,7 +12183,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1967">
+              <clipPath id="clip0_1031_1967-:r70:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -12329,7 +12329,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1954)"
+               clip-path="url(#clip0_1031_1954-:r73:)"
             >
               <path fill-rule="evenodd"
                     d="M44 34H4a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2M4 32a4 4 0 0 0-4 4v8a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4v-8a4 4 0 0 0-4-4z"
@@ -12352,7 +12352,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1954">
+              <clipPath id="clip0_1031_1954-:r73:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -12379,7 +12379,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1993)">
+            <g clip-path="url(#clip0_1031_1993-:r74:)">
               <path fill="#888"
                     fill-rule="evenodd"
                     d="M33.777 0c.319 2.809-.838 5.634-2.555 7.663-1.716 2.029-4.528 3.605-7.283 3.396-.38-2.752 1.015-5.628 2.604-7.423C28.315 1.608 31.305.096 33.777 0M27.18 12.987c1.81-.7 4.059-1.57 6.538-1.39 1.584.115 6.085.577 8.998 4.769l-.02.012c-.418.248-5.344 3.17-5.288 9.122.065 7.264 6.519 9.684 6.592 9.711l-.014.044c-.136.431-1.126 3.558-3.388 6.783-2.048 2.928-4.17 5.839-7.518 5.9-1.607.029-2.682-.426-3.8-.898-1.17-.495-2.386-1.01-4.308-1.01-2.015 0-3.288.53-4.514 1.041-1.063.443-2.09.87-3.535.926-3.232.12-5.693-3.162-7.756-6.074-4.217-5.96-7.442-16.842-3.113-24.186 2.15-3.647 5.993-5.96 10.162-6.018 1.8-.033 3.542.641 5.067 1.232 1.165.45 2.204.853 3.045.853.741 0 1.71-.375 2.852-.817"
@@ -12388,7 +12388,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1993">
+              <clipPath id="clip0_1031_1993-:r74:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -12439,7 +12439,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2040)">
+            <g clip-path="url(#clip0_1031_2040-:r76:)">
               <path fill="#FF6A3E"
                     fill-rule="evenodd"
                     d="M47.616 32.075c-.749.804-1.727.114-1.727.114L24.02 8.645l23.77 21.823s.575.804-.173 1.608m-2.446-7.63-9.912-10.704 10.852 9.896s.285.377-.086.754c-.37.376-.854.054-.854.054m1.621 14.201c-1.071 1.152-2.47.166-2.47.166L13.015 5.11l34.022 31.235s.824 1.151-.247 2.301m-3.212 5.673c-1.071 1.15-2.472.164-2.472.164L0 1l43.826 41.017s.823 1.15-.247 2.302m-5.931 3.123c-1.072 1.15-2.472.165-2.472.165L3.872 13.905 37.895 45.14s.823 1.151-.247 2.302m-7.167.086c-.748.804-1.726.115-1.726.115L6.885 24.098l23.77 21.822s.574.805-.174 1.608m-7.358-1.93c-.37.377-.853.054-.853.054l-9.912-10.704 10.851 9.896s.284.377-.086.754"
@@ -12448,7 +12448,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2040">
+              <clipPath id="clip0_1031_2040-:r76:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -12499,14 +12499,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1981)">
+            <g clip-path="url(#clip0_1031_1981-:r78:)">
               <path fill="#333"
                     d="M4.067 47.862c0-.3 10.023-12.344 10.235-12.298.12.026 4.597 1.928 9.947 4.226 9.138 3.925 9.745 4.157 9.992 3.826.373-.5 1.66-3.193 2.341-4.898l.578-1.447-.973-.532c-1.38-.753-3.402-2.433-4.668-3.876-1.156-1.316-3.24-4.492-3.24-4.937 0-.147.662.522 1.471 1.487 2.274 2.71 7.515 6.951 7.844 6.348.39-.716.643-2.83.63-5.28-.015-2.992-.407-5.32-1.437-8.534l-.577-1.801-2.852-.897-3.495-1.098c-1.232-.388-.461-.367 1.343.036 2.157.482 4.348.889 5.705 1.06 1.195.15 1.458-.085 1.585-1.414.163-1.695-.93-6.377-2.034-8.707-.44-.93-.64-1.131-1.521-1.535-2.936-1.344-12.124-2.603-16.026-2.195-1.686.176-3.419.586-3.959.936-.152.1.936.38 2.809.724 1.68.309 2.906.591 2.722.627s-2.825-.254-5.87-.645c-5.347-.686-5.55-.698-5.923-.361-.776.702-1.893 2.623-2.123 3.65-.223.995-.207 1.11.288 2.123.844 1.726 2.414 2.981 5.987 4.788 1.69.855 3.03 1.595 2.98 1.645s-1.491-.488-3.203-1.196L9.51 16.399l-4.568 1.279C2.43 18.38.29 18.956.187 18.956.07 18.956 0 15.92 0 10.786c0-7.869.015-8.202.401-9C.637 1.3 1.097.774 1.515.514l.712-.443L23.146.013C34.65-.019 44.529.01 45.098.078c1.282.152 2.438 1.09 2.745 2.226.131.49.18 7.938.146 22.108l-.051 21.37-.443.712c-.26.419-.786.878-1.272 1.114-.822.398-.989.401-21.492.401-11.365 0-20.664-.066-20.664-.147"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1981">
+              <clipPath id="clip0_1031_1981-:r78:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -12619,7 +12619,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1921)">
+            <g clip-path="url(#clip0_1031_1921-:r7c:)">
               <path fill="#512BD4"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -12630,7 +12630,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1921">
+              <clipPath id="clip0_1031_1921-:r7c:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -12700,8 +12700,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_2276_25)">
-              <g clip-path="url(#clip1_2276_25)">
+            <g clip-path="url(#clip0_2276_25-:r7e:)">
+              <g clip-path="url(#clip1_2276_25-:r7e:)">
                 <mask id="mask0_2276_25"
                       width="48"
                       height="48"
@@ -12720,11 +12720,11 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                         d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24"
                   >
                   </path>
-                  <path fill="url(#paint0_linear_2276_25)"
+                  <path fill="url(#paint0_linear_2276_25-:r7e:)"
                         d="M39.869 42.005 18.438 14.4H14.4v19.192h3.23v-15.09L37.333 43.96a24 24 0 0 0 2.536-1.954"
                   >
                   </path>
-                  <path fill="url(#paint1_linear_2276_25)"
+                  <path fill="url(#paint1_linear_2276_25-:r7e:)"
                         d="M33.867 14.4h-3.2v19.2h3.2z"
                   >
                   </path>
@@ -12732,7 +12732,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </g>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_2276_25"
+              <linearGradient id="paint0_linear_2276_25-:r7e:"
                               x1="29.067"
                               x2="38.533"
                               y1="31.067"
@@ -12747,7 +12747,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_2276_25"
+              <linearGradient id="paint1_linear_2276_25-:r7e:"
                               x1="32.267"
                               x2="32.213"
                               y1="14.4"
@@ -12762,13 +12762,13 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_2276_25">
+              <clipPath id="clip0_2276_25-:r7e:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
                 </path>
               </clipPath>
-              <clipPath id="clip1_2276_25">
+              <clipPath id="clip1_2276_25-:r7e:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -12820,24 +12820,24 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1900)"
+               clip-path="url(#clip0_1031_1900-:r7g:)"
                clip-rule="evenodd"
             >
-              <path fill="url(#paint0_linear_1031_1900)"
+              <path fill="url(#paint0_linear_1031_1900-:r7g:)"
                     d="M22.944.539h.005L4.137 11.397A2.27 2.27 0 0 0 3 13.365v21.732a2.27 2.27 0 0 0 1.137 1.967L22.95 47.932c.703.405 1.57.405 2.273 0l18.81-10.868a2.28 2.28 0 0 0 1.135-1.967V13.365a2.27 2.27 0 0 0-1.139-1.968L25.222.54a2.29 2.29 0 0 0-2.278 0"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1900)"
+              <path fill="url(#paint1_linear_1031_1900-:r7g:)"
                     d="M3.466 36.477c.18.234.405.436.67.588l16.138 9.322 2.688 1.544a2.28 2.28 0 0 0 1.757.216L44.56 11.816a2.3 2.3 0 0 0-.529-.42L31.713 4.283 25.202.536a2.4 2.4 0 0 0-.59-.236z"
               >
               </path>
-              <path fill="url(#paint2_linear_1031_1900)"
+              <path fill="url(#paint2_linear_1031_1900-:r7g:)"
                     d="M23.87.248h-.012c-.315.031-.624.13-.908.29L4.19 11.367 24.42 48.21c.281-.04.558-.134.808-.278L44.04 37.064a2.28 2.28 0 0 0 1.09-1.51v-.056L24.517.285a2.4 2.4 0 0 0-.648-.037"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1900"
+              <linearGradient id="paint0_linear_1031_1900-:r7g:"
                               x1="24.084"
                               x2="-23.516"
                               y1="-23.765"
@@ -12851,7 +12851,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1900"
+              <linearGradient id="paint1_linear_1031_1900-:r7g:"
                               x1="18.428"
                               x2="-6.405"
                               y1="-5.756"
@@ -12869,7 +12869,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1031_1900"
+              <linearGradient id="paint2_linear_1031_1900-:r7g:"
                               x1="3.048"
                               x2="45.13"
                               y1="48.88"
@@ -12883,7 +12883,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1900">
+              <clipPath id="clip0_1031_1900-:r7g:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -12911,13 +12911,13 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1913)"
+               clip-path="url(#clip0_1031_1913-:r7h:)"
             >
               <path d="M48 45v3H38v-3zM10 45v3H0v-3zM33.068 31.276c-1.728 1.26-3.888 2.088-6.48 2.088-5.508 0-9.54-3.816-9.54-9.144 0-5.4 3.924-9.252 9.252-9.252l7.74 2.376v-5.076c-1.98-.72-4.788-1.476-7.884-1.476-7.74 0-13.752 5.436-13.752 13.428s6.012 13.428 13.752 13.428c3.348 0 6.48-.972 8.532-2.268zM0 3h3v42H0zM48 0v3H38V0zM45 3h3v42h-3zM10 0v3H0V0z">
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1913">
+              <clipPath id="clip0_1031_1913-:r7h:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13138,7 +13138,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           >
             <g fill="#03020D"
                fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1944)"
+               clip-path="url(#clip0_1031_1944-:r7o:)"
                clip-rule="evenodd"
             >
               <path d="M38.933 29 32 23.8l1.2-1.6 8 6a1 1 0 0 1 0 1.6l-8 6-1.2-1.6zM14.667 25l6.933-5.2-1.2-1.6-8 6a1 1 0 0 0 0 1.6l8 6 1.2-1.6zM30.96 15.28l-7 24-1.92-.56 7-24z">
@@ -13149,7 +13149,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1944">
+              <clipPath id="clip0_1031_1944-:r7o:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13203,7 +13203,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1928)"
+               clip-path="url(#clip0_1031_1928-:r7q:)"
             >
               <circle cx="14.5"
                       cy="29.5"
@@ -13224,7 +13224,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1928">
+              <clipPath id="clip0_1031_1928-:r7q:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13303,7 +13303,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1908)">
+            <g clip-path="url(#clip0_1031_1908-:r7s:)">
               <path fill="#D02129"
                     fill-rule="evenodd"
                     d="M0 9.009s7.125-.02 10.469 0a15.8 15.8 0 0 1 4.684.66c2.755.868 4.377 2.868 4.698 5.763.183 1.495.126 3.01-.168 4.488-.559 2.643-2.198 4.299-4.684 5.169a13.3 13.3 0 0 1-4.323.688c-1.262.015-2.525.01-3.788.005h-.001l-1.899-.005h-.447v13.215H0zM4.55 22.46q.078.001.129.009.04.005.077.006.727 0 1.455.004c1.26.005 2.522.01 3.783-.02a11 11 0 0 0 2.178-.281c1.484-.337 2.57-1.15 2.968-2.703a8.9 8.9 0 0 0 .141-3.852c-.277-1.524-1.147-2.549-2.649-2.908a14 14 0 0 0-2.75-.386c-1.164-.044-2.33-.035-3.496-.025q-.732.007-1.465.008c-.12 0-.247 0-.378.017zm39.234 16.534h4.204L48 9.034H44.01v26.128a.56.56 0 0 1-.216-.25Q37.185 22.11 30.595 9.3a.455.455 0 0 0-.475-.291h-6.203q-.082.001-.165.008-.081.009-.161.01v29.945h3.957V12.956a.55.55 0 0 1 .212.234l7.576 14.711q2.777 5.386 5.537 10.782a.494.494 0 0 0 .531.312z"
@@ -13312,7 +13312,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1908">
+              <clipPath id="clip0_1031_1908-:r7s:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13339,7 +13339,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2020)">
+            <g clip-path="url(#clip0_1031_2020-:r7t:)">
               <path fill="#22AFEC"
                     fill-rule="evenodd"
                     d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24c0 9.24 5.222 17.26 12.875 21.271V31.5a2.5 2.5 0 0 1 4.483-1.523A8.98 8.98 0 0 0 24.5 33.5a9 9 0 1 0 0-18 8.98 8.98 0 0 0-7.142 3.523 2.5 2.5 0 1 1-3.965-3.046A13.98 13.98 0 0 1 24.5 10.5c7.732 0 14 6.268 14 14s-6.268 14-14 14a13.94 13.94 0 0 1-6.625-1.664V47q0 .105-.009.21c1.958.515 4.014.79 6.134.79M9 24.5a2.5 2.5 0 0 1 2.5-2.5h10a2.5 2.5 0 0 1 0 5h-10A2.5 2.5 0 0 1 9 24.5"
@@ -13348,7 +13348,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2020">
+              <clipPath id="clip0_1031_2020-:r7t:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13400,18 +13400,18 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1963)"
+               clip-path="url(#clip0_1031_1963-:r7v:)"
                clip-rule="evenodd"
             >
-              <path fill="url(#paint0_radial_1031_1963)"
+              <path fill="url(#paint0_radial_1031_1963-:r7v:)"
                     d="M23.895 48.218c-7.073 0-12.807-1.112-12.807-2.483s5.734-2.483 12.807-2.483 12.807 1.112 12.807 2.483-5.734 2.483-12.807 2.483"
               >
               </path>
-              <path fill="url(#paint1_radial_1031_1963)"
+              <path fill="url(#paint1_radial_1031_1963-:r7v:)"
                     d="M23.895 48.218c-7.073 0-12.807-1.112-12.807-2.483s5.734-2.483 12.807-2.483 12.807 1.112 12.807 2.483-5.734 2.483-12.807 2.483"
               >
               </path>
-              <path fill="url(#paint2_linear_1031_1963)"
+              <path fill="url(#paint2_linear_1031_1963-:r7v:)"
                     d="M29.156 33.479c.99 0 1.793.811 1.793 1.815 0 1.007-.803 1.827-1.794 1.827-.987 0-1.793-.82-1.793-1.827 0-1.004.806-1.815 1.794-1.815m5.368-23.046v4.244c0 3.29-2.79 6.059-5.97 6.059h-9.546c-2.614 0-4.778 2.238-4.778 4.857v9.1c0 2.59 2.252 4.113 4.778 4.856 3.025.89 5.926 1.05 9.546 0 2.406-.696 4.778-2.099 4.778-4.856V31.05h-9.546v-1.215H38.11c2.778 0 3.813-1.937 4.78-4.845.997-2.993.954-5.872 0-9.713-.687-2.765-1.998-4.845-4.78-4.845z"
               >
               </path>
@@ -13421,7 +13421,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <radialGradient id="paint0_radial_1031_1963"
+              <radialGradient id="paint0_radial_1031_1963-:r7v:"
                               cx="0"
                               cy="0"
                               r="1"
@@ -13435,7 +13435,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </radialGradient>
-              <radialGradient id="paint1_radial_1031_1963"
+              <radialGradient id="paint1_radial_1031_1963-:r7v:"
                               cx="0"
                               cy="0"
                               r="1"
@@ -13449,7 +13449,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </radialGradient>
-              <linearGradient id="paint2_linear_1031_1963"
+              <linearGradient id="paint2_linear_1031_1963-:r7v:"
                               x1="38.828"
                               x2="30.863"
                               y1="27.877"
@@ -13463,7 +13463,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1963">
+              <clipPath id="clip0_1031_1963-:r7v:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13546,7 +13546,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           >
             <g fill="#C00"
                fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1890)"
+               clip-path="url(#clip0_1031_1890-:r82:)"
                clip-rule="evenodd"
             >
               <path d="M1.481 38.46h16.72s-3.196-14.581 7.386-20.486c2.307-1.122 9.651-5.312 21.672 3.577.381-.318.741-.572.741-.572S36.995 9.995 24.74 11.223c-6.158.55-13.735 6.158-18.18 13.566C2.117 32.196 1.482 38.46 1.482 38.46">
@@ -13559,7 +13559,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1890">
+              <clipPath id="clip0_1031_1890-:r82:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13587,7 +13587,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#61DAFB"
-               clip-path="url(#clip0_1031_1960)"
+               clip-path="url(#clip0_1031_1960-:r83:)"
             >
               <path d="M48 24.378c0-3.18-3.982-6.193-10.087-8.062 1.409-6.223.783-11.173-1.977-12.758-.636-.372-1.38-.548-2.191-.548v2.182c.45 0 .812.088 1.115.254 1.33.763 1.908 3.669 1.458 7.406-.108.92-.284 1.889-.499 2.877a47 47 0 0 0-6.213-1.066 48 48 0 0 0-4.07-4.893c3.19-2.964 6.183-4.588 8.219-4.588V3c-2.691 0-6.213 1.918-9.775 5.244-3.56-3.307-7.083-5.205-9.774-5.205v2.182c2.026 0 5.03 1.614 8.219 4.56a46 46 0 0 0-4.041 4.881 46 46 0 0 0-6.223 1.077 30 30 0 0 1-.508-2.838c-.46-3.737.107-6.643 1.428-7.416.294-.176.675-.254 1.125-.254V3.049c-.822 0-1.565.176-2.21.548-2.75 1.585-3.367 6.526-1.948 12.729C3.962 18.204 0 21.208 0 24.378c0 3.18 3.982 6.193 10.087 8.062-1.409 6.223-.782 11.173 1.977 12.758.636.372 1.38.548 2.201.548 2.69 0 6.213-1.918 9.774-5.244 3.561 3.307 7.084 5.205 9.774 5.205.822 0 1.566-.176 2.212-.548 2.749-1.585 3.365-6.526 1.947-12.729C44.038 30.561 48 27.548 48 24.378m-12.739-6.526a44 44 0 0 1-1.32 3.865 46 46 0 0 0-1.282-2.348 53 53 0 0 0-1.41-2.29c1.39.206 2.73.46 4.012.773m-4.48 10.42a52 52 0 0 1-2.359 3.737 51 51 0 0 1-8.825.01 54 54 0 0 1-2.367-3.718 51 51 0 0 1-2.036-3.894 51 51 0 0 1 2.026-3.904 52 52 0 0 1 2.358-3.737 51 51 0 0 1 8.825-.01 54 54 0 0 1 2.367 3.718 51 51 0 0 1 2.036 3.894 55 55 0 0 1-2.026 3.904M33.94 27a42 42 0 0 1 1.35 3.894 44 44 0 0 1-4.031.783c.48-.754.958-1.527 1.409-2.32.45-.782.87-1.574 1.272-2.357M24.02 37.44c-.91-.94-1.82-1.987-2.72-3.131.88.039 1.78.068 2.69.068.92 0 1.83-.02 2.72-.068a38 38 0 0 1-2.69 3.13m-7.28-5.763c-1.389-.206-2.73-.46-4.011-.773a44 44 0 0 1 1.32-3.865c.402.783.823 1.566 1.282 2.348q.69 1.174 1.41 2.29m7.23-20.36c.91.939 1.82 1.986 2.72 3.13-.88-.039-1.78-.068-2.69-.068-.92 0-1.83.02-2.72.068a38 38 0 0 1 2.69-3.13m-7.24 5.762a54 54 0 0 0-2.68 4.667 42 42 0 0 1-1.35-3.894 48 48 0 0 1 4.03-.773M7.877 29.33c-3.463-1.478-5.704-3.415-5.704-4.951s2.24-3.483 5.704-4.95a30 30 0 0 1 2.71-.989 47 47 0 0 0 2.202 5.959 46 46 0 0 0-2.172 5.929 30 30 0 0 1-2.74-.998m5.264 13.98c-1.33-.762-1.908-3.668-1.458-7.406.108-.92.284-1.888.499-2.876 1.918.47 4.011.831 6.213 1.066a48 48 0 0 0 4.07 4.892c-3.19 2.965-6.183 4.589-8.219 4.589-.44-.01-.812-.098-1.105-.264m23.207-7.454c.46 3.737-.107 6.643-1.428 7.416-.294.176-.675.254-1.125.254-2.026 0-5.03-1.614-8.219-4.56a46 46 0 0 0 4.041-4.881 46 46 0 0 0 6.223-1.077c.225.989.4 1.938.508 2.848m3.767-6.526a30 30 0 0 1-2.71.988 47 47 0 0 0-2.201-5.959 46 46 0 0 0 2.172-5.929c.968.304 1.888.636 2.749.998 3.463 1.478 5.704 3.415 5.704 4.95-.01 1.537-2.25 3.484-5.714 4.952">
               </path>
@@ -13595,7 +13595,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1960">
+              <clipPath id="clip0_1031_1960-:r83:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13623,7 +13623,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#61DAFB"
-               clip-path="url(#clip0_1031_1888)"
+               clip-path="url(#clip0_1031_1888-:r84:)"
             >
               <path d="M48 24.378c0-3.18-3.982-6.193-10.087-8.062 1.409-6.223.783-11.173-1.977-12.758-.636-.372-1.38-.548-2.191-.548v2.182c.45 0 .812.088 1.115.254 1.33.763 1.908 3.669 1.458 7.406-.108.92-.284 1.889-.499 2.877a47 47 0 0 0-6.213-1.066 48 48 0 0 0-4.07-4.893c3.19-2.964 6.183-4.588 8.219-4.588V3c-2.691 0-6.213 1.918-9.775 5.244-3.56-3.307-7.083-5.205-9.774-5.205v2.182c2.026 0 5.03 1.614 8.219 4.56a46 46 0 0 0-4.041 4.881 46 46 0 0 0-6.223 1.077 30 30 0 0 1-.508-2.838c-.46-3.737.107-6.643 1.428-7.416.294-.176.675-.254 1.125-.254V3.049c-.822 0-1.565.176-2.21.548-2.75 1.585-3.367 6.526-1.948 12.729C3.962 18.204 0 21.208 0 24.378c0 3.18 3.982 6.193 10.087 8.062-1.409 6.223-.782 11.173 1.977 12.758.636.372 1.38.548 2.201.548 2.69 0 6.213-1.918 9.774-5.244 3.561 3.307 7.084 5.205 9.774 5.205.822 0 1.566-.176 2.212-.548 2.749-1.585 3.365-6.526 1.947-12.729C44.038 30.561 48 27.548 48 24.378m-12.739-6.526a44 44 0 0 1-1.32 3.865 46 46 0 0 0-1.282-2.348 53 53 0 0 0-1.41-2.29c1.39.206 2.73.46 4.012.773m-4.48 10.42a52 52 0 0 1-2.359 3.737 51 51 0 0 1-8.825.01 54 54 0 0 1-2.367-3.718 51 51 0 0 1-2.036-3.894 51 51 0 0 1 2.026-3.904 52 52 0 0 1 2.358-3.737 51 51 0 0 1 8.825-.01 54 54 0 0 1 2.367 3.718 51 51 0 0 1 2.036 3.894 55 55 0 0 1-2.026 3.904M33.94 27a42 42 0 0 1 1.35 3.894 44 44 0 0 1-4.031.783c.48-.754.958-1.527 1.409-2.32.45-.782.87-1.574 1.272-2.357M24.02 37.44c-.91-.94-1.82-1.987-2.72-3.131.88.039 1.78.068 2.69.068.92 0 1.83-.02 2.72-.068a38 38 0 0 1-2.69 3.13m-7.28-5.763c-1.389-.206-2.73-.46-4.011-.773a44 44 0 0 1 1.32-3.865c.402.783.823 1.566 1.282 2.348q.69 1.174 1.41 2.29m7.23-20.36c.91.939 1.82 1.986 2.72 3.13-.88-.039-1.78-.068-2.69-.068-.92 0-1.83.02-2.72.068a38 38 0 0 1 2.69-3.13m-7.24 5.762a54 54 0 0 0-2.68 4.667 42 42 0 0 1-1.35-3.894 48 48 0 0 1 4.03-.773M7.877 29.33c-3.463-1.478-5.704-3.415-5.704-4.951s2.24-3.483 5.704-4.95a30 30 0 0 1 2.71-.989 47 47 0 0 0 2.202 5.959 46 46 0 0 0-2.172 5.929 30 30 0 0 1-2.74-.998m5.264 13.98c-1.33-.762-1.908-3.668-1.458-7.406.108-.92.284-1.888.499-2.876 1.918.47 4.011.831 6.213 1.066a48 48 0 0 0 4.07 4.892c-3.19 2.965-6.183 4.589-8.219 4.589-.44-.01-.812-.098-1.105-.264m23.207-7.454c.46 3.737-.107 6.643-1.428 7.416-.294.176-.675.254-1.125.254-2.026 0-5.03-1.614-8.219-4.56a46 46 0 0 0 4.041-4.881 46 46 0 0 0 6.223-1.077c.225.989.4 1.938.508 2.848m3.767-6.526a30 30 0 0 1-2.71.988 47 47 0 0 0-2.201-5.959 46 46 0 0 0 2.172-5.929c.968.304 1.888.636 2.749.998 3.463 1.478 5.704 3.415 5.704 4.95-.01 1.537-2.25 3.484-5.714 4.952">
               </path>
@@ -13631,7 +13631,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1888">
+              <clipPath id="clip0_1031_1888-:r84:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -13966,8 +13966,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_2566_117)">
-              <path fill="url(#paint0_linear_2566_117)"
+            <g clip-path="url(#clip0_2566_117-:r88:)">
+              <path fill="url(#paint0_linear_2566_117-:r88:)"
                     d="m16.346 34.39-.003-.002-.003-.001-15.747-8.41a.227.227 0 0 1-.008-.394l14.961-8.83h.001c2.438-1.404 5.618-2.132 8.79-2.163s6.311.635 8.668 1.99c1.61.929 2.637 2.05 3.117 3.218.48 1.162.425 2.39-.161 3.562-.22.438.041 1.034.58 1.067l10.75.657c.227.013.295.314.097.424L23.864 38.595a.23.23 0 0 1-.223-.002l-5.82-3.355z"
               >
               </path>
@@ -13985,7 +13985,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     d="M48 27.207v-1.394h-.453v1.394zM24.034 41.803l23.633-14.01-.232-.391-23.633 14.01zm-.463-.39L.564 27.716l-.232.39L23.34 41.802zM.453 27.52V26.13H0v1.392zm.34-1.59 22.556 12.9.225-.393-22.556-12.9zm46.19-.708L23.8 38.438l.224.394 23.185-13.216zM23.35 38.832a.68.68 0 0 0 .674 0l-.224-.394a.23.23 0 0 1-.225 0zM.453 26.129c0-.175.189-.284.34-.197l.225-.394a.68.68 0 0 0-1.018.59zm.111 1.587a.23.23 0 0 1-.11-.195H0c0 .24.126.462.332.585zm23.238 13.697a.23.23 0 0 1-.231 0l-.232.39a.68.68 0 0 0 .695 0zM48 25.813a.68.68 0 0 0-1.017-.59l.225.393a.227.227 0 0 1 .339.197zm-.453 1.394c0 .08-.043.154-.111.195l.23.39a.68.68 0 0 0 .334-.585z"
               >
               </path>
-              <path fill="url(#paint1_linear_2566_117)"
+              <path fill="url(#paint1_linear_2566_117-:r88:)"
                     d="m16.346 26.229-.003-.002-.003-.002L.593 17.816a.227.227 0 0 1-.008-.395l14.961-8.83h.001c2.438-1.404 5.618-2.131 8.79-2.162s6.311.634 8.668 1.99c1.61.928 2.637 2.05 3.117 3.217.48 1.163.425 2.39-.161 3.563-.22.437.041 1.033.58 1.066l10.75.657c.227.014.295.314.097.424L23.864 30.433a.23.23 0 0 1-.223-.002l-5.82-3.355z"
               >
               </path>
@@ -14005,7 +14005,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_2566_117"
+              <linearGradient id="paint0_linear_2566_117-:r88:"
                               x1="24.001"
                               x2="24.001"
                               y1="14.402"
@@ -14023,7 +14023,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_2566_117"
+              <linearGradient id="paint1_linear_2566_117-:r88:"
                               x1="24.001"
                               x2="24.001"
                               y1="6.24"
@@ -14041,7 +14041,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_2566_117">
+              <clipPath id="clip0_2566_117-:r88:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -14068,7 +14068,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1942)">
+            <g clip-path="url(#clip0_1031_1942-:r89:)">
               <path fill="#136C7A"
                     d="M0 0h48v48H0z"
               >
@@ -14079,7 +14079,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1942">
+              <clipPath id="clip0_1031_1942-:r89:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -14130,36 +14130,36 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2037)">
-              <path fill="url(#paint0_linear_1031_2037)"
+            <g clip-path="url(#clip0_1031_2037-:r8b:)">
+              <path fill="url(#paint0_linear_1031_2037-:r8b:)"
                     d="M37.174 31.582 9.779 47.849l35.471-2.407 2.732-35.767z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_2037)"
+              <path fill="url(#paint1_linear_1031_2037-:r8b:)"
                     d="M45.308 45.417 42.26 24.375l-8.305 10.966z"
               >
               </path>
-              <path fill="url(#paint2_linear_1031_2037)"
+              <path fill="url(#paint2_linear_1031_2037-:r8b:)"
                     d="m45.35 45.417-22.336-1.753-13.116 4.139z"
               >
               </path>
-              <path fill="url(#paint3_linear_1031_2037)"
+              <path fill="url(#paint3_linear_1031_2037-:r8b:)"
                     d="m9.93 47.808 5.58-18.28-12.28 2.626z"
               >
               </path>
-              <path fill="url(#paint4_linear_1031_2037)"
+              <path fill="url(#paint4_linear_1031_2037-:r8b:)"
                     d="m0 38.285 3.422-6.24-2.768-7.436z"
               >
               </path>
-              <path fill="url(#paint5_linear_1031_2037)"
+              <path fill="url(#paint5_linear_1031_2037-:r8b:)"
                     d="m33.953 35.401-5.134-20.11-14.693 13.773z"
               >
               </path>
-              <path fill="url(#paint6_linear_1031_2037)"
+              <path fill="url(#paint6_linear_1031_2037-:r8b:)"
                     d="M46.817 15.574 32.93 4.23 29.06 16.734z"
               >
               </path>
-              <path fill="url(#paint7_linear_1031_2037)"
+              <path fill="url(#paint7_linear_1031_2037-:r8b:)"
                     d="m40.322.186-8.168 4.515L27 .126z"
               >
               </path>
@@ -14167,11 +14167,11 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     d="m.47 24.375 2.785 7.9 12.102-2.715 13.815-12.84 3.9-12.385L26.931 0 16.494 3.906c-3.288 3.059-9.67 9.11-9.9 9.225-.227.116-4.213 7.65-6.124 11.244"
               >
               </path>
-              <path fill="url(#paint8_linear_1031_2037)"
+              <path fill="url(#paint8_linear_1031_2037-:r8b:)"
                     d="M10.249 10.183C17.376 3.117 26.564-1.059 30.09 2.5c3.524 3.558-.213 12.203-7.34 19.268-7.128 7.064-16.202 11.469-19.725 7.911-3.526-3.555.097-12.43 7.224-19.495"
               >
               </path>
-              <path fill="url(#paint9_linear_1031_2037)"
+              <path fill="url(#paint9_linear_1031_2037-:r8b:)"
                     d="m9.93 47.8 5.535-18.337 18.386 5.907C27.203 41.603 19.81 46.873 9.93 47.8"
               >
               </path>
@@ -14179,33 +14179,33 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                     d="M0 38.204c.262 9.408 7.05 9.548 9.941 9.631L3.262 32.236z"
               >
               </path>
-              <path fill="url(#paint10_linear_1031_2037)"
+              <path fill="url(#paint10_linear_1031_2037-:r8b:)"
                     d="M3.233 32.255 2.185 44.742c1.978 2.702 4.7 2.937 7.555 2.727-2.065-5.142-6.192-15.422-6.507-15.214"
               >
               </path>
-              <path fill="url(#paint11_linear_1031_2037)"
+              <path fill="url(#paint11_linear_1031_2037-:r8b:)"
                     d="m29.197 16.683 4.72 18.696C39.47 29.54 44.453 23.263 46.894 15.5z"
               >
               </path>
-              <path fill="url(#paint12_radial_1031_2037)"
+              <path fill="url(#paint12_radial_1031_2037-:r8b:)"
                     d="m15.458 29.463 7.4 14.279c4.377-2.374 7.804-5.265 10.942-8.363z"
               >
               </path>
-              <path fill="url(#paint13_linear_1031_2037)"
+              <path fill="url(#paint13_linear_1031_2037-:r8b:)"
                     d="M46.846 15.594c1.89-5.701 2.325-13.88-6.582-15.398l-7.31 4.037z"
               >
               </path>
-              <path fill="url(#paint14_radial_1031_2037)"
+              <path fill="url(#paint14_radial_1031_2037-:r8b:)"
                     d="M29.223 16.713c4.267 2.622 12.867 7.89 13.041 7.987.271.152 3.708-5.796 4.488-9.157z"
               >
               </path>
-              <path fill="url(#paint15_linear_1031_2037)"
+              <path fill="url(#paint15_linear_1031_2037-:r8b:)"
                     d="m32.912 4.265 14.702 2.063C46.83 3.003 44.42.858 40.312.187z"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_2037"
+              <linearGradient id="paint0_linear_1031_2037-:r8b:"
                               x1="51.112"
                               x2="41.001"
                               y1="47.178"
@@ -14229,7 +14229,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_2037"
+              <linearGradient id="paint1_linear_1031_2037-:r8b:"
                               x1="67.988"
                               x2="22.822"
                               y1="-4.343"
@@ -14249,7 +14249,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1031_2037"
+              <linearGradient id="paint2_linear_1031_2037-:r8b:"
                               x1="2787.28"
                               x2="2787.11"
                               y1="559.152"
@@ -14269,7 +14269,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint3_linear_1031_2037"
+              <linearGradient id="paint3_linear_1031_2037-:r8b:"
                               x1="4.959"
                               x2="12.911"
                               y1="34.187"
@@ -14297,7 +14297,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint4_linear_1031_2037"
+              <linearGradient id="paint4_linear_1031_2037-:r8b:"
                               x1="-11.51"
                               x2="1.418"
                               y1="52.752"
@@ -14321,7 +14321,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint5_linear_1031_2037"
+              <linearGradient id="paint5_linear_1031_2037-:r8b:"
                               x1="16.647"
                               x2="17.436"
                               y1="18.967"
@@ -14349,7 +14349,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint6_linear_1031_2037"
+              <linearGradient id="paint6_linear_1031_2037-:r8b:"
                               x1="21.859"
                               x2="22.969"
                               y1="2.592"
@@ -14377,7 +14377,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint7_linear_1031_2037"
+              <linearGradient id="paint7_linear_1031_2037-:r8b:"
                               x1="88.161"
                               x2="89.301"
                               y1="7.302"
@@ -14401,7 +14401,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint8_linear_1031_2037"
+              <linearGradient id="paint8_linear_1031_2037-:r8b:"
                               x1="14.71"
                               x2="51.846"
                               y1="56.193"
@@ -14445,7 +14445,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint9_linear_1031_2037"
+              <linearGradient id="paint9_linear_1031_2037-:r8b:"
                               x1="27.062"
                               x2="17.422"
                               y1="39.083"
@@ -14469,7 +14469,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint10_linear_1031_2037"
+              <linearGradient id="paint10_linear_1031_2037-:r8b:"
                               x1="11.381"
                               x2="-7.149"
                               y1="31.099"
@@ -14493,7 +14493,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint11_linear_1031_2037"
+              <linearGradient id="paint11_linear_1031_2037-:r8b:"
                               x1="48.563"
                               x2="35.215"
                               y1="20.922"
@@ -14513,7 +14513,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint13_linear_1031_2037"
+              <linearGradient id="paint13_linear_1031_2037-:r8b:"
                               x1="49.814"
                               x2="44.46"
                               y1="8.931"
@@ -14533,7 +14533,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint15_linear_1031_2037"
+              <linearGradient id="paint15_linear_1031_2037-:r8b:"
                               x1="10.024"
                               x2="11.64"
                               y1="0.08"
@@ -14557,7 +14557,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <radialGradient id="paint12_radial_1031_2037"
+              <radialGradient id="paint12_radial_1031_2037-:r8b:"
                               cx="0"
                               cy="0"
                               r="1"
@@ -14577,7 +14577,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </radialGradient>
-              <radialGradient id="paint14_radial_1031_2037"
+              <radialGradient id="paint14_radial_1031_2037-:r8b:"
                               cx="0"
                               cy="0"
                               r="1"
@@ -14597,7 +14597,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </radialGradient>
-              <clipPath id="clip0_1031_2037">
+              <clipPath id="clip0_1031_2037-:r8b:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -14624,30 +14624,30 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1901)">
-              <path fill="url(#paint0_linear_1031_1901)"
+            <g clip-path="url(#clip0_1031_1901-:r8c:)">
+              <path fill="url(#paint0_linear_1031_1901-:r8c:)"
                     d="M9 29.539v3.692c0 .622 13.428 1.665 22.177 3.692 4.226-.98 7.361-2.188 7.361-3.692v-3.692c0-1.503-3.135-2.713-7.361-3.693C22.428 27.874 9 28.916 9 29.54"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1901)"
+              <path fill="url(#paint1_linear_1031_1901-:r8c:)"
                     d="M9 14.77v3.692c0 .622 13.428 1.665 22.177 3.692 4.226-.98 7.361-2.188 7.361-3.692V14.77c0-1.503-3.135-2.713-7.361-3.693C22.428 13.105 9 14.147 9 14.77"
               >
               </path>
-              <path fill="url(#paint2_linear_1031_1901)"
+              <path fill="url(#paint2_linear_1031_1901-:r8c:)"
                     d="M9 22.154V33.23c0-.924 29.539-2.77 29.539-7.385V14.769C38.539 19.384 9 21.23 9 22.154"
               >
               </path>
-              <path fill="url(#paint3_linear_1031_1901)"
+              <path fill="url(#paint3_linear_1031_1901-:r8c:)"
                     d="M9 36.923v11.076c0-.923 29.539-2.769 29.539-7.384V29.538C38.539 34.153 9 35.999 9 36.923"
               >
               </path>
-              <path fill="url(#paint4_linear_1031_1901)"
+              <path fill="url(#paint4_linear_1031_1901-:r8c:)"
                     d="M9 7.385V18.46c0-.923 29.539-2.769 29.539-7.384V0C38.539 4.615 9 6.46 9 7.385"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1901"
+              <linearGradient id="paint0_linear_1031_1901-:r8c:"
                               x1="9"
                               x2="38.538"
                               y1="25.846"
@@ -14659,7 +14659,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 <stop offset="1">
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1901"
+              <linearGradient id="paint1_linear_1031_1901-:r8c:"
                               x1="9"
                               x2="38.538"
                               y1="11.077"
@@ -14671,7 +14671,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 <stop offset="1">
                 </stop>
               </linearGradient>
-              <linearGradient id="paint2_linear_1031_1901"
+              <linearGradient id="paint2_linear_1031_1901-:r8c:"
                               x1="9"
                               x2="38.538"
                               y1="14.769"
@@ -14685,7 +14685,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint3_linear_1031_1901"
+              <linearGradient id="paint3_linear_1031_1901-:r8c:"
                               x1="9"
                               x2="38.538"
                               y1="29.538"
@@ -14699,7 +14699,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint4_linear_1031_1901"
+              <linearGradient id="paint4_linear_1031_1901-:r8c:"
                               x1="9"
                               x2="38.538"
                               y1="0"
@@ -14713,7 +14713,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1901">
+              <clipPath id="clip0_1031_1901-:r8c:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -14740,8 +14740,8 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1994)">
-              <path fill="url(#paint0_linear_1031_1994)"
+            <g clip-path="url(#clip0_1031_1994-:r8d:)">
+              <path fill="url(#paint0_linear_1031_1994-:r8d:)"
                     d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24"
                     opacity="0.5"
               >
@@ -14752,7 +14752,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1994"
+              <linearGradient id="paint0_linear_1031_1994-:r8d:"
                               x1="36.045"
                               x2="12.607"
                               y1="44.823"
@@ -14773,7 +14773,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1994">
+              <clipPath id="clip0_1031_1994-:r8d:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -14876,14 +14876,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2023)">
+            <g clip-path="url(#clip0_1031_2023-:r8g:)">
               <path fill="#59B4D9"
                     d="m19.315 35.143 2.693-6.55h5.89c2.16 0 4.066-1.54 4.387-3.678a4.352 4.352 0 0 0-4.29-5H8.466l10.85-10.85v4.246h8.647c5.165 0 10.14 4.16 10.882 9.272A10.85 10.85 0 0 1 28.558 35.07l8.879 8.878a24 24 0 1 0-13.682 4.294c2.55.004 5.082-.414 7.496-1.237z"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2023">
+              <clipPath id="clip0_1031_2023-:r8g:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -14910,7 +14910,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1970)">
+            <g clip-path="url(#clip0_1031_1970-:r8h:)">
               <path fill="#29B5E8"
                     fill-rule="evenodd"
                     d="M16.836 17.323 6.68 11.473a2.974 2.974 0 0 1-1.094-4.067A2.99 2.99 0 0 1 9.662 6.32l5.769 3.322V2.968A2.97 2.97 0 0 1 18.406 0a2.97 2.97 0 0 1 2.97 2.968v11.724a2.95 2.95 0 0 1-.96 2.182 2.99 2.99 0 0 1-3.58.449m-.847 6.716a2.92 2.92 0 0 0-1.458-2.571l-10.157-5.85a2.92 2.92 0 0 0-3.983 1.066 2.907 2.907 0 0 0 1.068 3.973l5.855 3.369-5.855 3.373a2.88 2.88 0 0 0-1.357 1.764 2.88 2.88 0 0 0 .29 2.209 2.925 2.925 0 0 0 3.982 1.065l10.157-5.85a2.92 2.92 0 0 0 1.458-2.548M41.25 36.582 31.094 30.73a2.993 2.993 0 0 0-4.078 1.091 2.97 2.97 0 0 0-.384 1.777v11.44A2.97 2.97 0 0 0 29.605 48a2.97 2.97 0 0 0 2.971-2.963v-6.578l5.69 3.278a2.99 2.99 0 0 0 4.078-1.091 2.964 2.964 0 0 0-1.093-4.064M29.52 24.513c0 .224-.13.535-.29.699l-4.026 4.016c-.16.16-.475.289-.7.289h-1.025c-.225 0-.54-.13-.7-.29l-4.03-4.015a1.15 1.15 0 0 1-.29-.699v-1.022c0-.229.13-.54.29-.699l4.03-4.02c.16-.16.475-.289.7-.289h1.025c.225 0 .54.13.7.289l4.026 4.02c.16.16.29.47.29.699zm-3.593-.492v-.043a.85.85 0 0 0-.212-.513l-1.19-1.182a.8.8 0 0 0-.514-.216h-.043a.83.83 0 0 0-.515.216l-1.185 1.182a.83.83 0 0 0-.212.513v.043c0 .169.096.397.212.514l1.185 1.186c.121.116.35.211.515.211h.043a.83.83 0 0 0 .515-.211l1.189-1.186a.83.83 0 0 0 .212-.514M41.25 11.474l-10.158 5.849a2.99 2.99 0 0 1-4.078-1.087 2.98 2.98 0 0 1-.384-1.777V2.968A2.97 2.97 0 0 1 29.606 0a2.97 2.97 0 0 1 2.97 2.968v6.63l5.69-3.279a2.99 2.99 0 0 1 4.079 1.087 2.973 2.973 0 0 1-1.094 4.068m-22.378 18.91a2.97 2.97 0 0 0-2.037.345L6.68 36.582a2.97 2.97 0 0 0-1.094 4.063 2.986 2.986 0 0 0 4.077 1.092l5.769-3.322v6.622A2.97 2.97 0 0 0 18.406 48a2.97 2.97 0 0 0 2.97-2.963V33.313a2.97 2.97 0 0 0-2.503-2.93M43.52 15.559a2.985 2.985 0 0 1 4.077 1.09 2.964 2.964 0 0 1-1.094 4.064l-5.75 3.313 5.75 3.313a2.974 2.974 0 0 1 1.094 4.067 2.993 2.993 0 0 1-4.077 1.092l-10.158-5.854a2.97 2.97 0 0 1-1.492-2.605 2.98 2.98 0 0 1 1.492-2.631z"
@@ -14919,7 +14919,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1970">
+              <clipPath id="clip0_1031_1970-:r8h:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -14948,7 +14948,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           >
             <g fill="#010101"
                fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1953)"
+               clip-path="url(#clip0_1031_1953-:r8i:)"
                clip-rule="evenodd"
             >
               <path d="M36.473 3.476C30.996.092 24.132-.837 17.922.758 8.56 3.086 1.135 11.575.184 21.198c-1.18 9.108 3.414 18.594 11.287 23.297 7.723 4.84 18.184 4.645 25.747-.448 6.795-4.416 11.023-12.468 10.771-20.59-.114-8.04-4.617-15.852-11.516-19.981m7.29 17.9C42.579 9.13 28.557.687 17.125 5.26 8.975 8.115 3.28 16.68 4.074 25.313c.301 10.661 10.572 19.661 21.2 18.602 11.176-.324 20.331-11.52 18.489-22.54">
@@ -14957,7 +14957,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1953">
+              <clipPath id="clip0_1031_1953-:r8i:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -14984,14 +14984,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2024)">
+            <g clip-path="url(#clip0_1031_2024-:r8j:)">
               <path fill="#03020D"
                     d="M22.415.071C14.466 1.128 10.848 5.227 9.323 7.897a.95.95 0 0 0 .135 1.108C12.95 12.859 19.588 20.322 21.5 23c3.364 4.71 1.5 7.5 1 9s-2 6-3.5 7.5-6 .5-6.5 3c-.392 1.961 1.475 5.5 6.5 5.5 6 0 9.16-3.652 10.5-7 2-5 6.5-6.5 9-10.5s-4.625-8.5-6.5-11C30.203 17.104 25.878 4.598 23.32.484a.92.92 0 0 0-.905-.413"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2024">
+              <clipPath id="clip0_1031_2024-:r8j:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15018,7 +15018,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1987)">
+            <g clip-path="url(#clip0_1031_1987-:r8k:)">
               <circle cx="24"
                       cy="24"
                       r="24"
@@ -15027,7 +15027,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </circle>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1987">
+              <clipPath id="clip0_1031_1987-:r8k:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15054,14 +15054,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2045)">
+            <g clip-path="url(#clip0_1031_2045-:r8l:)">
               <path fill="#68BD45"
                     d="M43.65 2.524a22 22 0 0 1-2.564 4.548A24.071 24.071 0 1 0 7.474 41.529l.89.785a24.059 24.059 0 0 0 39.502-16.69c.656-6.127-1.143-13.882-4.215-23.1M10.898 41.669a2.059 2.059 0 1 1-3.2-2.591 2.059 2.059 0 0 1 3.2 2.59M43.55 34.46c-5.94 7.913-18.622 5.243-26.754 5.627 0 0-1.441.084-2.893.322 0 0 .548-.232 1.248-.497 5.71-1.988 8.41-2.37 11.878-4.155 6.531-3.32 12.992-10.592 14.334-18.15-2.485 7.271-10.03 13.524-16.897 16.063-4.707 1.735-13.21 3.425-13.21 3.425l-.344-.184C5.128 34.1 4.95 21.57 15.471 17.528c4.607-1.774 9.015-.8 13.99-1.987 5.314-1.262 11.46-5.243 13.962-10.437 2.797 8.31 6.168 21.316.124 29.362z"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2045">
+              <clipPath id="clip0_1031_2045-:r8l:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15164,7 +15164,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2017)">
+            <g clip-path="url(#clip0_1031_2017-:r8n:)">
               <path fill="#E82C2A"
                     fill-rule="evenodd"
                     d="M46.458 31.907 8.19 14.09v6.45l30.464 14.182zm-33.727-6.032v6.448l6.958 3.224L8.495 47.146h7.422l13.284-13.608zm33.716-6.859.014 9.679L3 8.45V2l38.027 17.724V10.04L51 14.683v6.454z"
@@ -15173,7 +15173,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2017">
+              <clipPath id="clip0_1031_2017-:r8n:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -15200,14 +15200,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1968)">
+            <g clip-path="url(#clip0_1031_1968-:r8o:)">
               <path fill="#FF5C00"
                     d="M30.004 2.228V.852A.85.85 0 0 0 29.12 0C19.807.46 12.383 7.943 12 17.254a.734.734 0 0 0 .772.738h1.42a.826.826 0 0 0 .83-.772c.403-7.673 6.538-13.805 14.215-14.207.585-.073.772-.394.772-.783zm-12.65 15.778H18.7c.43.001.79-.33.823-.76a10.5 10.5 0 0 1 9.783-9.728.75.75 0 0 0 .698-.794v-1.37a.85.85 0 0 0-.894-.831c-6.761.447-12.147 5.828-12.596 12.586a.85.85 0 0 0 .832.894zm12.65-8.133v1.376a.806.806 0 0 1-.726.794 6.01 6.01 0 0 0-5.234 5.214.85.85 0 0 1-.829.746h-1.189c-.647 0-1.036-.42-.988-.905a9.01 9.01 0 0 1 8.064-8.056.83.83 0 0 1 .902.83M45.78 29.97c-.39 0-.71-.187-.784-.771-.397-7.683-6.54-13.823-14.228-14.218a.826.826 0 0 1-.772-.831v-1.419a.735.735 0 0 1 .738-.771c9.316.38 16.804 7.8 17.265 17.108a.85.85 0 0 1-.834.888zM30.004 17.322a.85.85 0 0 1 .897-.831c6.76.448 12.144 5.828 12.594 12.584a.85.85 0 0 1-.832.896h-1.37a.75.75 0 0 1-.795-.706c-.348-5.228-4.5-9.4-9.73-9.773a.823.823 0 0 1-.76-.822zM38.14 29.97h-1.38a.806.806 0 0 1-.794-.727 6.01 6.01 0 0 0-5.22-5.23.85.85 0 0 1-.746-.83v-1.338a.83.83 0 0 1 .905-.831 9.01 9.01 0 0 1 8.064 8.056.83.83 0 0 1-.832.902zM2.212 18c.389 0 .71.187.783.772.398 7.686 6.547 13.827 14.237 14.218a.826.826 0 0 1 .772.83v1.42a.735.735 0 0 1-.738.77C7.95 35.63.461 28.21.001 18.903a.85.85 0 0 1 .834-.888zm15.784 12.638a.85.85 0 0 1-.897.831c-6.756-.45-12.137-5.824-12.591-12.575a.85.85 0 0 1 .832-.897h1.37a.75.75 0 0 1 .795.707 10.5 10.5 0 0 0 9.727 9.775c.43.033.762.392.76.823zM9.853 18h1.376a.806.806 0 0 1 .795.726 6.01 6.01 0 0 0 5.22 5.231c.42.052.738.406.746.829v1.342a.83.83 0 0 1-.9.822 9.01 9.01 0 0 1-8.063-8.056.83.83 0 0 1 .826-.894m8.14 27.78c0-.388.187-.708.772-.782 7.687-.395 13.831-6.535 14.228-14.218a.826.826 0 0 1 .832-.772h1.419a.735.735 0 0 1 .772.738c-.382 9.311-7.808 16.794-17.12 17.253a.85.85 0 0 1-.89-.834zm12.656-15.775a.85.85 0 0 1 .831.897c-.45 6.756-5.834 12.135-12.593 12.584a.85.85 0 0 1-.897-.831v-1.37a.75.75 0 0 1 .707-.795 10.5 10.5 0 0 0 9.78-9.722.823.823 0 0 1 .823-.76zm-12.65 8.13V36.76a.806.806 0 0 1 .726-.794 6.01 6.01 0 0 0 5.234-5.215.85.85 0 0 1 .829-.746h1.189c.647 0 1.036.42.988.905a9.01 9.01 0 0 1-8.064 8.057.83.83 0 0 1-.903-.831m0 7.646c0-.389.187-.71.771-.783C26.458 44.603 32.602 38.463 33 30.78a.826.826 0 0 1 .831-.772h1.42a.735.735 0 0 1 .772.738c-.383 9.311-7.808 16.794-17.121 17.253a.85.85 0 0 1-.888-.834zm12.655-15.776a.85.85 0 0 1 .832.897c-.45 6.756-5.834 12.135-12.594 12.584a.85.85 0 0 1-.896-.831v-1.37a.75.75 0 0 1 .706-.795 10.5 10.5 0 0 0 9.781-9.722.823.823 0 0 1 .823-.76zm-12.656 8.13V36.76a.806.806 0 0 1 .727-.794 6.01 6.01 0 0 0 5.234-5.215.85.85 0 0 1 .829-.746h1.189c.647 0 1.036.42.988.905a9.01 9.01 0 0 1-8.064 8.057.83.83 0 0 1-.903-.831"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1968">
+              <clipPath id="clip0_1031_1968-:r8o:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -15235,14 +15235,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1912)"
+               clip-path="url(#clip0_1031_1912-:r8p:)"
                clip-rule="evenodd"
             >
-              <path fill="url(#paint0_linear_1031_1912)"
+              <path fill="url(#paint0_linear_1031_1912-:r8p:)"
                     d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1912)"
+              <path fill="url(#paint1_linear_1031_1912-:r8p:)"
                     d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
               >
               </path>
@@ -15252,7 +15252,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1912"
+              <linearGradient id="paint0_linear_1031_1912-:r8p:"
                               x1="2.813"
                               x2="-6.259"
                               y1="-6.259"
@@ -15266,7 +15266,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1912"
+              <linearGradient id="paint1_linear_1031_1912-:r8p:"
                               x1="4.876"
                               x2="-1.23"
                               y1="-2.365"
@@ -15280,7 +15280,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1912">
+              <clipPath id="clip0_1031_1912-:r8p:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15307,7 +15307,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1916)">
+            <g clip-path="url(#clip0_1031_1916-:r8q:)">
               <path fill="#1A171B"
                     fill-rule="evenodd"
                     d="M48 24c0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0s24 10.745 24 24M28.303 12.151c1.582-1.856 3.707-3.198 6.142-3.283 2.433-.08 4.27 1.022 4.33 2.766.025.742-.402 2.187-1.886 2.235-1.108.04-1.875-.623-1.91-1.63-.011-.37.084-.692.336-1.07l.112-.216c.153-.293.188-.36.182-.536-.022-.634-.981-.659-1.243-.646-3.597.118-4.546 4.974-5.314 8.922l-.377 2.082c2.072.304 3.543-.07 4.363-.601.699-.453.434-.913.157-1.396-.181-.314-.368-.639-.294-.976.19-.87.98-1.289 1.609-1.306.879-.021 1.506.89 1.486 1.816-.03 1.53-2.062 3.634-6.123 3.549-.495-.012-.95-.046-1.375-.097l-.766 4.23-.02.097c-.685 3.194-1.61 7.521-4.839 11.3-2.802 3.33-5.645 3.849-6.918 3.893-2.381.08-3.961-1.19-4.018-2.885-.054-1.64 1.397-2.537 2.35-2.57 1.271-.042 2.151.88 2.185 1.941.032.899-.437 1.18-.747 1.348q-.046.037-.096.074c-.196.147-.422.317-.412.634.008.158.178.521.706.505.977-.034 1.635-.503 2.1-.834l.043-.03c2.32-1.935 3.214-5.304 4.383-11.439l.244-1.487.02-.105c.395-1.968.833-4.153 1.497-6.33-.499-.375-.937-.777-1.366-1.173-.981-.902-1.922-1.766-3.451-2.182-1.507-.41-2.428-.061-3.074.756-.765.968-.511 2.228.228 2.967l1.222 1.35c1.499 1.732 2.317 3.078 2.01 4.89-.49 2.894-3.936 5.112-8.01 3.86-3.478-1.072-4.127-3.534-3.71-4.89.368-1.195 1.317-1.42 2.245-1.135.994.306 1.382 1.514 1.098 2.442l-.01.03c-.032.1-.082.255-.177.455-.048.108-.113.21-.18.313a2 2 0 0 0-.24.466c-.224.729.774 1.247 1.47 1.458 1.555.48 3.072-.334 3.458-1.592.358-1.158-.373-1.965-.677-2.274l-1.472-1.578c-.674-.751-2.157-2.843-1.434-5.194.28-.904.866-1.867 1.719-2.503 1.799-1.34 3.755-1.561 5.617-1.027 1.811.523 2.916 1.553 3.99 2.555.355.33.707.659 1.08.965.84-2.464 2.005-4.878 3.757-6.914"
@@ -15316,7 +15316,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1916">
+              <clipPath id="clip0_1031_1916-:r8q:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15344,20 +15344,20 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1917)"
+               clip-path="url(#clip0_1031_1917-:r8r:)"
                clip-rule="evenodd"
             >
-              <path fill="url(#paint0_linear_1031_1917)"
+              <path fill="url(#paint0_linear_1031_1917-:r8r:)"
                     d="M24 46c12.15 0 22-9.85 22-22S36.15 2 24 2 2 11.85 2 24s9.85 22 22 22m0 2c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1917)"
+              <path fill="url(#paint1_linear_1031_1917-:r8r:)"
                     d="M24 43c10.493 0 19-8.507 19-19S34.493 5 24 5 5 13.507 5 24c0 2.957.676 5.756 1.88 8.252.85-.542 2.016-1.22 3.395-2.022C16.98 26.328 28.75 19.48 34 11c-.333 5-2.8 15.6-10 18 1.667-.333 5.5-2.5 7.5-5.5 0 3.5-2.3 10-9.5 12 1.167 0 3.9-.4 5.5-2-.948 3.316-5.217 8.698-13.149 6.871A18.9 18.9 0 0 0 24 43"
               >
               </path>
             </g>
             <defs>
-              <linearGradient id="paint0_linear_1031_1917"
+              <linearGradient id="paint0_linear_1031_1917-:r8r:"
                               x1="3.158"
                               x2="45.474"
                               y1="8.211"
@@ -15371,7 +15371,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1917"
+              <linearGradient id="paint1_linear_1031_1917-:r8r:"
                               x1="7.5"
                               x2="41"
                               y1="11.5"
@@ -15385,7 +15385,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1917">
+              <clipPath id="clip0_1031_1917-:r8r:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15412,7 +15412,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1986)">
+            <g clip-path="url(#clip0_1031_1986-:r8s:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M0 14.237A5.287 5.287 0 0 1 5.223 8.95C9.699 3.494 16.43 0 24.035 0c5.52 0 10.621 1.888 14.686 5.046q.335-.042.679-.043a5.287 5.287 0 0 1 5.135 6.553 23.5 23.5 0 0 1 2.952 7.487l.002.01.002.012c.286 1.577.509 3.193.509 4.899 0 13.232-10.733 23.965-23.965 23.965C10.81 47.929 0 37.272 0 23.964c0-2.31.315-4.565.948-6.704A5.26 5.26 0 0 1 0 14.237m43.466-.566A5.288 5.288 0 1 1 36.5 5.868a21.87 21.87 0 0 0-12.466-3.892q-1.441 0-2.834.178a27.6 27.6 0 0 0-.336 4.33q.001 3.995 1.007 7.632.233-.02.472-.02a5.29 5.29 0 0 1 4.677 2.819 40 40 0 0 1 7.586-.705c3.617 0 7.128.484 10.485 1.407a21.5 21.5 0 0 0-1.626-3.946m2.153 6.157a37.5 37.5 0 0 0-11.012-1.642c-2.408 0-4.759.21-7.006.63q.03.28.03.567a5.27 5.27 0 0 1-1.572 3.762c1.73 2.42 3.787 4.582 6.086 6.368a5.3 5.3 0 0 1 3.223-1.11 5.12 5.12 0 0 1 3.106.929c2.273-1.321 4.763-2.37 7.424-3.007q.125-1.164.126-2.361c0-1.398-.166-2.754-.405-4.136m-.054 8.624a25.7 25.7 0 0 0-5.693 2.358 5.28 5.28 0 0 1 .776 3.296c.795.284 1.633.502 2.512.713a21.8 21.8 0 0 0 2.405-6.367M30.813 30.98a32.6 32.6 0 0 1-6.395-6.733 5.285 5.285 0 0 1-6.655-2.222 39 39 0 0 0-3.938 2.264 28.3 28.3 0 0 1 1.563 5.266 5.29 5.29 0 0 1 .304 10.314c-.205 1.403-.543 2.756-.931 4.053a22.1 22.1 0 0 0 9.274 2.03q.965 0 1.908-.083a26.7 26.7 0 0 1 4.81-9.675 5.3 5.3 0 0 1-.658-2.575c0-.974.248-1.872.718-2.64m11.231 5.6c-3.24 4.615-8.21 7.93-13.966 9a24.7 24.7 0 0 1 3.976-7.838 5.28 5.28 0 0 0 3.329 1.164 5.29 5.29 0 0 0 4.712-2.9c.642.224 1.299.408 1.95.573m-29.07 6.415A22.07 22.07 0 0 1 4.1 33.405a38.5 38.5 0 0 1 8.056-7.959c.512 1.326.92 2.699 1.215 4.11a5.29 5.29 0 0 0 .302 10.432 27 27 0 0 1-.7 3.008m4.136-22.853a41 41 0 0 0-4.1 2.32 29.8 29.8 0 0 0-3.32-5.296 5.289 5.289 0 0 0-2.253-7.762c3.062-3.402 7.114-5.86 11.715-6.892a30 30 0 0 0-.263 3.972q0 4.257 1.082 8.171a5.29 5.29 0 0 0-2.86 5.487m-11.823-.618a5.26 5.26 0 0 0 3.005-.936 27.7 27.7 0 0 1 3.065 4.997A40.5 40.5 0 0 0 3.23 31.3a22 22 0 0 1-1.253-7.337c0-1.783.204-3.52.608-5.181a5.26 5.26 0 0 0 2.703.742m0-8.599a3.311 3.311 0 1 0 0 6.623 3.311 3.311 0 0 0 0-6.623m30.802-.635a3.311 3.311 0 1 1 6.622 0 3.311 3.311 0 0 1-6.622 0m-13.745 5.78a3.311 3.311 0 1 0 0 6.623 3.311 3.311 0 0 0 0-6.622M11.068 34.748a3.311 3.311 0 1 1 6.623 0 3.311 3.311 0 0 1-6.623 0m27.626-1.127c0-1.857-1.46-3.295-3.282-3.241h-.029a3.38 3.38 0 0 0-2.559 1.2l-.01.012-.01.011c-.461.514-.733 1.19-.733 2.018 0 1.85 1.461 3.31 3.312 3.31 1.84 0 3.31-1.52 3.31-3.31"
@@ -15421,7 +15421,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1986">
+              <clipPath id="clip0_1031_1986-:r8s:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15448,7 +15448,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1891)">
+            <g clip-path="url(#clip0_1031_1891-:r8t:)">
               <rect width="48"
                     height="48"
                     fill="#3367C6"
@@ -15501,7 +15501,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1891">
+              <clipPath id="clip0_1031_1891-:r8t:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15552,7 +15552,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1939)">
+            <g clip-path="url(#clip0_1031_1939-:r8v:)">
               <path fill="#888"
                     fill-rule="evenodd"
                     d="M33.777 0c.319 2.809-.838 5.634-2.555 7.663-1.716 2.029-4.528 3.605-7.283 3.396-.38-2.752 1.015-5.628 2.604-7.423C28.315 1.608 31.305.096 33.777 0M27.18 12.987c1.81-.7 4.059-1.57 6.538-1.39 1.584.115 6.085.577 8.998 4.769l-.02.012c-.418.248-5.344 3.17-5.288 9.122.065 7.264 6.519 9.684 6.592 9.711l-.014.044c-.136.431-1.126 3.558-3.388 6.783-2.048 2.928-4.17 5.839-7.518 5.9-1.607.029-2.682-.426-3.8-.898-1.17-.495-2.386-1.01-4.308-1.01-2.015 0-3.288.53-4.514 1.041-1.063.443-2.09.87-3.535.926-3.232.12-5.693-3.162-7.756-6.074-4.217-5.96-7.442-16.842-3.113-24.186 2.15-3.647 5.993-5.96 10.162-6.018 1.8-.033 3.542.641 5.067 1.232 1.165.45 2.204.853 3.045.853.741 0 1.71-.375 2.852-.817"
@@ -15561,7 +15561,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1939">
+              <clipPath id="clip0_1031_1939-:r8v:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15588,14 +15588,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2036)">
+            <g clip-path="url(#clip0_1031_2036-:r90:)">
               <path fill="#F22F46"
                     d="M23.04 18.08c0 2.72-2.24 4.96-4.96 4.96s-4.96-2.24-4.96-4.96 2.24-4.96 4.96-4.96 4.96 2.24 4.96 4.96m-4.96 6.88c-2.72 0-4.96 2.24-4.96 4.96s2.24 4.96 4.96 4.96 4.96-2.24 4.96-4.96-2.24-4.96-4.96-4.96M48 24c0 13.28-10.72 24-24 24S0 37.28 0 24 10.72 0 24 0s24 10.72 24 24m-6.4 0c0-9.76-7.84-17.6-17.6-17.6S6.4 14.24 6.4 24 14.24 41.6 24 41.6 41.6 33.76 41.6 24m-11.68.96c-2.72 0-4.96 2.24-4.96 4.96s2.24 4.96 4.96 4.96 4.96-2.24 4.96-4.96-2.24-4.96-4.96-4.96m0-11.84c-2.72 0-4.96 2.24-4.96 4.96s2.24 4.96 4.96 4.96 4.96-2.24 4.96-4.96-2.24-4.96-4.96-4.96"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2036">
+              <clipPath id="clip0_1031_2036-:r90:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15622,7 +15622,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1977)">
+            <g clip-path="url(#clip0_1031_1977-:r91:)">
               <path fill="#007ACC"
                     d="M0 24V0h48v48H0"
               >
@@ -15635,7 +15635,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1977">
+              <clipPath id="clip0_1031_1977-:r91:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -15662,7 +15662,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1991)">
+            <g clip-path="url(#clip0_1031_1991-:r92:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M30 24c0 7.732-6.268 14-14 14S2 31.732 2 24s6.268-14 14-14 14 6.268 14 14m2 0c0 8.837-7.163 16-16 16S0 32.837 0 24C0 15.84 6.107 9.108 14 8.124V6h-.5a1.5 1.5 0 0 1 0-3h5a1.5 1.5 0 0 1 0 3H18v2.124c2.007.25 3.899.872 5.604 1.795l1.229-2.129-.967-.558a1 1 0 0 1 1-1.732l3.464 2a1 1 0 1 1-1 1.732l-.765-.442-1.264 2.19C29.357 13.881 32 18.631 32 24m12 4a4 4 0 0 1-3.874-3H34v-2h6.126A4.002 4.002 0 0 1 48 24a4 4 0 0 1-4 4m-5.705-17.38a4 4 0 1 0-1.544-1.285l-4.433 4.434 1.414 1.414zM36 41c0-.87.278-1.677.75-2.334l-4.432-4.432 1.414-1.415 4.562 4.562A4 4 0 1 1 36 41m8-15a2 2 0 1 0 0-4 2 2 0 0 0 0 4M42 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0m-2 36a2 2 0 1 0 0-4 2 2 0 0 0 0 4M14.508 25.822a2.133 2.133 0 0 0 3.018 0c.833-.833 9.13-10.48 8.296-11.313-.833-.834-10.48 7.463-11.313 8.296a2.133 2.133 0 0 0 0 3.017"
@@ -15671,7 +15671,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1991">
+              <clipPath id="clip0_1031_1991-:r92:">
                 <path fill="#fff"
                       d="M0 48V0h48v48z"
                 >
@@ -15762,19 +15762,19 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   d="m55.302 14.182-9.89-4.762A2.99 2.99 0 0 0 42 10L9.623 39.52a2 2 0 0 0 .002 2.957l2.645 2.405a2 2 0 0 0 2.554.113l38.99-29.578C55.12 14.425 57 15.358 57 17v-.115a3 3 0 0 0-1.699-2.703"
             >
             </path>
-            <g filter="url(#filter0_d_1031_1962)">
+            <g filter="url(#filter0_d_1031_1962-:r95:)">
               <path fill="#007ACC"
                     d="m55.302 51.818-9.89 4.762A2.99 2.99 0 0 1 42 56L9.623 26.48a2 2 0 0 1 .002-2.958l2.645-2.404a2 2 0 0 1 2.554-.114l38.99 29.578C55.12 51.574 57 50.642 57 49v.115a3 3 0 0 1-1.699 2.703"
               >
               </path>
             </g>
-            <g filter="url(#filter1_d_1031_1962)">
+            <g filter="url(#filter1_d_1031_1962-:r95:)">
               <path fill="#1F9CF0"
                     d="M45.412 56.58A2.99 2.99 0 0 1 42 56c1.107 1.107 3 .323 3-1.243V11.242c0-1.565-1.893-2.35-3-1.242a2.99 2.99 0 0 1 3.412-.58l9.888 4.755a3 3 0 0 1 1.7 2.703v32.244a3 3 0 0 1-1.7 2.703z"
               >
               </path>
             </g>
-            <path fill="url(#paint0_linear_1031_1962)"
+            <path fill="url(#paint0_linear_1031_1962-:r95:)"
                   fill-rule="evenodd"
                   d="M43.009 56.672a2.99 2.99 0 0 0 2.38-.091l9.883-4.756a3 3 0 0 0 1.699-2.703V16.878a3 3 0 0 0-1.699-2.703L45.39 9.419a2.99 2.99 0 0 0-3.41.58L23.06 27.26l-8.24-6.255a2 2 0 0 0-2.553.114l-2.643 2.404a2 2 0 0 0-.002 2.958L16.769 33l-7.146 6.52a2 2 0 0 0 .002 2.957l2.643 2.405a2 2 0 0 0 2.553.113l8.24-6.255L41.98 56c.3.3.65.525 1.029.672m1.97-34.569L30.622 33l14.355 10.896z"
                   clip-rule="evenodd"
@@ -15783,7 +15783,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
             >
             </path>
             <defs>
-              <filter id="filter0_d_1031_1962"
+              <filter id="filter0_d_1031_1962-:r95:"
                       width="64.696"
                       height="52.944"
                       x="0.637"
@@ -15817,7 +15817,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </feBlend>
               </filter>
-              <filter id="filter1_d_1031_1962"
+              <filter id="filter1_d_1031_1962-:r95:"
                       width="31.667"
                       height="64.419"
                       x="33.667"
@@ -15851,7 +15851,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </feBlend>
               </filter>
-              <linearGradient id="paint0_linear_1031_1962"
+              <linearGradient id="paint0_linear_1031_1962-:r95:"
                               x1="32.971"
                               x2="32.971"
                               y1="9.124"
@@ -15943,7 +15943,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1894)">
+            <g clip-path="url(#clip0_1031_1894-:r98:)">
               <path fill="#888"
                     fill-rule="evenodd"
                     d="M33.777 0c.319 2.809-.838 5.634-2.555 7.663-1.716 2.029-4.528 3.605-7.283 3.396-.38-2.752 1.015-5.628 2.604-7.423C28.315 1.608 31.305.096 33.777 0M27.18 12.987c1.81-.7 4.059-1.57 6.538-1.39 1.584.115 6.085.577 8.998 4.769l-.02.012c-.418.248-5.344 3.17-5.288 9.122.065 7.264 6.519 9.684 6.592 9.711l-.014.044c-.136.431-1.126 3.558-3.388 6.783-2.048 2.928-4.17 5.839-7.518 5.9-1.607.029-2.682-.426-3.8-.898-1.17-.495-2.386-1.01-4.308-1.01-2.015 0-3.288.53-4.514 1.041-1.063.443-2.09.87-3.535.926-3.232.12-5.693-3.162-7.756-6.074-4.217-5.96-7.442-16.842-3.113-24.186 2.15-3.647 5.993-5.96 10.162-6.018 1.8-.033 3.542.641 5.067 1.232 1.165.45 2.204.853 3.045.853.741 0 1.71-.375 2.852-.817"
@@ -15952,7 +15952,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1894">
+              <clipPath id="clip0_1031_1894-:r98:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -16009,7 +16009,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1965)">
+            <g clip-path="url(#clip0_1031_1965-:r9a:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z"
@@ -16022,7 +16022,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1965">
+              <clipPath id="clip0_1031_1965-:r9a:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -16049,7 +16049,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1949)">
+            <g clip-path="url(#clip0_1031_1949-:r9b:)">
               <path fill="#C73A63"
                     d="M22.496 20.73c-1.997 3.356-3.91 6.607-5.863 9.833-.501.828-.75 1.502-.349 2.555 1.106 2.908-.454 5.738-3.387 6.507-2.765.724-5.46-1.093-6.009-4.054-.486-2.621 1.548-5.19 4.438-5.6.242-.035.489-.039.896-.07l4.395-7.37c-2.764-2.75-4.41-5.962-4.046-9.944.258-2.815 1.365-5.247 3.388-7.241C19.833 1.528 25.744.91 30.307 3.84c4.381 2.815 6.388 8.298 4.678 12.99l-4.017-1.089c.537-2.609.14-4.952-1.62-6.959-1.162-1.325-2.654-2.02-4.35-2.276-3.401-.513-6.74 1.671-7.731 5.01-1.125 3.787.578 6.882 5.229 9.214"
               >
@@ -16064,7 +16064,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1949">
+              <clipPath id="clip0_1031_1949-:r9b:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -16182,7 +16182,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="#03020D"
-               clip-path="url(#clip0_1031_1959)"
+               clip-path="url(#clip0_1031_1959-:r9e:)"
             >
               <path fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z"
@@ -16193,7 +16193,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1959">
+              <clipPath id="clip0_1031_1959-:r9e:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -16220,14 +16220,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1957)">
+            <g clip-path="url(#clip0_1031_1957-:r9f:)">
               <path fill="#3498DB"
                     d="M13.85 3c-1.296.003-2.565.739-3.218 1.861L.482 22.493a3.84 3.84 0 0 0 0 3.723l10.15 17.631c.652 1.123 1.922 1.86 3.218 1.862h20.3c1.297-.003 2.566-.739 3.218-1.862l10.15-17.632a3.84 3.84 0 0 0 0-3.722L37.368 4.861C36.715 3.74 35.446 3.003 34.15 3zm.184 10.315a.4.4 0 0 1 .085 0h3.502a.46.46 0 0 1 .383.227l5.94 10.585q.045.079.056.17a.5.5 0 0 1 .056-.17l5.926-10.585a.46.46 0 0 1 .397-.227h3.501c.31.003.543.393.397.668L28.48 24.354l5.798 10.358c.16.276-.078.684-.397.682H30.38a.46.46 0 0 1-.397-.242l-5.926-10.585a.5.5 0 0 1-.056-.17.5.5 0 0 1-.057.17l-5.94 10.585a.46.46 0 0 1-.382.242h-3.502c-.318.003-.556-.406-.397-.682l5.798-10.358-5.798-10.371c-.139-.25.03-.615.312-.668"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1957">
+              <clipPath id="clip0_1031_1957-:r9f:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -16254,7 +16254,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_2008)">
+            <g clip-path="url(#clip0_1031_2008-:r9g:)">
               <path fill="#03020D"
                     fill-rule="evenodd"
                     d="M44 2H4a2 2 0 0 0-2 2v40a2 2 0 0 0 2 2h40a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2M4 0a4 4 0 0 0-4 4v40a4 4 0 0 0 4 4h40a4 4 0 0 0 4-4V4a4 4 0 0 0-4-4z"
@@ -16267,7 +16267,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_2008">
+              <clipPath id="clip0_1031_2008-:r9g:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -16294,7 +16294,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <path fill="url(#paint0_linear_1031_1929)"
+            <path fill="url(#paint0_linear_1031_1929-:r9h:)"
                   d="M38.153 10.915c.02.362-.481.267-.481.632 0 10.637-12.528 26.865-24.672 30V42c16.133-1.523 34.594-18.707 35-35l-9.848 3.915"
             >
             </path>
@@ -16306,7 +16306,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                   d="m40.887 10.001-2.008.74c.01.262.017.614.017.878 0 11.212-9.828 26.713-23.013 29.138-.856.296-1.988.565-2.883.797V42c17.207-1.512 29.297-19.549 27.889-32z"
             >
             </path>
-            <path fill="url(#paint1_linear_1031_1929)"
+            <path fill="url(#paint1_linear_1031_1929-:r9h:)"
                   d="M10.129 10.915c-.022.362.494.267.494.632 0 10.637 12.886 26.865 25.377 30V42C19.407 40.477.418 23.293 0 7z"
             >
             </path>
@@ -16319,7 +16319,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_1031_1929"
+              <linearGradient id="paint0_linear_1031_1929-:r9h:"
                               x1="30.511"
                               x2="30.511"
                               y1="42"
@@ -16339,7 +16339,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1929"
+              <linearGradient id="paint1_linear_1031_1929-:r9h:"
                               x1="17.989"
                               x2="17.989"
                               y1="42"
@@ -16380,14 +16380,14 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
                style="width: 24px; height: 24px;"
           >
-            <g clip-path="url(#clip0_1031_1930)">
+            <g clip-path="url(#clip0_1031_1930-:r9i:)">
               <path fill="#FF4A00"
                     d="M30 24.01c0 1.731-.312 3.448-.922 5.067a14.4 14.4 0 0 1-5.068.924h-.02a14.4 14.4 0 0 1-5.067-.923A14.4 14.4 0 0 1 18 24.011v-.021c0-1.73.311-3.447.92-5.067A14.3 14.3 0 0 1 23.99 18h.02c1.731 0 3.448.312 5.068.923.61 1.62.923 3.336.922 5.066zM47.667 20h-14.01l9.906-9.906a24 24 0 0 0-2.593-3.066 24 24 0 0 0-3.065-2.59L28 14.342V.334A24 24 0 0 0 24.012 0h-.025c-1.359 0-2.69.116-3.987.334v14.01l-9.906-9.907A24 24 0 0 0 7.03 7.03l-.006.004a24 24 0 0 0-2.589 3.06L14.343 20H.334S0 22.631 0 23.992v.016c0 1.36.115 2.694.334 3.992h14.01l-9.908 9.906a24.2 24.2 0 0 0 5.658 5.658L20 33.657v14.01c1.316.22 2.648.332 3.983.333h.034a24 24 0 0 0 3.982-.333v-14.01l9.907 9.907a24 24 0 0 0 3.064-2.592l.002-.002a24 24 0 0 0 2.59-3.064L33.657 28h14.01c.219-1.296.333-2.625.334-3.983v-.034A24 24 0 0 0 47.667 20"
               >
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1930">
+              <clipPath id="clip0_1031_1930-:r9i:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -16415,7 +16415,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                style="width: 24px; height: 24px;"
           >
             <g fill="red"
-               clip-path="url(#clip0_1031_1935)"
+               clip-path="url(#clip0_1031_1935-:r9j:)"
             >
               <path fill-rule="evenodd"
                     d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24m0-9c8.284 0 15-6.716 15-15S32.284 9 24 9 9 15.716 9 24s6.716 15 15 15"
@@ -16426,7 +16426,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
               </path>
             </g>
             <defs>
-              <clipPath id="clip0_1031_1935">
+              <clipPath id="clip0_1031_1935-:r9j:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >

--- a/src/core/Icon/utils.ts
+++ b/src/core/Icon/utils.ts
@@ -60,3 +60,37 @@ export const getHeroicon = (
     return null;
   }
 };
+
+export const setUniqueIds = (el: SVGSVGElement | null, uniqueId: string) => {
+  if (el) {
+    // Find all elements with IDs in defs and their URL references
+    const defsElements = el.querySelectorAll("defs [id]");
+    const elementsWithUrls = el.querySelectorAll(
+      '[fill*="url("], [stroke*="url("], [filter*="url("], [clip-path*="url("], [mask*="url("]',
+    );
+
+    defsElements.forEach((def) => {
+      const oldId = def.id;
+
+      // Prevent re-aliasing of processed ids
+      if (oldId.includes(uniqueId)) {
+        return;
+      }
+
+      const newId = `${oldId}-${uniqueId}`;
+
+      def.id = newId;
+
+      // Update all URL references to this ID
+      const regex = new RegExp(`url\\(#${oldId}\\)`, "g");
+      elementsWithUrls.forEach((element) => {
+        ["fill", "stroke", "filter", "clip-path", "mask"].forEach((attr) => {
+          const value = element.getAttribute(attr);
+          if (value && value.includes(`url(#${oldId})`)) {
+            element.setAttribute(attr, value.replace(regex, `url(#${newId})`));
+          }
+        });
+      });
+    });
+  }
+};

--- a/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
+++ b/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
@@ -63,14 +63,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                class="hidden group-hover/product-tile:flex"
                style="width: 26.6667px; height: 26.6667px;"
           >
-            <path fill="url(#paint0_linear_3807_142)"
+            <path fill="url(#paint0_linear_3807_142-:rk:)"
                   fill-rule="evenodd"
                   d="M54.48 12.572c3.453-5.551 12.02-3.105 12.02 3.433V41.5h41.302c5.099 0 8.212 5.603 5.519 9.933L73.52 115.428c-3.453 5.551-12.02 3.105-12.02-3.433V86.5H20.198c-5.099 0-8.212-5.603-5.52-9.933z"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_142"
+              <linearGradient id="paint0_linear_3807_142-:rk:"
                               x1="64"
                               x2="64"
                               y1="27.434"
@@ -137,14 +137,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                class="hidden group-hover/product-tile:flex"
                style="width: 26.6667px; height: 26.6667px;"
           >
-            <path fill="url(#paint0_linear_3636_438)"
+            <path fill="url(#paint0_linear_3636_438-:rm:)"
                   fill-rule="evenodd"
                   d="M11.5 35c0-12.426 10.074-22.5 22.5-22.5h60c12.426 0 22.5 10.074 22.5 22.5v74.41c0 7.385-8.77 11.257-14.227 6.281l-22.812-20.8a1.5 1.5 0 0 0-1.01-.391H34c-12.426 0-22.5-10.074-22.5-22.5z"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3636_438"
+              <linearGradient id="paint0_linear_3636_438-:rm:"
                               x1="64"
                               x2="64"
                               y1="29.85"
@@ -211,12 +211,12 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                class="hidden group-hover/product-tile:flex"
                style="width: 26.6667px; height: 26.6667px;"
           >
-            <path fill="url(#paint0_linear_3807_221)"
+            <path fill="url(#paint0_linear_3807_221-:ro:)"
                   d="M15.318 25.777c-1.762-6.366 4.093-12.221 10.46-10.46l84.559 23.406c7.856 2.174 8.443 13.088.866 16.093L73.036 69.951a5.5 5.5 0 0 0-3.085 3.085l-15.135 38.167c-3.005 7.577-13.919 6.99-16.093-.866z"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_221"
+              <linearGradient id="paint0_linear_3807_221-:ro:"
                               x1="65.785"
                               x2="65.785"
                               y1="31.716"
@@ -283,14 +283,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                class="hidden group-hover/product-tile:flex"
                style="width: 26.6667px; height: 26.6667px;"
           >
-            <path fill="url(#paint0_linear_3807_387)"
+            <path fill="url(#paint0_linear_3807_387-:rq:)"
                   fill-rule="evenodd"
                   d="M13.5 52a2.5 2.5 0 0 0-5 0v25c0 23.472 19.028 42.5 42.5 42.5h64.029c3.353 0 4.787-4.26 2.117-6.288l-50.03-37.985c-2.304-1.75-5.616-.106-5.616 2.788V114.5H51c-20.71 0-37.5-16.79-37.5-37.5zm53-2.015c0 2.894-3.312 4.538-5.617 2.788L10.854 14.788C8.184 12.76 9.618 8.5 12.971 8.5H77c23.472 0 42.5 19.028 42.5 42.5v25a2.5 2.5 0 1 1-5 0V51c0-20.71-16.79-37.5-37.5-37.5H66.5z"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_387"
+              <linearGradient id="paint0_linear_3807_387-:rq:"
                               x1="64"
                               x2="64"
                               y1="101.232"
@@ -358,14 +358,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                class="hidden group-hover/product-tile:flex"
                style="width: 26.6667px; height: 26.6667px;"
           >
-            <path fill="url(#paint0_linear_3807_424)"
+            <path fill="url(#paint0_linear_3807_424-:rs:)"
                   fill-rule="evenodd"
                   d="M72.208 116.222C85.188 101.747 109 72.533 109 53c0-24.853-20.147-45-45-45S19 28.147 19 53c0 19.533 23.811 48.747 36.792 63.222 4.435 4.945 11.98 4.945 16.416 0M64 71c9.941 0 18-8.059 18-18s-8.059-18-18-18-18 8.059-18 18 8.059 18 18 18"
                   clip-rule="evenodd"
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_424"
+              <linearGradient id="paint0_linear_3807_424-:rs:"
                               x1="64"
                               x2="64"
                               y1="26.421"
@@ -435,7 +435,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                   height="110"
                   x="9"
                   y="9"
-                  fill="url(#paint0_linear_3807_520)"
+                  fill="url(#paint0_linear_3807_520-:ru:)"
                   rx="26"
             >
             </rect>
@@ -447,7 +447,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
             >
             </path>
             <defs>
-              <linearGradient id="paint0_linear_3807_520"
+              <linearGradient id="paint0_linear_3807_520-:ru:"
                               x1="64"
                               x2="64"
                               y1="27.103"

--- a/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
+++ b/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
@@ -495,7 +495,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r0:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -506,7 +506,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r0:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -532,7 +532,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r1:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -543,7 +543,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r1:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -580,7 +580,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r2:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -591,7 +591,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r2:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -617,7 +617,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r3:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -628,7 +628,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r3:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -665,7 +665,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r4:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -676,7 +676,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r4:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -702,7 +702,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r5:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -713,7 +713,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r5:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -758,7 +758,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r6:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -769,7 +769,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r6:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -795,7 +795,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r7:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -806,7 +806,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r7:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -843,7 +843,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r8:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -854,7 +854,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r8:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -880,7 +880,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:r9:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -891,7 +891,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:r9:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -928,7 +928,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:ra:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -939,7 +939,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:ra:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -965,7 +965,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >
-          <g clip-path="url(#clip0_1031_1922)">
+          <g clip-path="url(#clip0_1031_1922-:rb:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -976,7 +976,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
             </path>
           </g>
           <defs>
-            <clipPath id="clip0_1031_1922">
+            <clipPath id="clip0_1031_1922-:rb:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >


### PR DESCRIPTION
A fun quirk of switching from spritesheets to inline SVGs packaged within React components is that we now have to worry about ID duplication in complex assets that have gradients and such. 

The problem currently is that IDs for paths within Icons are baked into the assets themselves, meaning that, much like other HTML elements with duplicate IDs, you can get unexpected behaviour when two or more are on the page at one time. In this case, we were getting blank tech icons when switching from desktop to mobile. This will influence the code blocks in docs, but also probably the new dashboard.

The solution here is to, in the Icon component, conditionally append a generated key to SVG sub-elements with IDs so that subsequent instances of the same icon are distinct where the DOM is concerned.

To test, go to the "With SDK Types" [CodeSnippet example](https://ably.github.io/ably-ui/?path=/story/components-code-snippet--with-sdk-types), click on "Rest", and verify that the Kotlin icon is present between desktop and mobile modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved SVG icon rendering to ensure unique IDs for each icon instance, preventing potential conflicts when using multiple icons on the same page.

- **Refactor**
  - Updated the logic for rendering icons to better separate handling of local and external icon types, with distinct styling and behavior.
  - Enhanced dark mode and secondary color handling for local icons.

- **Style**
  - Updated the code snippet example in the documentation to display a Kotlin snippet instead of TypeScript.

- **Chores**
  - Incremented package version to 17.3.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->