### PR TITLE
[WEB-4400] fix: bump to 17.6.4, tweak logo badge proportions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.6.3",
+  "version": "17.6.4",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Badge.tsx
+++ b/src/core/Badge.tsx
@@ -57,6 +57,11 @@ interface BadgeProps {
    * Accessible label for the badge when interactive
    */
   ariaLabel?: string;
+
+  /**
+   * Additional CSS class names to apply to the children of the badge.
+   */
+  childClassName?: string;
 }
 
 const Badge: React.FC<PropsWithChildren<BadgeProps>> = ({
@@ -65,6 +70,7 @@ const Badge: React.FC<PropsWithChildren<BadgeProps>> = ({
   iconBefore,
   iconAfter,
   className,
+  childClassName,
   children,
   disabled = false,
   focusable = false,
@@ -140,7 +146,13 @@ const Badge: React.FC<PropsWithChildren<BadgeProps>> = ({
       {iconBefore ? (
         <Icon name={iconBefore} size={iconSize} color={colorClass} />
       ) : null}
-      <span className={cn("whitespace-nowrap tracking-[0.04em]", childClass)}>
+      <span
+        className={cn(
+          "whitespace-nowrap tracking-[0.04em]",
+          childClass,
+          childClassName,
+        )}
+      >
         {children}
       </span>
       {iconAfter ? (

--- a/src/core/Logo.tsx
+++ b/src/core/Logo.tsx
@@ -71,7 +71,10 @@ const Logo = ({
     >
       <img src={logoSrc} width="96px" alt={logoAlt} {...additionalImgAttrs} />
       {badge && (
-        <Badge className="uppercase h-8 bg-transparent dark:bg-transparent rounded border border-neutral-400 dark:border-neutral-900 text-lg p-2 font-semibold text-neutral-800 dark:text-neutral-500">
+        <Badge
+          className="uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-neutral-800 dark:text-neutral-500"
+          childClassName="tracking-[0.01em]"
+        >
           {badge}
         </Badge>
       )}

--- a/src/core/Logo/__snapshots__/Logo.stories.tsx.snap
+++ b/src/core/Logo/__snapshots__/Logo.stories.tsx.snap
@@ -96,8 +96,8 @@ exports[`Components/Logo WithBadge smoke-test 1`] = `
          width="96px"
          alt="Ably logo"
     >
-    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none uppercase h-8 bg-transparent dark:bg-transparent rounded border border-neutral-400 dark:border-neutral-900 text-lg p-2 font-semibold text-neutral-800 dark:text-neutral-500">
-      <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
+    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-neutral-800 dark:text-neutral-500">
+      <span class="whitespace-nowrap leading-[20px] tracking-[0.01em]">
         docs
       </span>
     </div>
@@ -109,8 +109,8 @@ exports[`Components/Logo WithBadge smoke-test 1`] = `
          width="96px"
          alt="Ably logo"
     >
-    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none uppercase h-8 bg-transparent dark:bg-transparent rounded border border-neutral-400 dark:border-neutral-900 text-lg p-2 font-semibold text-neutral-800 dark:text-neutral-500">
-      <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
+    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-neutral-800 dark:text-neutral-500">
+      <span class="whitespace-nowrap leading-[20px] tracking-[0.01em]">
         docs
       </span>
     </div>


### PR DESCRIPTION
Follows on from [this](https://github.com/ably/ably-ui/pull/875), updates the styling of the logo badge after Jamie W's feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Badges support finer text styling, enabling clearer labels in relevant views.
- Style
  - Refined logo badge appearance: more compact sizing, adjusted padding, improved letter spacing, and tighter border radius for better readability.
- Chores
  - Bumped patch version to 17.6.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->