### PR TITLE
[WEB-4553] chore: bump node to latest lts (22)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile && npx playwright install --with-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
       - name: Release latest Ably UI version
         env:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.13.1
+nodejs 22.18.0
 pnpm 10.12.4

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/lodash.throttle": "^4.1.9",
     "@types/mixpanel-browser": "^2.60.0",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "@types/svg-sprite": "^0.0.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,13 +68,13 @@ importers:
     devDependencies:
       '@storybook/addon-docs':
         specifier: ^9.1.1
-        version: 9.1.1(@types/react@18.3.12)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))
+        version: 9.1.1(@types/react@18.3.12)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))
       '@storybook/react-vite':
         specifier: ^9.1.1
-        version: 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+        version: 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       '@storybook/test-runner':
         specifier: ^0.23.0
-        version: 0.23.0(@types/node@20.19.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+        version: 0.23.0(@types/node@22.17.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       '@svgr/core':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.8.3)
@@ -92,7 +92,7 @@ importers:
         version: 1.13.0
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
-        version: 0.1.1(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)))
+        version: 0.1.1(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)))
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
@@ -103,8 +103,8 @@ importers:
         specifier: ^2.60.0
         version: 2.66.0
       '@types/node':
-        specifier: ^20
-        version: 20.19.1
+        specifier: ^22
+        version: 22.17.1
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.12
@@ -122,7 +122,7 @@ importers:
         version: 8.39.1(eslint@8.57.1)(typescript@5.8.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
-        version: 3.11.0(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+        version: 3.11.0(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       '@vueless/storybook-dark-mode':
         specifier: ^9.0.6
         version: 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -140,7 +140,7 @@ importers:
         version: 7.37.2(eslint@8.57.1)
       eslint-plugin-storybook:
         specifier: ^9.1.1
-        version: 9.1.1(eslint@8.57.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)
+        version: 9.1.1(eslint@8.57.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)
       heroicons:
         specifier: ^2.2.0
         version: 2.2.0
@@ -155,10 +155,10 @@ importers:
         version: 2.67.0
       msw:
         specifier: 2.10.2
-        version: 2.10.2(@types/node@20.19.1)(typescript@5.8.3)
+        version: 2.10.2(@types/node@22.17.1)(typescript@5.8.3)
       msw-storybook-addon:
         specifier: ^2.0.5
-        version: 2.0.5(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))
+        version: 2.0.5(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))
       playwright:
         specifier: ^1.49.1
         version: 1.54.1
@@ -170,25 +170,25 @@ importers:
         version: 3.6.2
       storybook:
         specifier: ^9.1.1
-        version: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+        version: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       svg-sprite:
         specifier: ^2.0.4
         version: 2.0.4
       tailwindcss:
         specifier: ^3.3.6
-        version: 3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+        version: 3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)
+        version: 10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vite:
         specifier: ^7.1.1
-        version: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+        version: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
       vitest:
         specifier: ^3.0.8
-        version: 3.2.4(@types/node@20.19.1)(jiti@1.21.6)(jsdom@26.1.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(yaml@2.6.1)
+        version: 3.2.4(@types/node@22.17.1)(jiti@1.21.6)(jsdom@26.1.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(yaml@2.6.1)
       wait-on:
         specifier: ^8.0.3
         version: 8.0.3
@@ -1911,8 +1911,8 @@ packages:
     resolution: {integrity: sha512-07zYZZ9ZVHc7R4ktM+3a2clZvKkj+EJcYZ/FevTs011Fr9tdp59lVgAskMf6ZQUp3lOHLqi7K3f+9QtmEsqh1w==}
     deprecated: This is a stub types definition. mixpanel-browser provides its own type definitions, so you do not need this installed.
 
-  '@types/node@20.19.1':
-    resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
+  '@types/node@22.17.1':
+    resolution: {integrity: sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==}
 
   '@types/prop-types@15.7.11':
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
@@ -6068,16 +6068,16 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@inquirer/confirm@5.0.1(@types/node@20.19.1)':
+  '@inquirer/confirm@5.0.1(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.0.1(@types/node@20.19.1)
-      '@inquirer/type': 3.0.0(@types/node@20.19.1)
-      '@types/node': 20.19.1
+      '@inquirer/core': 10.0.1(@types/node@22.17.1)
+      '@inquirer/type': 3.0.0(@types/node@22.17.1)
+      '@types/node': 22.17.1
 
-  '@inquirer/core@10.0.1(@types/node@20.19.1)':
+  '@inquirer/core@10.0.1(@types/node@22.17.1)':
     dependencies:
       '@inquirer/figures': 1.0.7
-      '@inquirer/type': 3.0.0(@types/node@20.19.1)
+      '@inquirer/type': 3.0.0(@types/node@22.17.1)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -6090,9 +6090,9 @@ snapshots:
 
   '@inquirer/figures@1.0.7': {}
 
-  '@inquirer/type@3.0.0(@types/node@20.19.1)':
+  '@inquirer/type@3.0.0(@types/node@22.17.1)':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6116,27 +6116,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6165,7 +6165,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -6183,7 +6183,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6205,7 +6205,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -6275,16 +6275,16 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
-      vite: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -6927,29 +6927,29 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storybook/addon-docs@9.1.1(@types/react@18.3.12)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))':
+  '@storybook/addon-docs@9.1.1(@types/react@18.3.12)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))':
     dependencies:
       '@mdx-js/react': 3.0.1(@types/react@18.3.12)(react@18.3.1)
-      '@storybook/csf-plugin': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))
+      '@storybook/csf-plugin': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))
       '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))
+      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/builder-vite@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))':
+  '@storybook/builder-vite@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      '@storybook/csf-plugin': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       ts-dedent: 2.2.0
-      vite: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
 
-  '@storybook/csf-plugin@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))':
+  '@storybook/csf-plugin@9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))':
     dependencies:
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -6964,43 +6964,43 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))':
+  '@storybook/react-dom-shim@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
 
-  '@storybook/react-vite@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))':
+  '@storybook/react-vite@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      '@storybook/builder-vite': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
-      '@storybook/react': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)
+      '@storybook/builder-vite': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
+      '@storybook/react': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)
       find-up: 7.0.0
       magic-string: 0.30.17
       react: 18.3.1
       react-docgen: 8.0.0
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       tsconfig-paths: 4.2.0
-      vite: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)':
+  '@storybook/react@9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))
+      '@storybook/react-dom-shim': 9.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
     optionalDependencies:
       typescript: 5.8.3
 
-  '@storybook/test-runner@0.23.0(@types/node@20.19.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))':
+  '@storybook/test-runner@0.23.0(@types/node@22.17.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/generator': 7.25.6
@@ -7010,17 +7010,17 @@ snapshots:
       '@swc/core': 1.13.0
       '@swc/jest': 0.2.36(@swc/core@1.13.0)
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
-      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)))
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)))
       jest-runner: 29.7.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)))
       nyc: 15.1.0
       playwright: 1.54.1
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -7185,9 +7185,9 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)))':
+  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)))':
     dependencies:
-      tailwindcss: 3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      tailwindcss: 3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -7267,7 +7267,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -7295,7 +7295,7 @@ snapshots:
     dependencies:
       mixpanel-browser: 2.67.0
 
-  '@types/node@20.19.1':
+  '@types/node@22.17.1':
     dependencies:
       undici-types: 6.21.0
 
@@ -7318,7 +7318,7 @@ snapshots:
 
   '@types/svg-sprite@0.0.39':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       '@types/vinyl': 2.0.12
       winston: 3.15.0
 
@@ -7332,11 +7332,11 @@ snapshots:
   '@types/vinyl@2.0.12':
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
 
   '@types/wait-on@5.3.4':
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7491,11 +7491,11 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react-swc@3.11.0(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))':
+  '@vitejs/plugin-react-swc@3.11.0(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@swc/core': 1.13.0
-      vite: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -7507,14 +7507,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.10.2(@types/node@20.19.1)(typescript@5.8.3)
-      vite: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+      msw: 2.10.2(@types/node@22.17.1)(typescript@5.8.3)
+      vite: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8121,13 +8121,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  create-jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)):
+  create-jest@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -8569,11 +8569,11 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@9.1.1(eslint@8.57.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3):
+  eslint-plugin-storybook@9.1.1(eslint@8.57.1)(storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.38.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
-      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      storybook: 9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9336,7 +9336,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -9356,16 +9356,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)):
+  jest-cli@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      create-jest: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9375,7 +9375,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)):
+  jest-config@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -9400,8 +9400,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.1
-      ts-node: 10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)
+      '@types/node': 22.17.1
+      ts-node: 10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9430,7 +9430,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -9440,7 +9440,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9486,13 +9486,13 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       jest-util: 29.7.0
 
-  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))):
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -9553,7 +9553,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -9581,7 +9581,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -9631,7 +9631,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9646,11 +9646,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.3.0
-      jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -9661,7 +9661,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9670,17 +9670,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)):
+  jest@29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      jest-cli: 29.7.0(@types/node@22.17.1)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9927,17 +9927,17 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw-storybook-addon@2.0.5(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3)):
+  msw-storybook-addon@2.0.5(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
       is-node-process: 1.2.0
-      msw: 2.10.2(@types/node@20.19.1)(typescript@5.8.3)
+      msw: 2.10.2(@types/node@22.17.1)(typescript@5.8.3)
 
-  msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3):
+  msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.0.1(@types/node@20.19.1)
+      '@inquirer/confirm': 5.0.1(@types/node@22.17.1)
       '@mswjs/interceptors': 0.39.2
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -10250,13 +10250,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.6.1
     optionalDependencies:
       postcss: 8.4.49
-      ts-node: 10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)
+      ts-node: 10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)
 
   postcss-nested@6.2.0(postcss@8.4.49):
     dependencies:
@@ -10738,13 +10738,13 @@ snapshots:
 
   std-env@3.9.0: {}
 
-  storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)):
+  storybook@9.1.1(@testing-library/dom@10.4.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.3
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.8
@@ -10954,7 +10954,7 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3)):
+  tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -10973,7 +10973,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3))
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -11074,14 +11074,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@swc/core@1.13.0)(@types/node@20.19.1)(typescript@5.8.3):
+  ts-node@10.9.2(@swc/core@1.13.0)(@types/node@22.17.1)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       acorn: 8.12.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -11246,13 +11246,13 @@ snapshots:
       remove-trailing-separator: 1.1.0
       replace-ext: 1.0.1
 
-  vite-node@3.2.4(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1):
+  vite-node@3.2.4(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -11267,7 +11267,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1):
+  vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -11276,16 +11276,16 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       fsevents: 2.3.3
       jiti: 1.21.6
       yaml: 2.6.1
 
-  vitest@3.2.4(@types/node@20.19.1)(jiti@1.21.6)(jsdom@26.1.0)(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(yaml@2.6.1):
+  vitest@3.2.4(@types/node@22.17.1)(jiti@1.21.6)(jsdom@26.1.0)(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(yaml@2.6.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))(vite@7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@22.17.1)(typescript@5.8.3))(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -11303,11 +11303,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.1(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
-      vite-node: 3.2.4(@types/node@20.19.1)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 7.1.1(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
+      vite-node: 3.2.4(@types/node@22.17.1)(jiti@1.21.6)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.1
+      '@types/node': 22.17.1
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
This repo still uses node 20 for no discernible reason, and packages are starting to require a higher 20 version or 22. Let's just bump to the latest LTS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Node.js runtime to version 22 across build and release processes.
  * Updated development type definitions to align with Node.js 22.
  * Synchronized toolchain configuration to use the updated Node.js version.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->