### PR TITLE
[WEB-4478] fix: add antialiasing to storybook fonts to bring in line with apps

### DIFF
--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -14,3 +14,7 @@
 @import "../src/reset/styles.css";
 
 @import "./application.css";
+
+body {
+  -webkit-font-smoothing: antialiased;
+}


### PR DESCRIPTION
Addresses an observation on Jamie W that fonts on Storybook are heavier than our apps. That's because we don't anti-alias the fonts, so now we do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text rendering for smoother font appearance on WebKit-based browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->