### PR TITLE
[WEB-4440] fix: implement correct axis overflows for code component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.4.1",
+  "version": "17.4.2",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Code.tsx
+++ b/src/core/Code.tsx
@@ -37,7 +37,10 @@ const Code = ({
   const lineCount = lines.length;
 
   return (
-    <div className={cn("hljs flex", padding, additionalCSS)} data-id="code">
+    <div
+      className={cn("hljs overflow-y-auto flex", padding, additionalCSS)}
+      data-id="code"
+    >
       {showLines ? (
         <div className="text-code leading-6 pt-px">
           {[...Array(lineCount)].map((_, i) => (
@@ -53,7 +56,7 @@ const Code = ({
           ))}
         </div>
       ) : null}
-      <pre lang={language} className="overflow-auto flex-1 leading-6">
+      <pre lang={language} className="overflow-x-auto h-full flex-1 leading-6">
         <code
           className={className}
           dangerouslySetInnerHTML={{ __html: HTMLraw }}

--- a/src/core/Code/__snapshots__/Code.stories.tsx.snap
+++ b/src/core/Code/__snapshots__/Code.stories.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Code CodeWithLines smoke-test 1`] = `
-<div class="hljs flex p-8"
+<div class="hljs overflow-y-auto flex p-8"
      data-id="code"
 >
   <div class="text-code leading-6 pt-px">
@@ -28,7 +28,7 @@ exports[`Components/Code CodeWithLines smoke-test 1`] = `
     </p>
   </div>
   <pre lang="javascript"
-       class="overflow-auto flex-1 leading-6"
+       class="overflow-x-auto h-full flex-1 leading-6"
   >
     <code class="language-javascript ui-text-code">
       <span class="hljs-keyword">
@@ -101,11 +101,11 @@ exports[`Components/Code CodeWithLines smoke-test 1`] = `
 `;
 
 exports[`Components/Code Java smoke-test 1`] = `
-<div class="hljs flex p-8"
+<div class="hljs overflow-y-auto flex p-8"
      data-id="code"
 >
   <pre lang="java"
-       class="overflow-auto flex-1 leading-6"
+       class="overflow-x-auto h-full flex-1 leading-6"
   >
     <code class="language-java ui-text-code">
       <span class="hljs-type">
@@ -184,11 +184,11 @@ channel.subscribe(
 `;
 
 exports[`Components/Code Javascript smoke-test 1`] = `
-<div class="hljs flex bg-neutral-1200 p-4"
+<div class="hljs overflow-y-auto flex bg-neutral-1200 p-4"
      data-id="code"
 >
   <pre lang="javascript"
-       class="overflow-auto flex-1 leading-6"
+       class="overflow-x-auto h-full flex-1 leading-6"
   >
     <code class="language-javascript ui-text-code">
       <span class="hljs-keyword">
@@ -261,11 +261,11 @@ exports[`Components/Code Javascript smoke-test 1`] = `
 `;
 
 exports[`Components/Code Kotlin smoke-test 1`] = `
-<div class="hljs flex p-8"
+<div class="hljs overflow-y-auto flex p-8"
      data-id="code"
 >
   <pre lang="kotlin"
-       class="overflow-auto flex-1 leading-6"
+       class="overflow-x-auto h-full flex-1 leading-6"
   >
     <code class="language-kotlin ui-text-code">
       <span class="hljs-keyword">
@@ -318,11 +318,11 @@ exports[`Components/Code Kotlin smoke-test 1`] = `
 `;
 
 exports[`Components/Code Swift smoke-test 1`] = `
-<div class="hljs flex p-8"
+<div class="hljs overflow-y-auto flex p-8"
      data-id="code"
 >
   <pre lang="swift"
-       class="overflow-auto flex-1 leading-6"
+       class="overflow-x-auto h-full flex-1 leading-6"
   >
     <code class="language-swift ui-text-code">
       <span class="hljs-keyword">

--- a/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
+++ b/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
@@ -154,7 +154,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -181,7 +181,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -264,7 +264,7 @@ exports[`Components/Code Snippet FixedMode smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -291,7 +291,7 @@ exports[`Components/Code Snippet FixedMode smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -425,7 +425,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -494,7 +494,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
         </p>
       </div>
       <pre lang="json"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-json ui-text-code">
           <span class="hljs-punctuation">
@@ -712,11 +712,11 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <div class="hljs flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+      <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
            data-id="code"
       >
         <pre lang="shell"
-             class="overflow-auto flex-1 leading-6"
+             class="overflow-x-auto h-full flex-1 leading-6"
         >
           <code class="language-shell ui-text-code">
             npm install @ably/asset-tracking
@@ -756,11 +756,11 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <div class="hljs flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+      <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
            data-id="code"
       >
         <pre lang="shell"
-             class="overflow-auto flex-1 leading-6"
+             class="overflow-x-auto h-full flex-1 leading-6"
         >
           <code class="language-shell ui-text-code">
             <span class="hljs-built_in">
@@ -800,11 +800,11 @@ npm run start
           </svg>
         </div>
       </div>
-      <div class="hljs flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+      <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
            data-id="code"
       >
         <pre lang="shell"
-             class="overflow-auto flex-1 leading-6"
+             class="overflow-x-auto h-full flex-1 leading-6"
         >
           <code class="language-shell ui-text-code">
             curl -X POST https://api.ably.io/keys \\
@@ -867,11 +867,11 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
         </svg>
       </div>
     </div>
-    <div class="hljs flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+    <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
          data-id="code"
     >
       <pre lang="shell"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-shell ui-text-code">
           npm install @ably/asset-tracking
@@ -889,11 +889,11 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
   <div class="rounded-lg overflow-hidden bg-neutral-000 dark:bg-neutral-1300 border border-neutral-300 dark:border-neutral-1000 relative flex items-center min-h-12"
        tabindex="0"
   >
-    <div class="hljs flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2"
+    <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2"
          data-id="code"
     >
       <pre lang="text"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-text ui-text-code">
           It was the best of times, it was the blurst of times.
@@ -943,7 +943,7 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -970,7 +970,7 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -1102,7 +1102,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -1129,7 +1129,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -1376,7 +1376,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -1403,7 +1403,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -1895,7 +1895,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -1922,7 +1922,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
         </p>
       </div>
       <pre lang="swift"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-swift ui-text-code">
           <span class="hljs-keyword">
@@ -2263,7 +2263,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -2290,7 +2290,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
         </p>
       </div>
       <pre lang="swift"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-swift ui-text-code">
           <span class="hljs-keyword">
@@ -2520,7 +2520,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -2547,7 +2547,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -2905,7 +2905,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -2932,7 +2932,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -3985,7 +3985,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
     <div class="relative"
          tabindex="0"
     >
-      <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+      <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
            data-id="code"
       >
         <div class="text-code leading-6 pt-px">
@@ -4012,7 +4012,7 @@ exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
           </p>
         </div>
         <pre lang="javascript"
-             class="overflow-auto flex-1 leading-6"
+             class="overflow-x-auto h-full flex-1 leading-6"
         >
           <code class="language-javascript ui-text-code">
             <span class="hljs-keyword">
@@ -4289,7 +4289,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -4316,7 +4316,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
         </p>
       </div>
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">
@@ -4563,11 +4563,11 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <pre lang="javascript"
-           class="overflow-auto flex-1 leading-6"
+           class="overflow-x-auto h-full flex-1 leading-6"
       >
         <code class="language-javascript ui-text-code">
           <span class="hljs-keyword">


### PR DESCRIPTION
Regression from #831, specifically https://github.com/ably/ably-ui/pull/831/commits/11f40512b4d8f9e56da299d20b27250a0d86f74f. We handle horizontal overflows better with the Code component (horizontal scrolling keeps the positioning of the code line numbers intact), but we lost the ability to overflow vertically. This PR adds more specific rules around how to overflow in each axis, and where.

In short, we keep the code line numbers in place when overflowing horizontally, and we scroll the whole unit when overflowing vertically.

This matters in situations like the chat page where we constrain the height of the code snippet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the scrolling behavior and layout of code blocks for better readability and usability.

* **Chores**
  * Updated the application version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->