### PR TITLE
[WEB-4478] fix: update icon usage in Button story, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,31 +102,18 @@ import Meganav from "@ably/ui/core/Meganav";
 
 ### Icons
 
-We have access to two sets of icons via the `Icon` component, custom local assets hosted in the repo itself, and the third-party Heroicons library.
+Icons are available in two formats to support different application types:
 
-#### Local Custom Icons
+1. **React Component Imports** (recommended for React apps)
+2. **SVG Spritesheets** (fallback for non-React apps)
 
-Putting SVG files inside a `src/core/icons` folder will:
+We provide access to both custom local assets hosted in the repo and the third-party [Heroicons](https://heroicons.com/) library.
 
-1. Add them to a per-group sprites file (e.g., `core/sprites-gui.svg`) for backward compatibility
-2. Generate React components that can be imported dynamically
+#### For React Applications (Recommended)
 
-The sprites file can be loaded with the `loadSprites` helper available in the `core` module or included in the page directly.
+**Using the Icon React Component**
 
-#### Heroicons Integration
-
-The system automatically falls back to [Heroicons](https://heroicons.com/) when a local icon isn't found, using this naming convention:
-
-- `icon-gui-{heroicon-name}-{variant}`
-
-Where `variant` can be:
-
-- `outline` → 24px outline icons
-- `solid` → 24px solid icons
-- `mini` → 20px solid icons
-- `micro` → 16px solid icons
-
-#### Usage with the Icon React Component
+The `Icon` component is the preferred method for React applications, providing automatic fallback and consistent sizing:
 
 ```tsx
 // Local custom icon
@@ -139,7 +126,17 @@ Where `variant` can be:
 <Icon name="icon-gui-chevron-down" variant="solid" size="1.5rem" />
 ```
 
-#### Usage without a component (sprites method)
+**How the React Component Works**
+
+1. **First**: Attempts to load a local React component generated from your custom SVGs
+2. **Fallback**: If no local component exists, dynamically imports the corresponding heroicon
+3. **Graceful degradation**: If neither exists, returns null (no icon displayed)
+
+#### For Non-React Applications
+
+**Using SVG Spritesheets**
+
+For applications that don't use React, icons are available as SVG sprites that can be referenced directly:
 
 ```html
 <!-- The width and height are required for correct sizing. The actual color class might depend on the svg and whether it uses strokes, fills etc. Note as well xlink:href, which is xlinkHref in react. -->
@@ -148,7 +145,7 @@ Where `variant` can be:
 </svg>
 ```
 
-Usage without a component, in React, with hover states. Note the [group](https://tailwindcss.com/docs/hover-focus-and-other-states#group-hover) class:
+Even in React applications, you can use the sprite method for advanced use cases like hover states with the [group](https://tailwindcss.com/docs/hover-focus-and-other-states#group-hover) class:
 
 ```tsx
 <a
@@ -162,11 +159,29 @@ Usage without a component, in React, with hover states. Note the [group](https:/
 </a>
 ```
 
-#### How the Fallback System Works
+The sprites file can be loaded with the `loadSprites` helper available in the `core` module or included in the page directly.
 
-1. **First**: Attempts to load a local React component generated from your custom SVGs
-2. **Fallback**: If no local component exists, dynamically imports the corresponding heroicon
-3. **Graceful degradation**: If neither exists, returns null (no icon displayed)
+#### Icon Sources
+
+**Local Custom Icons**
+
+Putting SVG files inside a `src/core/icons` folder will:
+
+1. Generate React components that can be imported dynamically
+2. Add them to a per-group sprites file (e.g., `core/sprites-gui.svg`) for non-React usage
+
+**Heroicons Integration**
+
+The system automatically falls back to [Heroicons](https://heroicons.com/) when a local icon isn't found, using this naming convention:
+
+- `icon-gui-{heroicon-name}-{variant}`
+
+Where `variant` can be:
+
+- `outline` → 24px outline icons
+- `solid` → 24px solid icons
+- `mini` → 20px solid icons
+- `micro` → 16px solid icons
 
 This hybrid approach allows you to use custom brand icons while having access to the entire heroicons library as a fallback.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.5.7",
+  "version": "17.5.8",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/styles/Button.stories.tsx
+++ b/src/core/styles/Button.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Button, { ButtonType, iconModifierClasses } from "../Button";
 import Tooltip from "../Tooltip";
 import cn from "../utils/cn";
+import Icon from "../Icon";
 
 export default {
   title: "Components/Button",
@@ -73,15 +74,17 @@ const buttonSet = (type: ButtonType) => (
                   disabled={index === 3}
                 >
                   {index === 1 ? (
-                    <svg style={{ width: "1.5rem", height: "1.5rem" }}>
-                      <use xlinkHref="#sprite-icon-gui-magnifying-glass-outline"></use>
-                    </svg>
+                    <Icon
+                      name="icon-gui-magnifying-glass-outline"
+                      size="1.5rem"
+                    />
                   ) : null}
                   {size.label}
                   {index === 2 ? (
-                    <svg style={{ width: "1.5rem", height: "1.5rem" }}>
-                      <use xlinkHref="#sprite-icon-gui-arrow-long-right-outline"></use>
-                    </svg>
+                    <Icon
+                      name="icon-gui-arrow-long-right-outline"
+                      size="1.5rem"
+                    />
                   ) : null}
                 </button>
               }

--- a/src/core/styles/__snapshots__/Button.stories.tsx.snap
+++ b/src/core/styles/__snapshots__/Button.stories.tsx.snap
@@ -62,9 +62,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
       <button type="button"
               class="ui-button-primary-lg ui-button-lg-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Large
       </button>
@@ -78,9 +90,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
       <button type="button"
               class="ui-button-primary ui-button-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Regular
       </button>
@@ -94,9 +118,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
       <button type="button"
               class="ui-button-primary-sm ui-button-sm-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Small
       </button>
@@ -110,9 +146,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
       <button type="button"
               class="ui-button-primary-xs"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Extra small
       </button>
@@ -129,9 +177,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
               class="ui-button-primary-lg ui-button-lg-right-icon"
       >
         Large
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -145,9 +205,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
               class="ui-button-primary ui-button-right-icon"
       >
         Regular
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -161,9 +233,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
               class="ui-button-primary-sm ui-button-sm-right-icon"
       >
         Small
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -177,9 +261,21 @@ exports[`Components/Button Primary smoke-test 1`] = `
               class="ui-button-primary-xs"
       >
         Extra small
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -303,9 +399,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
       <button type="button"
               class="ui-button-priority-lg ui-button-lg-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Large
       </button>
@@ -319,9 +427,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
       <button type="button"
               class="ui-button-priority ui-button-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Regular
       </button>
@@ -335,9 +455,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
       <button type="button"
               class="ui-button-priority-sm ui-button-sm-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Small
       </button>
@@ -351,9 +483,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
       <button type="button"
               class="ui-button-priority-xs"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Extra small
       </button>
@@ -370,9 +514,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
               class="ui-button-priority-lg ui-button-lg-right-icon"
       >
         Large
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -386,9 +542,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
               class="ui-button-priority ui-button-right-icon"
       >
         Regular
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -402,9 +570,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
               class="ui-button-priority-sm ui-button-sm-right-icon"
       >
         Small
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -418,9 +598,21 @@ exports[`Components/Button Priority smoke-test 1`] = `
               class="ui-button-priority-xs"
       >
         Extra small
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -596,9 +788,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
       <button type="button"
               class="ui-button-secondary-lg ui-button-lg-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Large
       </button>
@@ -612,9 +816,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
       <button type="button"
               class="ui-button-secondary ui-button-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Regular
       </button>
@@ -628,9 +844,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
       <button type="button"
               class="ui-button-secondary-sm ui-button-sm-left-icon"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Small
       </button>
@@ -644,9 +872,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
       <button type="button"
               class="ui-button-secondary-xs"
       >
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-magnifying-glass-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          >
+          </path>
         </svg>
         Extra small
       </button>
@@ -663,9 +903,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
               class="ui-button-secondary-lg ui-button-lg-right-icon"
       >
         Large
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -679,9 +931,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
               class="ui-button-secondary ui-button-right-icon"
       >
         Regular
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -695,9 +959,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
               class="ui-button-secondary-sm ui-button-sm-right-icon"
       >
         Small
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>
@@ -711,9 +987,21 @@ exports[`Components/Button Secondary smoke-test 1`] = `
               class="ui-button-secondary-xs"
       >
         Extra small
-        <svg style="width: 1.5rem; height: 1.5rem;">
-          <use xlink:href="#sprite-icon-gui-arrow-long-right-outline">
-          </use>
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class
+             style="width: 1.5rem; height: 1.5rem;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"
+          >
+          </path>
         </svg>
       </button>
     </div>


### PR DESCRIPTION
Tackles an issue raised by Jamie W where the icons weren't showing up in the Button stories, because it was still using the old spritesheet syntax in those stories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and restructured README to clarify icon usage, distinguishing between React component imports and SVG spritesheets, and providing detailed usage examples for both.

* **New Features**
  * Updated button stories to use the reusable Icon component instead of inline SVGs for more consistent icon rendering.

* **Chores**
  * Bumped package version to 17.5.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->