### PR TITLE
[WEB-4478] Non-TSX type generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.5.4",
+  "version": "17.5.5",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@types/js-cookie": "^3.0.6",
     "@types/lodash.throttle": "^4.1.9",
+    "@types/mixpanel-browser": "^2.60.0",
     "@types/node": "^20",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
@@ -69,7 +70,7 @@
   "scripts": {
     "build:prebuild": "rm -rf core reset && mkdir -p dist/core",
     "build:swc": "ts-node swc.config.ts",
-    "build:tsc": "tsc && node tsc.js && rm -r types",
+    "build:tsc": "tsc && ts-node tsc.ts && rm -r types",
     "build:cleanup": "mv dist/* . && rm -r dist",
     "build:icons": "ts-node scripts/generate-icons.ts",
     "build": "pnpm build:prebuild && pnpm build:icons && pnpm build:swc && pnpm build:tsc && pnpm build:cleanup",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@types/lodash.throttle':
         specifier: ^4.1.9
         version: 4.1.9
+      '@types/mixpanel-browser':
+        specifier: ^2.60.0
+        version: 2.60.0
       '@types/node':
         specifier: ^20
         version: 20.19.1
@@ -2166,6 +2169,9 @@ packages:
 
   '@types/mdx@2.0.10':
     resolution: {integrity: sha512-Rllzc5KHk0Al5/WANwgSPl1/CwjqCy+AZrGd78zuK+jO9aDM6ffblZ+zIjgPNAaEBmlO0RYDvLNh7wD0zKVgEg==}
+
+  '@types/mixpanel-browser@2.60.0':
+    resolution: {integrity: sha512-70oe8T3KdxHwsSo5aZphALdoqcsIorQBrlisnouIn9Do4dmC2C6/D56978CmSE/BO2QHgb85ojPGa4R8OFvVHA==}
 
   '@types/node@20.19.1':
     resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
@@ -7706,6 +7712,8 @@ snapshots:
   '@types/lodash@4.17.7': {}
 
   '@types/mdx@2.0.10': {}
+
+  '@types/mixpanel-browser@2.60.0': {}
 
   '@types/node@20.19.1':
     dependencies:

--- a/src/core/insights/command-queue.ts
+++ b/src/core/insights/command-queue.ts
@@ -18,7 +18,7 @@ export class InsightsCommandQueue implements AnalyticsService {
   constructor() {
     // Create a proxy that will either queue commands or execute them directly
     return new Proxy(this, {
-      get: (target: InsightsCommandQueue, prop: string) => {
+      get: (target: InsightsCommandQueue, prop: keyof InsightsCommandQueue) => {
         // Return actual properties of the queue
         if (prop in target && typeof target[prop] !== "function") {
           return target[prop];
@@ -40,7 +40,7 @@ export class InsightsCommandQueue implements AnalyticsService {
             }
 
             target.queue.push({
-              methodName: prop as keyof AnalyticsService,
+              methodName: prop,
               args,
             });
 
@@ -49,7 +49,9 @@ export class InsightsCommandQueue implements AnalyticsService {
 
           // Execute the command immediately on the real implementation
           if (typeof target.realImplementation[prop] === "function") {
-            return target.realImplementation[prop](...args);
+            return (
+              target.realImplementation[prop] as (...args: unknown[]) => unknown
+            )(...args);
           }
         };
       },

--- a/src/core/insights/mixpanel.ts
+++ b/src/core/insights/mixpanel.ts
@@ -25,7 +25,7 @@ export const initMixpanel = (
       : false,
     track_pageview: false, // We'll track page views manually
     record_sessions_percent: recordSessionsPercent,
-    record_mask_text_selector: null, // Prevents all text from being masked - we have other masking configured/enabled
+    record_mask_text_selector: undefined, // Prevents all text from being masked - we have other masking configured/enabled
   });
 };
 

--- a/src/core/insights/service.ts
+++ b/src/core/insights/service.ts
@@ -221,7 +221,7 @@ export class InsightsService implements AnalyticsService {
   setupObserver(): () => void {
     // Helper to get all data-insight-* attributes from an element
     const getInsightAttributes = (
-      element,
+      element: HTMLElement,
     ): { event?: string; [key: string]: string | undefined } => {
       // limit how many data attributes we'll process
       const MAX_ATTRIBUTES = 10;
@@ -230,7 +230,7 @@ export class InsightsService implements AnalyticsService {
       const attributes: { event?: string; [key: string]: string | undefined } =
         {};
 
-      for (const attr of element.attributes) {
+      for (const attr of Array.from(element.attributes)) {
         if (count >= MAX_ATTRIBUTES) break;
         if (attr.name.startsWith("data-insight-")) {
           // Validate attribute name format
@@ -244,7 +244,7 @@ export class InsightsService implements AnalyticsService {
           const key = attr.name
             .replace("data-insight-", "")
             .split("-")
-            .map((part, index) =>
+            .map((part: string, index: number) =>
               index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1),
             )
             .join("");
@@ -256,14 +256,15 @@ export class InsightsService implements AnalyticsService {
     };
 
     // Helper to find closest element with data-insight attributes
-    const findClosestElementWithInsights = (element) => {
+    const findClosestElementWithInsights = (element: HTMLElement) => {
       let current = element;
       while (current && current !== document.body) {
         const insights = getInsightAttributes(current);
         if (Object.keys(insights).length > 0) {
           return insights;
         }
-        current = current.parentElement;
+
+        current = current.parentElement as HTMLElement;
       }
       return null;
     };

--- a/src/core/react-renderer.tsx
+++ b/src/core/react-renderer.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 
-const renderComponent = (Component, props, node) => {
+const renderComponent = (
+  Component: React.FC,
+  props: React.ComponentProps<React.FC>,
+  node: HTMLElement,
+) => {
   const root = createRoot(node);
   root.render(<Component {...props} />);
 };
 
 export { renderComponent };
 
-export default function reactRenderer(components) {
+export default function reactRenderer(components: Record<string, React.FC>) {
   const reactComponents = document.querySelectorAll("[data-react]");
 
   Array.from(reactComponents).forEach((node) => {

--- a/tsc.ts
+++ b/tsc.ts
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
+import path from "path";
 
 // Directory containing the .d.ts files
 const directoryPath = "./types";
@@ -9,7 +9,7 @@ const indexPath = "./index.d.ts";
 
 // Function to recursively get all .d.ts files
 function getDtsFiles(dir) {
-  let results = [];
+  let results: string[] = [];
   const list = fs.readdirSync(dir);
 
   list.forEach((file) => {
@@ -19,7 +19,7 @@ function getDtsFiles(dir) {
     if (stat && stat.isDirectory()) {
       // Recursively search in subdirectories
       results = results.concat(getDtsFiles(filePath));
-    } else if (file.endsWith(".d.ts") && file !== "index.d.ts") {
+    } else if (file.endsWith(".d.ts")) {
       // Add .d.ts file to results
       results.push(filePath);
     }
@@ -55,7 +55,8 @@ dtsFiles.forEach((file) => {
     path
       .relative(directoryPath, file)
       .replace(/\\/g, "/")
-      .replace(/\.d\.ts$/, "");
+      .replace(/\.d\.ts$/, "")
+      .replace(/\/index$/, "");
 
   fs.appendFileSync(
     indexPath,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
   "ts-node": {
     "swc": true
   },
-  "include": ["src/**/*.tsx", "custom.d.ts"],
+  "include": ["src/**/*", "custom.d.ts"],
   "exclude": ["node_modules/**/*", "public", "preview", "src/**/*.stories.tsx", "src/core/react-renderer.tsx"]
 }


### PR DESCRIPTION
`ably-ui` generates its own types so that downstream apps can consume these types for its own benefit (and eslint's benefit). Currently, we only generate definitions for `.tsx` files, i.e. the main components. This PR:
- expands this to generate types for both TS and TSX (the wildcard string in tsconfig suggests all types, but TSC only does (T|J)S(X))
- generates types for index files (i.e. ones which re-export a bunch of other assets)
- converts the type compilation script to TS (the only change is stripping "/index" from the end of module names)
- fixes exposed minor typing errors in the insights and renderer code

The motivation for this was to solve a TS error in `website` when importing from `@ably/ui/core/insights` (no types available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version and development dependencies.
  * Modified build scripts for improved TypeScript execution.
  * Broadened TypeScript compiler coverage to include all files in the source directory.

* **Refactor**
  * Improved type safety and robustness across various components and internal helper functions.
  * Updated function signatures with explicit TypeScript type annotations.
  * Migrated script imports to ES module syntax for better compatibility.

* **Style**
  * Enhanced code consistency by refining type annotations and iterable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->