### PR TITLE
[WEB-4553] fix: fallback to present sdk snippets in CodeSnippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.6.4",
+  "version": "17.6.5",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/CodeSnippet.tsx
+++ b/src/core/CodeSnippet.tsx
@@ -217,13 +217,20 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
       };
     }, [children, extractLanguageFromCode]);
 
+  const resolvedSdk: SDKType = useMemo(() => {
+    if (sdkTypes.size === 1 && sdk && !sdkTypes.has(sdk)) {
+      return Array.from(sdkTypes)[0];
+    }
+    return sdk ?? null;
+  }, [sdk, sdkTypes]);
+
   const showSDKSelector = sdkTypes.size > 0;
 
   const filteredLanguages = useMemo(() => {
     const filtered =
-      !sdk || !showSDKSelector
+      !resolvedSdk || !showSDKSelector
         ? [...languages]
-        : languages.filter((lang) => lang.startsWith(`${sdk}_`));
+        : languages.filter((lang) => lang.startsWith(`${resolvedSdk}_`));
 
     // Apply custom ordering if provided
     if (languageOrdering && languageOrdering.length > 0) {
@@ -242,11 +249,11 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
     }
 
     return filtered;
-  }, [sdk, showSDKSelector, languages, languageOrdering]);
+  }, [resolvedSdk, showSDKSelector, languages, languageOrdering]);
 
   const activeLanguage = useMemo(() => {
-    if (sdk && sdkTypes.has(sdk)) {
-      return `${sdk}_${lang}`;
+    if (resolvedSdk && sdkTypes.has(resolvedSdk)) {
+      return `${resolvedSdk}_${lang}`;
     }
 
     if (lang) return lang;
@@ -254,7 +261,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
     if (filteredLanguages.length > 0) return filteredLanguages[0];
 
     return languages[0];
-  }, [lang, sdk, sdkTypes, filteredLanguages]);
+  }, [lang, resolvedSdk, sdkTypes, filteredLanguages]);
 
   const requiresApiKeySubstitution = useMemo(() => {
     const containsPlaceholder = codeData.some(
@@ -357,10 +364,10 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
   const handleLanguageChange = useCallback(
     (language: string) => {
       if (onChange) {
-        onChange(stripSdkType(language), sdk);
+        onChange(stripSdkType(language), resolvedSdk);
       }
     },
-    [onChange, sdk],
+    [onChange, resolvedSdk],
   );
 
   const NoSnippetMessage = useMemo(() => {
@@ -464,7 +471,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
             {sdkTypes.has("realtime") && (
               <TooltipButton
                 tooltip="Realtime SDK"
-                active={sdk === "realtime"}
+                active={resolvedSdk === "realtime"}
                 onClick={() => handleSDKTypeChange("realtime")}
                 variant="segmented"
                 size="sm"
@@ -477,7 +484,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
             {sdkTypes.has("rest") && (
               <TooltipButton
                 tooltip="REST SDK"
-                active={sdk === "rest"}
+                active={resolvedSdk === "rest"}
                 onClick={() => handleSDKTypeChange("rest")}
                 variant="segmented"
                 size="sm"

--- a/src/core/CodeSnippet/CodeSnippet.stories.tsx
+++ b/src/core/CodeSnippet/CodeSnippet.stories.tsx
@@ -306,51 +306,6 @@ export const WithMissingLanguageSnippet: Story = {
 };
 
 /**
- * CodeSnippet with a language change callback that's fired whenever the user
- * selects a different language. Note: this callback doesn't fire on initial render.
- */
-export const WithOnChangeCallback: Story = {
-  render: () => {
-    const [currentLang, setCurrentLang] = useState<string>(
-      "realtime_javascript",
-    );
-    const [_currentSdk, setCurrentSdk] = useState<string>("realtime");
-
-    return (
-      <div>
-        <CodeSnippet
-          headerRow
-          title="Language Change Example"
-          lang={currentLang}
-          onChange={(lang, sdk) => {
-            setCurrentLang(lang);
-            setCurrentSdk(sdk || "realtime");
-            alert(`Language changed to: ${lang} and SDK: ${sdk}`);
-          }}
-        >
-          <pre>
-            <code className="language-realtime_javascript">
-              {CODE_SNIPPETS.javascript}
-            </code>
-          </pre>
-          <pre>
-            <code className="language-realtime_typescript">
-              {CODE_SNIPPETS.typescript}
-            </code>
-          </pre>
-          <pre>
-            <code className="language-rest_swift">{CODE_SNIPPETS.swift}</code>
-          </pre>
-          <pre>
-            <code className="language-rest_php">{CODE_SNIPPETS.php}</code>
-          </pre>
-        </CodeSnippet>
-      </div>
-    );
-  },
-};
-
-/**
  * CodeSnippet with demo API key mode, showing a "DEMO ONLY" badge and information tooltip.
  */
 export const WithDemoApiKeys: Story = {
@@ -469,6 +424,57 @@ export const WithSDKTypes: Story = {
           <code className="language-rest_kotlin">{CODE_SNIPPETS.kotlin}</code>
         </pre>
       </CodeSnippet>
+    );
+  },
+};
+
+export const WithFallbackSDKTypeAcrossInstances: Story = {
+  render: () => {
+    const [currentLang, setCurrentLang] = useState<string>("javascript");
+    const [currentSdk, setCurrentSdk] = useState<SDKType>("realtime");
+
+    return (
+      <div className="flex flex-col gap-4">
+        <CodeSnippet
+          headerRow
+          title="SDK Type Example (realtime only)"
+          lang={currentLang}
+          sdk={currentSdk}
+          onChange={(lang, sdk) => {
+            setCurrentLang(lang);
+            setCurrentSdk(sdk || "realtime");
+          }}
+        >
+          <pre>
+            <code className="language-realtime_javascript">
+              {CODE_SNIPPETS.javascript}
+            </code>
+          </pre>
+          <pre>
+            <code className="language-realtime_typescript">
+              {CODE_SNIPPETS.typescript}
+            </code>
+          </pre>
+        </CodeSnippet>
+
+        <CodeSnippet
+          headerRow
+          title="SDK Type Example (rest only)"
+          lang={currentLang}
+          sdk={currentSdk}
+          onChange={(lang, sdk) => {
+            setCurrentLang(lang);
+            setCurrentSdk(sdk || "realtime");
+          }}
+        >
+          <pre>
+            <code className="language-rest_php">{CODE_SNIPPETS.php}</code>
+          </pre>
+          <pre>
+            <code className="language-rest_kotlin">{CODE_SNIPPETS.kotlin}</code>
+          </pre>
+        </CodeSnippet>
+      </div>
     );
   },
 };

--- a/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
+++ b/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
@@ -397,14 +397,14 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
            style="width: 16px; height: 16px;"
       >
         <defs>
-          <clipPath id="clip0_4810_1924-:r3c:">
+          <clipPath id="clip0_4810_1924-:r3g:">
             <path fill="#fff"
                   d="M0 0h48v48H0z"
             >
             </path>
           </clipPath>
         </defs>
-        <g clip-path="url(#clip0_4810_1924-:r3c:)">
+        <g clip-path="url(#clip0_4810_1924-:r3g:)">
           <path stroke="currentColor"
                 stroke-linecap="round"
                 stroke-width="3"
@@ -1241,14 +1241,14 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
              style="width: 22px; height: 22px;"
         >
           <defs>
-            <clipPath id="clip0_1031_1922-:r2b:">
+            <clipPath id="clip0_1031_1922-:r1r:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
               </path>
             </clipPath>
           </defs>
-          <g clip-path="url(#clip0_1031_1922-:r2b:)">
+          <g clip-path="url(#clip0_1031_1922-:r1r:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -1283,14 +1283,14 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <defs>
-                <clipPath id="clip0_1031_1977-:r2c:">
+                <clipPath id="clip0_1031_1977-:r1s:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
                   </path>
                 </clipPath>
               </defs>
-              <g clip-path="url(#clip0_1031_1977-:r2c:)">
+              <g clip-path="url(#clip0_1031_1977-:r1s:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -1310,7 +1310,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r2d:"
+              aria-controls="radix-:r1t:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -1330,14 +1330,14 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                style="width: 20px; height: 20px;"
           >
             <defs>
-              <clipPath id="clip0_1031_1922-:r2e:">
+              <clipPath id="clip0_1031_1922-:r1u:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
                 </path>
               </clipPath>
             </defs>
-            <g clip-path="url(#clip0_1031_1922-:r2e:)">
+            <g clip-path="url(#clip0_1031_1922-:r1u:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -1484,7 +1484,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
     </span>
     <button type="button"
             role="combobox"
-            aria-controls="radix-:r2g:"
+            aria-controls="radix-:r20:"
             aria-expanded="false"
             aria-autocomplete="none"
             dir="ltr"
@@ -1555,7 +1555,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
              style="width: 22px; height: 22px;"
         >
           <defs>
-            <linearGradient id="paint0_linear_1031_1912-:r3n:"
+            <linearGradient id="paint0_linear_1031_1912-:r3r:"
                             x1="2.813"
                             x2="-6.259"
                             y1="-6.259"
@@ -1569,7 +1569,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               >
               </stop>
             </linearGradient>
-            <linearGradient id="paint1_linear_1031_1912-:r3n:"
+            <linearGradient id="paint1_linear_1031_1912-:r3r:"
                             x1="4.876"
                             x2="-1.23"
                             y1="-2.365"
@@ -1583,7 +1583,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               >
               </stop>
             </linearGradient>
-            <clipPath id="clip0_1031_1912-:r3n:">
+            <clipPath id="clip0_1031_1912-:r3r:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
@@ -1591,14 +1591,14 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
             </clipPath>
           </defs>
           <g fill-rule="evenodd"
-             clip-path="url(#clip0_1031_1912-:r3n:)"
+             clip-path="url(#clip0_1031_1912-:r3r:)"
              clip-rule="evenodd"
           >
-            <path fill="url(#paint0_linear_1031_1912-:r3n:)"
+            <path fill="url(#paint0_linear_1031_1912-:r3r:)"
                   d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
             >
             </path>
-            <path fill="url(#paint1_linear_1031_1912-:r3n:)"
+            <path fill="url(#paint1_linear_1031_1912-:r3r:)"
                   d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
             >
             </path>
@@ -1632,14 +1632,14 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <defs>
-                <clipPath id="clip0_1031_1977-:r3o:">
+                <clipPath id="clip0_1031_1977-:r3s:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
                   </path>
                 </clipPath>
               </defs>
-              <g clip-path="url(#clip0_1031_1977-:r3o:)">
+              <g clip-path="url(#clip0_1031_1977-:r3s:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -1675,14 +1675,14 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <defs>
-                <clipPath id="clip0_1031_1922-:r3p:">
+                <clipPath id="clip0_1031_1922-:r3t:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
                   </path>
                 </clipPath>
               </defs>
-              <g clip-path="url(#clip0_1031_1922-:r3p:)">
+              <g clip-path="url(#clip0_1031_1922-:r3t:)">
                 <path fill="#F7DF1E"
                       d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
                 >
@@ -1716,7 +1716,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <defs>
-                <radialGradient id="paint0_radial_1031_1963-:r3q:"
+                <radialGradient id="paint0_radial_1031_1963-:r3u:"
                                 cx="0"
                                 cy="0"
                                 r="1"
@@ -1730,7 +1730,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                   >
                   </stop>
                 </radialGradient>
-                <radialGradient id="paint1_radial_1031_1963-:r3q:"
+                <radialGradient id="paint1_radial_1031_1963-:r3u:"
                                 cx="0"
                                 cy="0"
                                 r="1"
@@ -1744,7 +1744,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                   >
                   </stop>
                 </radialGradient>
-                <linearGradient id="paint2_linear_1031_1963-:r3q:"
+                <linearGradient id="paint2_linear_1031_1963-:r3u:"
                                 x1="38.828"
                                 x2="30.863"
                                 y1="27.877"
@@ -1758,7 +1758,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                   >
                   </stop>
                 </linearGradient>
-                <clipPath id="clip0_1031_1963-:r3q:">
+                <clipPath id="clip0_1031_1963-:r3u:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
@@ -1766,18 +1766,18 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 </clipPath>
               </defs>
               <g fill-rule="evenodd"
-                 clip-path="url(#clip0_1031_1963-:r3q:)"
+                 clip-path="url(#clip0_1031_1963-:r3u:)"
                  clip-rule="evenodd"
               >
-                <path fill="url(#paint0_radial_1031_1963-:r3q:)"
+                <path fill="url(#paint0_radial_1031_1963-:r3u:)"
                       d="M23.895 48.218c-7.073 0-12.807-1.112-12.807-2.483s5.734-2.483 12.807-2.483 12.807 1.112 12.807 2.483-5.734 2.483-12.807 2.483"
                 >
                 </path>
-                <path fill="url(#paint1_radial_1031_1963-:r3q:)"
+                <path fill="url(#paint1_radial_1031_1963-:r3u:)"
                       d="M23.895 48.218c-7.073 0-12.807-1.112-12.807-2.483s5.734-2.483 12.807-2.483 12.807 1.112 12.807 2.483-5.734 2.483-12.807 2.483"
                 >
                 </path>
-                <path fill="url(#paint2_linear_1031_1963-:r3q:)"
+                <path fill="url(#paint2_linear_1031_1963-:r3u:)"
                       d="M29.156 33.479c.99 0 1.793.811 1.793 1.815 0 1.007-.803 1.827-1.794 1.827-.987 0-1.793-.82-1.793-1.827 0-1.004.806-1.815 1.794-1.815m5.368-23.046v4.244c0 3.29-2.79 6.059-5.97 6.059h-9.546c-2.614 0-4.778 2.238-4.778 4.857v9.1c0 2.59 2.252 4.113 4.778 4.856 3.025.89 5.926 1.05 9.546 0 2.406-.696 4.778-2.099 4.778-4.856V31.05h-9.546v-1.215H38.11c2.778 0 3.813-1.937 4.78-4.845.997-2.993.954-5.872 0-9.713-.687-2.765-1.998-4.845-4.78-4.845z"
                 >
                 </path>
@@ -1794,7 +1794,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r3r:"
+              aria-controls="radix-:r3v:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -1814,7 +1814,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                style="width: 20px; height: 20px;"
           >
             <defs>
-              <linearGradient id="paint0_linear_1031_1912-:r3s:"
+              <linearGradient id="paint0_linear_1031_1912-:r40:"
                               x1="2.813"
                               x2="-6.259"
                               y1="-6.259"
@@ -1828,7 +1828,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <linearGradient id="paint1_linear_1031_1912-:r3s:"
+              <linearGradient id="paint1_linear_1031_1912-:r40:"
                               x1="4.876"
                               x2="-1.23"
                               y1="-2.365"
@@ -1842,7 +1842,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 >
                 </stop>
               </linearGradient>
-              <clipPath id="clip0_1031_1912-:r3s:">
+              <clipPath id="clip0_1031_1912-:r40:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
@@ -1850,14 +1850,14 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               </clipPath>
             </defs>
             <g fill-rule="evenodd"
-               clip-path="url(#clip0_1031_1912-:r3s:)"
+               clip-path="url(#clip0_1031_1912-:r40:)"
                clip-rule="evenodd"
             >
-              <path fill="url(#paint0_linear_1031_1912-:r3s:)"
+              <path fill="url(#paint0_linear_1031_1912-:r40:)"
                     d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
               >
               </path>
-              <path fill="url(#paint1_linear_1031_1912-:r3s:)"
+              <path fill="url(#paint1_linear_1031_1912-:r40:)"
                     d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
               >
               </path>
@@ -2385,14 +2385,14 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
              style="width: 22px; height: 22px;"
         >
           <defs>
-            <clipPath id="clip0_1031_1922-:r20:">
+            <clipPath id="clip0_1031_1922-:r1g:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
               </path>
             </clipPath>
           </defs>
-          <g clip-path="url(#clip0_1031_1922-:r20:)">
+          <g clip-path="url(#clip0_1031_1922-:r1g:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -2427,14 +2427,14 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <defs>
-                <clipPath id="clip0_1031_1977-:r21:">
+                <clipPath id="clip0_1031_1977-:r1h:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
                   </path>
                 </clipPath>
               </defs>
-              <g clip-path="url(#clip0_1031_1977-:r21:)">
+              <g clip-path="url(#clip0_1031_1977-:r1h:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -2454,7 +2454,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r22:"
+              aria-controls="radix-:r1i:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -2474,14 +2474,14 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                style="width: 20px; height: 20px;"
           >
             <defs>
-              <clipPath id="clip0_1031_1922-:r23:">
+              <clipPath id="clip0_1031_1922-:r1j:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
                 </path>
               </clipPath>
             </defs>
-            <g clip-path="url(#clip0_1031_1922-:r23:)">
+            <g clip-path="url(#clip0_1031_1922-:r1j:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -2654,6 +2654,571 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
             </path>
           </svg>
         </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1`] = `
+<div class="flex flex-col gap-4">
+  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
+    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+      <div class="flex space-x-1.5">
+        <div class="w-3 h-3 rounded-full bg-orange-500">
+        </div>
+        <div class="w-3 h-3 rounded-full bg-yellow-500">
+        </div>
+        <div class="w-3 h-3 rounded-full bg-green-500">
+        </div>
+      </div>
+      <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+        SDK Type Example (realtime only)
+      </div>
+      <div class="w-12">
+      </div>
+    </div>
+    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
+      <div class="flex gap-3 justify-start">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+            Realtime
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+      <div class="hidden sm:flex gap-2">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg"
+               width="48"
+               height="48"
+               fill="none"
+               viewbox="0 0 48 48"
+               class="text-neutral-1300 dark:text-neutral-000"
+               aria-hidden="true"
+               style="width: 22px; height: 22px;"
+          >
+            <defs>
+              <clipPath id="clip0_1031_1922-:r2o:">
+                <path fill="#fff"
+                      d="M0 0h48v48H0z"
+                >
+                </path>
+              </clipPath>
+            </defs>
+            <g clip-path="url(#clip0_1031_1922-:r2o:)">
+              <path fill="#F7DF1E"
+                    d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
+              >
+              </path>
+              <path fill="#000"
+                    d="M32.244 37.5c.967 1.579 2.225 2.74 4.45 2.74 1.868 0 3.062-.935 3.062-2.225 0-1.547-1.227-2.095-3.284-2.995l-1.127-.484c-3.255-1.386-5.417-3.123-5.417-6.796 0-3.382 2.577-5.958 6.605-5.958 2.868 0 4.93.998 6.416 3.612l-3.513 2.255c-.773-1.387-1.607-1.933-2.903-1.933-1.32 0-2.158.838-2.158 1.933 0 1.353.838 1.9 2.773 2.739l1.128.483c3.832 1.643 5.996 3.319 5.996 7.086 0 4.06-3.19 6.285-7.474 6.285-4.19 0-6.896-1.996-8.22-4.612zm-15.934.391c.709 1.257 1.353 2.32 2.903 2.32 1.482 0 2.417-.58 2.417-2.834V22.04h4.51v15.398c0 4.67-2.738 6.796-6.735 6.796-3.612 0-5.703-1.869-6.767-4.12z"
+              >
+              </path>
+            </g>
+          </svg>
+          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+            JavaScript
+          </span>
+        </div>
+        <div class="inline-flex ml-0">
+          <button type="button"
+                  aria-describedby="tooltip"
+                  class="p-0 relative focus:outline-none h-[1rem]"
+          >
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+                 tabindex="0"
+                 role="button"
+                 aria-pressed="false"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg"
+                   width="48"
+                   height="48"
+                   fill="none"
+                   viewbox="0 0 48 48"
+                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                   aria-hidden="true"
+                   style="width: 22px; height: 22px;"
+              >
+                <defs>
+                  <clipPath id="clip0_1031_1977-:r2p:">
+                    <path fill="#fff"
+                          d="M0 0h48v48H0z"
+                    >
+                    </path>
+                  </clipPath>
+                </defs>
+                <g clip-path="url(#clip0_1031_1977-:r2p:)">
+                  <path fill="#007ACC"
+                        d="M0 24V0h48v48H0"
+                  >
+                  </path>
+                  <path fill="#fff"
+                        fill-rule="evenodd"
+                        d="M41.568 23.796c-.84-.876-1.776-1.428-3-1.716l.024-.024c-.828-.216-2.808-.288-3.648-.12-2.592.48-4.404 2.16-4.92 4.56-.168.684-.108 2.388.072 3.084.24.804.756 1.776 1.32 2.4.984 1.032 2.04 1.704 4.524 2.76 2.16.96 2.928 1.392 3.312 1.92.276.42.36.672.36 1.224 0 .6-.192 1.032-.636 1.44-1.032.936-3.12 1.044-4.68.24-.516-.288-1.404-1.128-1.8-1.752l-.312-.42-1.356.792-1.8 1.044-.456.288c-.048.084.804 1.368 1.248 1.848 1.128 1.236 2.964 2.196 4.884 2.556.9.156 2.82.18 3.66.036 2.676-.444 4.548-1.8 5.316-3.804.684-1.836.456-4.284-.564-5.844-.9-1.392-2.388-2.364-5.82-3.84-1.86-.816-2.46-1.212-2.784-1.872-.144-.312-.216-.528-.216-.912 0-1.26.96-2.016 2.4-1.92.996.072 1.632.456 2.256 1.344.192.312.384.516.432.48 1.26-.78 3.336-2.184 3.336-2.256-.048-.216-.708-1.056-1.152-1.536M10.524 26.04v-1.956l.036.012v-1.968l8.4-.036c4.62 0 8.424.012 8.424.048.048.024.048.9.048 1.98v1.92h-6.24V43.8h-4.428V26.04z"
+                        clip-rule="evenodd"
+                  >
+                  </path>
+                </g>
+              </svg>
+            </div>
+          </button>
+        </div>
+      </div>
+      <div class="sm:hidden w-full">
+        <button type="button"
+                role="combobox"
+                aria-controls="radix-:r2q:"
+                aria-expanded="false"
+                aria-autocomplete="none"
+                dir="ltr"
+                data-state="closed"
+                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+                aria-label="Select language"
+        >
+          <div class="flex items-center gap-2"
+               style="pointer-events: none;"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="48"
+                 height="48"
+                 fill="none"
+                 viewbox="0 0 48 48"
+                 class
+                 style="width: 20px; height: 20px;"
+            >
+              <defs>
+                <clipPath id="clip0_1031_1922-:r2r:">
+                  <path fill="#fff"
+                        d="M0 0h48v48H0z"
+                  >
+                  </path>
+                </clipPath>
+              </defs>
+              <g clip-path="url(#clip0_1031_1922-:r2r:)">
+                <path fill="#F7DF1E"
+                      d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
+                >
+                </path>
+                <path fill="#000"
+                      d="M32.244 37.5c.967 1.579 2.225 2.74 4.45 2.74 1.868 0 3.062-.935 3.062-2.225 0-1.547-1.227-2.095-3.284-2.995l-1.127-.484c-3.255-1.386-5.417-3.123-5.417-6.796 0-3.382 2.577-5.958 6.605-5.958 2.868 0 4.93.998 6.416 3.612l-3.513 2.255c-.773-1.387-1.607-1.933-2.903-1.933-1.32 0-2.158.838-2.158 1.933 0 1.353.838 1.9 2.773 2.739l1.128.483c3.832 1.643 5.996 3.319 5.996 7.086 0 4.06-3.19 6.285-7.474 6.285-4.19 0-6.896-1.996-8.22-4.612zm-15.934.391c.709 1.257 1.353 2.32 2.903 2.32 1.482 0 2.417-.58 2.417-2.834V22.04h4.51v15.398c0 4.67-2.738 6.796-6.735 6.796-3.612 0-5.703-1.869-6.767-4.12z"
+                >
+                </path>
+              </g>
+            </svg>
+            <span>
+              JavaScript
+            </span>
+          </div>
+          <span aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 fill="none"
+                 viewbox="0 0 24 24"
+                 stroke-width="1.5"
+                 stroke="currentColor"
+                 aria-hidden="true"
+                 data-slot="icon"
+                 class
+                 style="width: 16px; height: 16px;"
+            >
+              <path stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="m19.5 8.25-7.5 7.5-7.5-7.5"
+              >
+              </path>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <div class="relative"
+         tabindex="0"
+    >
+      <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+           data-id="code"
+      >
+        <div class="text-code leading-6 pt-px">
+          <p class="mr-4 font-mono text-right text-neutral-800">
+            1
+          </p>
+          <p class="mr-4 font-mono text-right text-neutral-800">
+            2
+          </p>
+          <p class="mr-4 font-mono text-right text-neutral-800">
+            3
+          </p>
+          <p class="mr-4 font-mono text-right text-neutral-800">
+            4
+          </p>
+          <p class="mr-4 font-mono text-right text-neutral-800">
+            5
+          </p>
+          <p class="mr-4 font-mono text-right text-neutral-800">
+            6
+          </p>
+          <p class="mr-4 font-mono text-right text-neutral-800">
+            7
+          </p>
+        </div>
+        <pre lang="javascript"
+             class="overflow-x-auto h-full flex-1 leading-6"
+        >
+          <code class="language-javascript ui-text-code">
+            <span class="hljs-keyword">
+              var
+            </span>
+            ably =
+            <span class="hljs-keyword">
+              new
+            </span>
+            <span class="hljs-title class_">
+              Ably
+            </span>
+            .
+            <span class="hljs-title class_">
+              Realtime
+            </span>
+            (
+            <span class="hljs-string">
+              '{{API_KEY}}'
+            </span>
+            );
+            <span class="hljs-keyword">
+              var
+            </span>
+            channel = ably.
+            <span class="hljs-property">
+              channels
+            </span>
+            .
+            <span class="hljs-title function_">
+              get
+            </span>
+            (
+            <span class="hljs-string">
+              'channel-name'
+            </span>
+            );
+            <span class="hljs-comment">
+              // Subscribe to messages on channel
+            </span>
+            channel.
+            <span class="hljs-title function_">
+              subscribe
+            </span>
+            (
+            <span class="hljs-string">
+              'event'
+            </span>
+            ,
+            <span class="hljs-keyword">
+              function
+            </span>
+            (
+            <span class="hljs-params">
+              message
+            </span>
+            ) {
+            <span class="hljs-variable language_">
+              console
+            </span>
+            .
+            <span class="hljs-title function_">
+              log
+            </span>
+            (message.
+            <span class="hljs-property">
+              data
+            </span>
+            );
+});
+          </code>
+        </pre>
+      </div>
+    </div>
+  </div>
+  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
+    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+      <div class="flex space-x-1.5">
+        <div class="w-3 h-3 rounded-full bg-orange-500">
+        </div>
+        <div class="w-3 h-3 rounded-full bg-yellow-500">
+        </div>
+        <div class="w-3 h-3 rounded-full bg-green-500">
+        </div>
+      </div>
+      <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+        SDK Type Example (rest only)
+      </div>
+      <div class="w-12">
+      </div>
+    </div>
+    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
+      <div class="flex gap-3 justify-start">
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+             tabindex="0"
+             role="button"
+             aria-pressed="true"
+        >
+          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+            REST
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+      <div class="hidden sm:flex gap-2">
+        <div class="inline-flex ml-0">
+          <button type="button"
+                  aria-describedby="tooltip"
+                  class="p-0 relative focus:outline-none h-[1rem]"
+          >
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+                 tabindex="0"
+                 role="button"
+                 aria-pressed="false"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg"
+                   width="48"
+                   height="48"
+                   fill="none"
+                   viewbox="0 0 48 48"
+                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                   aria-hidden="true"
+                   style="width: 22px; height: 22px;"
+              >
+                <path fill="#000"
+                      fill-rule="evenodd"
+                      d="M10.917 17.073H3.798L0 36.118h3.692l1.01-5.047h3.187q1.62 0 3.134-.372 1.515-.372 2.842-1.753a8.2 8.2 0 0 0 1.7-2.443q.638-1.355.824-2.763.479-3.081-.93-4.86-1.408-1.781-4.542-1.807m-4.016 3.055.005-.026-.026.026zm0 0L5.312 28.07q.16.027.32.027h.371q2.55.027 4.25-.505 1.7-.558 2.284-3.878.479-2.789-.956-3.214-1.408-.425-3.533-.398a8 8 0 0 1-.61.026z"
+                      clip-rule="evenodd"
+                >
+                </path>
+                <path fill="#000"
+                      d="M20.595 12h3.665l-1.036 5.073h3.294q2.71.054 4.037 1.116 1.355 1.062.797 4.037l-1.78 8.846h-3.718l1.7-8.447q.266-1.328-.16-1.886-.425-.558-1.832-.558l-2.949-.027-2.178 10.918H16.77z"
+                >
+                </path>
+                <path fill="#000"
+                      fill-rule="evenodd"
+                      d="M42.407 17.073h-7.119L31.49 36.118h3.692l1.01-5.047h3.187q1.62 0 3.134-.372 1.515-.372 2.842-1.753a8.2 8.2 0 0 0 1.7-2.443q.638-1.355.824-2.763.479-3.081-.93-4.86-1.409-1.781-4.542-1.807m-4.016 3.055.005-.026-.026.026zm0 0-1.588 7.942q.159.027.318.027h.372q2.55.027 4.25-.505 1.7-.558 2.284-3.878.479-2.789-.956-3.214-1.408-.425-3.533-.398a8 8 0 0 1-.61.026z"
+                      clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+            </div>
+          </button>
+        </div>
+        <div class="inline-flex ml-0">
+          <button type="button"
+                  aria-describedby="tooltip"
+                  class="p-0 relative focus:outline-none h-[1rem]"
+          >
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+                 tabindex="0"
+                 role="button"
+                 aria-pressed="false"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg"
+                   width="48"
+                   height="48"
+                   fill="none"
+                   viewbox="0 0 48 48"
+                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                   aria-hidden="true"
+                   style="width: 22px; height: 22px;"
+              >
+                <defs>
+                  <linearGradient id="paint0_linear_1031_1914-:r2u:"
+                                  x1="14.252"
+                                  x2="58.919"
+                                  y1="66.464"
+                                  y2="21.797"
+                                  gradientunits="userSpaceOnUse"
+                  >
+                    <stop offset="0.108"
+                          stop-color="#C757BC"
+                    >
+                    </stop>
+                    <stop offset="0.173"
+                          stop-color="#CD5CA9"
+                    >
+                    </stop>
+                    <stop offset="0.492"
+                          stop-color="#E8744F"
+                    >
+                    </stop>
+                    <stop offset="0.716"
+                          stop-color="#F88316"
+                    >
+                    </stop>
+                    <stop offset="0.823"
+                          stop-color="#FF8900"
+                    >
+                    </stop>
+                  </linearGradient>
+                  <linearGradient id="paint1_linear_1031_1914-:r2u:"
+                                  x1="36.994"
+                                  x2="43.459"
+                                  y1="62.127"
+                                  y2="36.495"
+                                  gradientunits="userSpaceOnUse"
+                  >
+                    <stop offset="0.296"
+                          stop-color="#00AFFF"
+                    >
+                    </stop>
+                    <stop offset="0.694"
+                          stop-color="#5282FF"
+                    >
+                    </stop>
+                    <stop offset="1"
+                          stop-color="#945DFF"
+                    >
+                    </stop>
+                  </linearGradient>
+                  <linearGradient id="paint2_linear_1031_1914-:r2u:"
+                                  x1="6.685"
+                                  x2="22.686"
+                                  y1="21.279"
+                                  y2="6.811"
+                                  gradientunits="userSpaceOnUse"
+                  >
+                    <stop offset="0.296"
+                          stop-color="#00AFFF"
+                    >
+                    </stop>
+                    <stop offset="0.694"
+                          stop-color="#5282FF"
+                    >
+                    </stop>
+                    <stop offset="1"
+                          stop-color="#945DFF"
+                    >
+                    </stop>
+                  </linearGradient>
+                  <clipPath id="clip0_1031_1914-:r2u:">
+                    <path fill="#fff"
+                          d="M0 0h48v48H0z"
+                    >
+                    </path>
+                  </clipPath>
+                </defs>
+                <g clip-path="url(#clip0_1031_1914-:r2u:)">
+                  <path fill="url(#paint0_linear_1031_1914-:r2u:)"
+                        d="M24.1 0 0 25.344V48l24.065-24.107L48 0z"
+                  >
+                  </path>
+                  <path fill="url(#paint1_linear_1031_1914-:r2u:)"
+                        d="m0 48 24.065-24.107L48 48z"
+                  >
+                  </path>
+                  <path fill="url(#paint2_linear_1031_1914-:r2u:)"
+                        d="M0 0h24.1L0 25.344z"
+                  >
+                  </path>
+                </g>
+              </svg>
+            </div>
+          </button>
+        </div>
+      </div>
+      <div class="sm:hidden w-full">
+        <button type="button"
+                role="combobox"
+                aria-controls="radix-:r2v:"
+                aria-expanded="false"
+                aria-autocomplete="none"
+                dir="ltr"
+                data-state="closed"
+                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+                aria-label="Select language"
+        >
+          <div class="flex items-center gap-2"
+               style="pointer-events: none;"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="48"
+                 height="48"
+                 fill="none"
+                 viewbox="0 0 48 48"
+                 class
+                 style="width: 20px; height: 20px;"
+            >
+              <defs>
+                <clipPath id="clip0_1031_1922-:r30:">
+                  <path fill="#fff"
+                        d="M0 0h48v48H0z"
+                  >
+                  </path>
+                </clipPath>
+              </defs>
+              <g clip-path="url(#clip0_1031_1922-:r30:)">
+                <path fill="#F7DF1E"
+                      d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
+                >
+                </path>
+                <path fill="#000"
+                      d="M32.244 37.5c.967 1.579 2.225 2.74 4.45 2.74 1.868 0 3.062-.935 3.062-2.225 0-1.547-1.227-2.095-3.284-2.995l-1.127-.484c-3.255-1.386-5.417-3.123-5.417-6.796 0-3.382 2.577-5.958 6.605-5.958 2.868 0 4.93.998 6.416 3.612l-3.513 2.255c-.773-1.387-1.607-1.933-2.903-1.933-1.32 0-2.158.838-2.158 1.933 0 1.353.838 1.9 2.773 2.739l1.128.483c3.832 1.643 5.996 3.319 5.996 7.086 0 4.06-3.19 6.285-7.474 6.285-4.19 0-6.896-1.996-8.22-4.612zm-15.934.391c.709 1.257 1.353 2.32 2.903 2.32 1.482 0 2.417-.58 2.417-2.834V22.04h4.51v15.398c0 4.67-2.738 6.796-6.735 6.796-3.612 0-5.703-1.869-6.767-4.12z"
+                >
+                </path>
+              </g>
+            </svg>
+            <span>
+              JavaScript
+            </span>
+          </div>
+          <span aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 fill="none"
+                 viewbox="0 0 24 24"
+                 stroke-width="1.5"
+                 stroke="currentColor"
+                 aria-hidden="true"
+                 data-slot="icon"
+                 class
+                 style="width: 16px; height: 16px;"
+            >
+              <path stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="m19.5 8.25-7.5 7.5-7.5-7.5"
+              >
+              </path>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <div class="relative"
+         tabindex="0"
+    >
+      <div class="px-16 py-6 ui-text-body2 text-neutral-800 dark:text-neutral-400 text-center flex flex-col gap-3 items-center">
+        <svg xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewbox="0 0 24 24"
+             stroke-width="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             data-slot="icon"
+             class="text-yellow-600 dark:text-yellow-400"
+             style="width: 24px; height: 24px;"
+        >
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+          >
+          </path>
+        </svg>
+        <p class="ui-text-p3 text-neutral-700 dark:text-neutral-600">
+          You're currently viewing the JavaScript docs. There either isn't a JavaScript code sample for this example, or this feature isn't supported in JavaScript. Switch language to view this example in a different language, or check which SDKs support this feature.
+        </p>
       </div>
     </div>
   </div>
@@ -3664,433 +4229,6 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
 </div>
 `;
 
-exports[`Components/Code Snippet WithOnChangeCallback smoke-test 1`] = `
-<div>
-  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
-      <div class="flex space-x-1.5">
-        <div class="w-3 h-3 rounded-full bg-orange-500">
-        </div>
-        <div class="w-3 h-3 rounded-full bg-yellow-500">
-        </div>
-        <div class="w-3 h-3 rounded-full bg-green-500">
-        </div>
-      </div>
-      <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
-        Language Change Example
-      </div>
-      <div class="w-12">
-      </div>
-    </div>
-    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
-      <div class="flex gap-3 justify-start">
-        <div class="inline-flex ml-0">
-          <button type="button"
-                  aria-describedby="tooltip"
-                  class="p-0 relative focus:outline-none h-[1rem]"
-          >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
-                 tabindex="0"
-                 role="button"
-                 aria-pressed="false"
-            >
-              <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
-                Realtime
-              </span>
-            </div>
-          </button>
-        </div>
-        <div class="inline-flex ml-0">
-          <button type="button"
-                  aria-describedby="tooltip"
-                  class="p-0 relative focus:outline-none h-[1rem]"
-          >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
-                 tabindex="0"
-                 role="button"
-                 aria-pressed="false"
-            >
-              <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
-                REST
-              </span>
-            </div>
-          </button>
-        </div>
-      </div>
-    </div>
-    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
-      <div class="hidden sm:flex gap-2">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
-             tabindex="0"
-             role="button"
-             aria-pressed="true"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg"
-               width="48"
-               height="48"
-               fill="none"
-               viewbox="0 0 48 48"
-               class="text-neutral-1300 dark:text-neutral-000"
-               aria-hidden="true"
-               style="width: 22px; height: 22px;"
-          >
-            <defs>
-              <clipPath id="clip0_1031_1922-:r1g:">
-                <path fill="#fff"
-                      d="M0 0h48v48H0z"
-                >
-                </path>
-              </clipPath>
-            </defs>
-            <g clip-path="url(#clip0_1031_1922-:r1g:)">
-              <path fill="#F7DF1E"
-                    d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
-              >
-              </path>
-              <path fill="#000"
-                    d="M32.244 37.5c.967 1.579 2.225 2.74 4.45 2.74 1.868 0 3.062-.935 3.062-2.225 0-1.547-1.227-2.095-3.284-2.995l-1.127-.484c-3.255-1.386-5.417-3.123-5.417-6.796 0-3.382 2.577-5.958 6.605-5.958 2.868 0 4.93.998 6.416 3.612l-3.513 2.255c-.773-1.387-1.607-1.933-2.903-1.933-1.32 0-2.158.838-2.158 1.933 0 1.353.838 1.9 2.773 2.739l1.128.483c3.832 1.643 5.996 3.319 5.996 7.086 0 4.06-3.19 6.285-7.474 6.285-4.19 0-6.896-1.996-8.22-4.612zm-15.934.391c.709 1.257 1.353 2.32 2.903 2.32 1.482 0 2.417-.58 2.417-2.834V22.04h4.51v15.398c0 4.67-2.738 6.796-6.735 6.796-3.612 0-5.703-1.869-6.767-4.12z"
-              >
-              </path>
-            </g>
-          </svg>
-          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
-            JavaScript
-          </span>
-        </div>
-        <div class="inline-flex ml-0">
-          <button type="button"
-                  aria-describedby="tooltip"
-                  class="p-0 relative focus:outline-none h-[1rem]"
-          >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
-                 tabindex="0"
-                 role="button"
-                 aria-pressed="false"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg"
-                   width="48"
-                   height="48"
-                   fill="none"
-                   viewbox="0 0 48 48"
-                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
-                   aria-hidden="true"
-                   style="width: 22px; height: 22px;"
-              >
-                <defs>
-                  <clipPath id="clip0_1031_1977-:r1h:">
-                    <path fill="#fff"
-                          d="M0 0h48v48H0z"
-                    >
-                    </path>
-                  </clipPath>
-                </defs>
-                <g clip-path="url(#clip0_1031_1977-:r1h:)">
-                  <path fill="#007ACC"
-                        d="M0 24V0h48v48H0"
-                  >
-                  </path>
-                  <path fill="#fff"
-                        fill-rule="evenodd"
-                        d="M41.568 23.796c-.84-.876-1.776-1.428-3-1.716l.024-.024c-.828-.216-2.808-.288-3.648-.12-2.592.48-4.404 2.16-4.92 4.56-.168.684-.108 2.388.072 3.084.24.804.756 1.776 1.32 2.4.984 1.032 2.04 1.704 4.524 2.76 2.16.96 2.928 1.392 3.312 1.92.276.42.36.672.36 1.224 0 .6-.192 1.032-.636 1.44-1.032.936-3.12 1.044-4.68.24-.516-.288-1.404-1.128-1.8-1.752l-.312-.42-1.356.792-1.8 1.044-.456.288c-.048.084.804 1.368 1.248 1.848 1.128 1.236 2.964 2.196 4.884 2.556.9.156 2.82.18 3.66.036 2.676-.444 4.548-1.8 5.316-3.804.684-1.836.456-4.284-.564-5.844-.9-1.392-2.388-2.364-5.82-3.84-1.86-.816-2.46-1.212-2.784-1.872-.144-.312-.216-.528-.216-.912 0-1.26.96-2.016 2.4-1.92.996.072 1.632.456 2.256 1.344.192.312.384.516.432.48 1.26-.78 3.336-2.184 3.336-2.256-.048-.216-.708-1.056-1.152-1.536M10.524 26.04v-1.956l.036.012v-1.968l8.4-.036c4.62 0 8.424.012 8.424.048.048.024.048.9.048 1.98v1.92h-6.24V43.8h-4.428V26.04z"
-                        clip-rule="evenodd"
-                  >
-                  </path>
-                </g>
-              </svg>
-            </div>
-          </button>
-        </div>
-        <div class="inline-flex ml-0">
-          <button type="button"
-                  aria-describedby="tooltip"
-                  class="p-0 relative focus:outline-none h-[1rem]"
-          >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
-                 tabindex="0"
-                 role="button"
-                 aria-pressed="false"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg"
-                   width="48"
-                   height="48"
-                   fill="none"
-                   viewbox="0 0 48 48"
-                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
-                   aria-hidden="true"
-                   style="width: 22px; height: 22px;"
-              >
-                <defs>
-                  <linearGradient id="paint0_linear_1031_1912-:r1i:"
-                                  x1="2.813"
-                                  x2="-6.259"
-                                  y1="-6.259"
-                                  y2="45.187"
-                                  gradientunits="userSpaceOnUse"
-                  >
-                    <stop stop-color="#FAAE41">
-                    </stop>
-                    <stop offset="1"
-                          stop-color="#EF3E31"
-                    >
-                    </stop>
-                  </linearGradient>
-                  <linearGradient id="paint1_linear_1031_1912-:r1i:"
-                                  x1="4.876"
-                                  x2="-1.23"
-                                  y1="-2.365"
-                                  y2="35.34"
-                                  gradientunits="userSpaceOnUse"
-                  >
-                    <stop stop-color="#E29F3A">
-                    </stop>
-                    <stop offset="1"
-                          stop-color="#D43929"
-                    >
-                    </stop>
-                  </linearGradient>
-                  <clipPath id="clip0_1031_1912-:r1i:">
-                    <path fill="#fff"
-                          d="M0 0h48v48H0z"
-                    >
-                    </path>
-                  </clipPath>
-                </defs>
-                <g fill-rule="evenodd"
-                   clip-path="url(#clip0_1031_1912-:r1i:)"
-                   clip-rule="evenodd"
-                >
-                  <path fill="url(#paint0_linear_1031_1912-:r1i:)"
-                        d="M10.633 0C4.76 0 0 4.76 0 10.633v26.734C0 43.24 4.76 48 10.633 48h26.734C43.24 48 48 43.24 48 37.367V10.633C48 4.76 43.24 0 37.367 0z"
-                  >
-                  </path>
-                  <path fill="url(#paint1_linear_1031_1912-:r1i:)"
-                        d="M10.624.038C4.756.038 0 4.795 0 10.662v12.092l4.925 5.301c.05.088 6.417 11.228 19.817 11.228 6.054 0 7.813-3.104 10.814-3.104 3.104 0 4.967 3.104 4.967 3.104 1.811-4.45-2.69-9.52-2.69-9.52s5.122-11.848-10.71-22.61l-.001-.001L20.107.038z"
-                  >
-                  </path>
-                  <path fill="#FEFEFE"
-                        d="M27.16 7.155c15.833 10.763 10.71 22.612 10.71 22.612s4.502 5.07 2.691 9.52c0 0-1.863-3.105-4.967-3.105-3.001 0-4.76 3.105-10.814 3.105-13.453 0-19.817-11.228-19.817-11.228 12.113 7.982 20.386 2.328 20.386 2.328-5.465-3.174-17.075-18.316-17.075-18.316 10.12 8.608 14.488 10.865 14.488 10.865-2.615-2.152-9.935-12.676-9.935-12.676 5.857 5.926 17.49 14.177 17.49 14.177 3.317-9.12-3.157-17.282-3.157-17.282"
-                  >
-                  </path>
-                </g>
-              </svg>
-            </div>
-          </button>
-        </div>
-        <div class="inline-flex ml-0">
-          <button type="button"
-                  aria-describedby="tooltip"
-                  class="p-0 relative focus:outline-none h-[1rem]"
-          >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
-                 tabindex="0"
-                 role="button"
-                 aria-pressed="false"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg"
-                   width="48"
-                   height="48"
-                   fill="none"
-                   viewbox="0 0 48 48"
-                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
-                   aria-hidden="true"
-                   style="width: 22px; height: 22px;"
-              >
-                <path fill="#000"
-                      fill-rule="evenodd"
-                      d="M10.917 17.073H3.798L0 36.118h3.692l1.01-5.047h3.187q1.62 0 3.134-.372 1.515-.372 2.842-1.753a8.2 8.2 0 0 0 1.7-2.443q.638-1.355.824-2.763.479-3.081-.93-4.86-1.408-1.781-4.542-1.807m-4.016 3.055.005-.026-.026.026zm0 0L5.312 28.07q.16.027.32.027h.371q2.55.027 4.25-.505 1.7-.558 2.284-3.878.479-2.789-.956-3.214-1.408-.425-3.533-.398a8 8 0 0 1-.61.026z"
-                      clip-rule="evenodd"
-                >
-                </path>
-                <path fill="#000"
-                      d="M20.595 12h3.665l-1.036 5.073h3.294q2.71.054 4.037 1.116 1.355 1.062.797 4.037l-1.78 8.846h-3.718l1.7-8.447q.266-1.328-.16-1.886-.425-.558-1.832-.558l-2.949-.027-2.178 10.918H16.77z"
-                >
-                </path>
-                <path fill="#000"
-                      fill-rule="evenodd"
-                      d="M42.407 17.073h-7.119L31.49 36.118h3.692l1.01-5.047h3.187q1.62 0 3.134-.372 1.515-.372 2.842-1.753a8.2 8.2 0 0 0 1.7-2.443q.638-1.355.824-2.763.479-3.081-.93-4.86-1.409-1.781-4.542-1.807m-4.016 3.055.005-.026-.026.026zm0 0-1.588 7.942q.159.027.318.027h.372q2.55.027 4.25-.505 1.7-.558 2.284-3.878.479-2.789-.956-3.214-1.408-.425-3.533-.398a8 8 0 0 1-.61.026z"
-                      clip-rule="evenodd"
-                >
-                </path>
-              </svg>
-            </div>
-          </button>
-        </div>
-      </div>
-      <div class="sm:hidden w-full">
-        <button type="button"
-                role="combobox"
-                aria-controls="radix-:r1k:"
-                aria-expanded="false"
-                aria-autocomplete="none"
-                dir="ltr"
-                data-state="closed"
-                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
-                aria-label="Select language"
-        >
-          <div class="flex items-center gap-2"
-               style="pointer-events: none;"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg"
-                 width="48"
-                 height="48"
-                 fill="none"
-                 viewbox="0 0 48 48"
-                 class
-                 style="width: 20px; height: 20px;"
-            >
-              <defs>
-                <clipPath id="clip0_1031_1922-:r1l:">
-                  <path fill="#fff"
-                        d="M0 0h48v48H0z"
-                  >
-                  </path>
-                </clipPath>
-              </defs>
-              <g clip-path="url(#clip0_1031_1922-:r1l:)">
-                <path fill="#F7DF1E"
-                      d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
-                >
-                </path>
-                <path fill="#000"
-                      d="M32.244 37.5c.967 1.579 2.225 2.74 4.45 2.74 1.868 0 3.062-.935 3.062-2.225 0-1.547-1.227-2.095-3.284-2.995l-1.127-.484c-3.255-1.386-5.417-3.123-5.417-6.796 0-3.382 2.577-5.958 6.605-5.958 2.868 0 4.93.998 6.416 3.612l-3.513 2.255c-.773-1.387-1.607-1.933-2.903-1.933-1.32 0-2.158.838-2.158 1.933 0 1.353.838 1.9 2.773 2.739l1.128.483c3.832 1.643 5.996 3.319 5.996 7.086 0 4.06-3.19 6.285-7.474 6.285-4.19 0-6.896-1.996-8.22-4.612zm-15.934.391c.709 1.257 1.353 2.32 2.903 2.32 1.482 0 2.417-.58 2.417-2.834V22.04h4.51v15.398c0 4.67-2.738 6.796-6.735 6.796-3.612 0-5.703-1.869-6.767-4.12z"
-                >
-                </path>
-              </g>
-            </svg>
-            <span>
-              JavaScript
-            </span>
-          </div>
-          <span aria-hidden="true">
-            <svg xmlns="http://www.w3.org/2000/svg"
-                 fill="none"
-                 viewbox="0 0 24 24"
-                 stroke-width="1.5"
-                 stroke="currentColor"
-                 aria-hidden="true"
-                 data-slot="icon"
-                 class
-                 style="width: 16px; height: 16px;"
-            >
-              <path stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="m19.5 8.25-7.5 7.5-7.5-7.5"
-              >
-              </path>
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <div class="relative"
-         tabindex="0"
-    >
-      <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
-           data-id="code"
-      >
-        <div class="text-code leading-6 pt-px">
-          <p class="mr-4 font-mono text-right text-neutral-800">
-            1
-          </p>
-          <p class="mr-4 font-mono text-right text-neutral-800">
-            2
-          </p>
-          <p class="mr-4 font-mono text-right text-neutral-800">
-            3
-          </p>
-          <p class="mr-4 font-mono text-right text-neutral-800">
-            4
-          </p>
-          <p class="mr-4 font-mono text-right text-neutral-800">
-            5
-          </p>
-          <p class="mr-4 font-mono text-right text-neutral-800">
-            6
-          </p>
-          <p class="mr-4 font-mono text-right text-neutral-800">
-            7
-          </p>
-        </div>
-        <pre lang="javascript"
-             class="overflow-x-auto h-full flex-1 leading-6"
-        >
-          <code class="language-javascript ui-text-code">
-            <span class="hljs-keyword">
-              var
-            </span>
-            ably =
-            <span class="hljs-keyword">
-              new
-            </span>
-            <span class="hljs-title class_">
-              Ably
-            </span>
-            .
-            <span class="hljs-title class_">
-              Realtime
-            </span>
-            (
-            <span class="hljs-string">
-              '{{API_KEY}}'
-            </span>
-            );
-            <span class="hljs-keyword">
-              var
-            </span>
-            channel = ably.
-            <span class="hljs-property">
-              channels
-            </span>
-            .
-            <span class="hljs-title function_">
-              get
-            </span>
-            (
-            <span class="hljs-string">
-              'channel-name'
-            </span>
-            );
-            <span class="hljs-comment">
-              // Subscribe to messages on channel
-            </span>
-            channel.
-            <span class="hljs-title function_">
-              subscribe
-            </span>
-            (
-            <span class="hljs-string">
-              'event'
-            </span>
-            ,
-            <span class="hljs-keyword">
-              function
-            </span>
-            (
-            <span class="hljs-params">
-              message
-            </span>
-            ) {
-            <span class="hljs-variable language_">
-              console
-            </span>
-            .
-            <span class="hljs-title function_">
-              log
-            </span>
-            (message.
-            <span class="hljs-property">
-              data
-            </span>
-            );
-});
-          </code>
-        </pre>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
 <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
   <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
@@ -4154,14 +4292,14 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
              style="width: 22px; height: 22px;"
         >
           <defs>
-            <clipPath id="clip0_1031_1922-:r2u:">
+            <clipPath id="clip0_1031_1922-:r2e:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
               </path>
             </clipPath>
           </defs>
-          <g clip-path="url(#clip0_1031_1922-:r2u:)">
+          <g clip-path="url(#clip0_1031_1922-:r2e:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -4196,14 +4334,14 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <defs>
-                <clipPath id="clip0_1031_1977-:r2v:">
+                <clipPath id="clip0_1031_1977-:r2f:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
                   </path>
                 </clipPath>
               </defs>
-              <g clip-path="url(#clip0_1031_1977-:r2v:)">
+              <g clip-path="url(#clip0_1031_1977-:r2f:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -4223,7 +4361,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r30:"
+              aria-controls="radix-:r2g:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -4243,14 +4381,14 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                style="width: 20px; height: 20px;"
           >
             <defs>
-              <clipPath id="clip0_1031_1922-:r31:">
+              <clipPath id="clip0_1031_1922-:r2h:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
                 </path>
               </clipPath>
             </defs>
-            <g clip-path="url(#clip0_1031_1922-:r31:)">
+            <g clip-path="url(#clip0_1031_1922-:r2h:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >
@@ -4428,14 +4566,14 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
              style="width: 22px; height: 22px;"
         >
           <defs>
-            <clipPath id="clip0_1031_1922-:r3d:">
+            <clipPath id="clip0_1031_1922-:r3h:">
               <path fill="#fff"
                     d="M0 0h48v48H0z"
               >
               </path>
             </clipPath>
           </defs>
-          <g clip-path="url(#clip0_1031_1922-:r3d:)">
+          <g clip-path="url(#clip0_1031_1922-:r3h:)">
             <path fill="#F7DF1E"
                   d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
             >
@@ -4470,14 +4608,14 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                  style="width: 22px; height: 22px;"
             >
               <defs>
-                <clipPath id="clip0_1031_1977-:r3e:">
+                <clipPath id="clip0_1031_1977-:r3i:">
                   <path fill="#fff"
                         d="M0 0h48v48H0z"
                   >
                   </path>
                 </clipPath>
               </defs>
-              <g clip-path="url(#clip0_1031_1977-:r3e:)">
+              <g clip-path="url(#clip0_1031_1977-:r3i:)">
                 <path fill="#007ACC"
                       d="M0 24V0h48v48H0"
                 >
@@ -4497,7 +4635,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
     <div class="sm:hidden w-full">
       <button type="button"
               role="combobox"
-              aria-controls="radix-:r3f:"
+              aria-controls="radix-:r3j:"
               aria-expanded="false"
               aria-autocomplete="none"
               dir="ltr"
@@ -4517,14 +4655,14 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                style="width: 20px; height: 20px;"
           >
             <defs>
-              <clipPath id="clip0_1031_1922-:r3g:">
+              <clipPath id="clip0_1031_1922-:r3k:">
                 <path fill="#fff"
                       d="M0 0h48v48H0z"
                 >
                 </path>
               </clipPath>
             </defs>
-            <g clip-path="url(#clip0_1031_1922-:r3g:)">
+            <g clip-path="url(#clip0_1031_1922-:r3k:)">
               <path fill="#F7DF1E"
                     d="M46 0H2a2 2 0 0 0-2 2v44a2 2 0 0 0 2 2h44a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2"
               >


### PR DESCRIPTION
Addresses a regression in the CodeSnippet component that happened at an unclear point, where the sdk type should fall back to one which has present code samples if the active SDK has none.

As an example, if the SDK type on a page is set to "realtime":
- code blocks with a mix of realtime and REST snippets will show the realtime ones first
- code blocks with realtime only will show realtime (duh)
- code blocks with rest only will show nothing (bad)

This PR makes it so that in the third case, it falls back to rest, even though the page is set to realtime. Language selection is still independent.

Greg has reviewed the dev version in docs here: https://ably-docs-web-4553-code-qop3gn.herokuapp.com/docs/presence-occupancy/presence

Review link in Storybook: https://ably-ui-web-4553-codesn-tr7wje.herokuapp.com/?path=/story/components-code-snippet--with-fallback-sdk-type-across-instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Improved SDK auto-selection in code snippets: when only one SDK is available, it’s chosen automatically for consistent language filtering and active state.
  * Enhanced multi-instance behavior: code snippets can share SDK/language state for coordinated updates across components.

* Documentation
  * Updated stories to demonstrate cross-instance state sharing and fallback SDK selection; removed outdated onChange alert example.

* Chores
  * Version bumped to 17.6.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->