### PR TITLE
[WEB-4440] chore: group common dependencies together in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,17 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      storybook:
+        patterns:
+          - "@storybook/*"
+          - "storybook"
+      ts-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+      svgr:
+        patterns:
+          - "@svgr/*"
+      swc:
+        patterns:
+          - "@swc/*"


### PR DESCRIPTION
Purely a QoL thing for the day to day. Group common families of packages together in the dependabot config.