### PR TITLE
[WEB-4553] chore: replace lodash usage with es-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.6.5",
+  "version": "17.6.6",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",
@@ -30,7 +30,6 @@
     "@swc/core": "^1.4.11",
     "@tailwindcss/container-queries": "^0.1.1",
     "@types/js-cookie": "^3.0.6",
-    "@types/lodash.throttle": "^4.1.9",
     "@types/mixpanel-browser": "^2.60.0",
     "@types/node": "^20",
     "@types/react": "^18.3.1",
@@ -39,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "@typescript-eslint/parser": "^8.25.0",
     "@vitejs/plugin-react-swc": "^3.8.0",
+    "@vueless/storybook-dark-mode": "^9.0.6",
     "autoprefixer": "^10.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^10.0.1",
@@ -60,7 +60,6 @@
     "typescript": "5.8.3",
     "vite": "^7.1.1",
     "vitest": "^3.0.8",
-    "@vueless/storybook-dark-mode": "^9.0.6",
     "wait-on": "^8.0.3"
   },
   "scripts": {
@@ -96,10 +95,10 @@
     "array-flat-polyfill": "^1.0.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.4",
+    "es-toolkit": "^1.39.10",
     "highlight.js": "^11.11.1",
     "highlightjs-curl": "^1.3.0",
     "js-cookie": "^3.0.5",
-    "lodash.throttle": "^4.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.3.1",
     "redux": "^4.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       dompurify:
         specifier: ^3.2.4
         version: 3.2.6
+      es-toolkit:
+        specifier: ^1.39.10
+        version: 1.39.10
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -44,9 +47,6 @@ importers:
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
-      lodash.throttle:
-        specifier: ^4.1.1
-        version: 4.1.1
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -96,9 +96,6 @@ importers:
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
-      '@types/lodash.throttle':
-        specifier: ^4.1.9
-        version: 4.1.9
       '@types/mixpanel-browser':
         specifier: ^2.60.0
         version: 2.66.0
@@ -1898,12 +1895,6 @@ packages:
   '@types/js-cookie@3.0.6':
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
 
-  '@types/lodash.throttle@4.1.9':
-    resolution: {integrity: sha512-PCPVfpfueguWZQB7pJQK890F2scYKoDUL3iM522AptHWn7d5NQmeS/LTEHIcLr5PaTzl3dK2Z0xSUHHTHwaL5g==}
-
-  '@types/lodash@4.17.7':
-    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
-
   '@types/mdx@2.0.10':
     resolution: {integrity: sha512-Rllzc5KHk0Al5/WANwgSPl1/CwjqCy+AZrGd78zuK+jO9aDM6ffblZ+zIjgPNAaEBmlO0RYDvLNh7wD0zKVgEg==}
 
@@ -2936,6 +2927,9 @@ packages:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.39.10:
+    resolution: {integrity: sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -3955,9 +3949,6 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  lodash.throttle@4.1.1:
-    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -7283,12 +7274,6 @@ snapshots:
 
   '@types/js-cookie@3.0.6': {}
 
-  '@types/lodash.throttle@4.1.9':
-    dependencies:
-      '@types/lodash': 4.17.7
-
-  '@types/lodash@4.17.7': {}
-
   '@types/mdx@2.0.10': {}
 
   '@types/mixpanel-browser@2.66.0':
@@ -8494,6 +8479,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+
+  es-toolkit@1.39.10: {}
 
   es6-error@4.1.1: {}
 
@@ -9808,8 +9795,6 @@ snapshots:
   lodash.flattendeep@4.4.0: {}
 
   lodash.merge@4.6.2: {}
-
-  lodash.throttle@4.1.1: {}
 
   lodash@4.17.21: {}
 

--- a/src/core/Expander.tsx
+++ b/src/core/Expander.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import throttle from "lodash.throttle";
+import { throttle } from "es-toolkit/compat";
 
 type ExpanderProps = {
   heightThreshold?: number;

--- a/src/core/Header.tsx
+++ b/src/core/Header.tsx
@@ -8,7 +8,7 @@ import {
   HEADER_HEIGHT,
 } from "./utils/heights";
 import { HeaderLinks } from "./Header/HeaderLinks";
-import throttle from "lodash.throttle";
+import { throttle } from "es-toolkit/compat";
 import { Theme } from "./styles/colors/types";
 import { COLLAPSE_TRIGGER_DISTANCE } from "./Notice/component";
 

--- a/src/core/Notice/component.js
+++ b/src/core/Notice/component.js
@@ -1,5 +1,5 @@
 import Cookie from "js-cookie";
-import throttle from "lodash.throttle";
+import { throttle } from "es-toolkit/compat";
 
 import { queryId } from "../dom-query";
 import { FLASH_DATA_ID } from "../Flash";

--- a/src/core/Pricing/PricingCards.tsx
+++ b/src/core/Pricing/PricingCards.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, useRef, useState } from "react";
-import throttle from "lodash.throttle";
+import { throttle } from "es-toolkit/compat";
 import type { PricingDataFeature } from "./types";
 import Icon from "../Icon";
 import LinkButton from "../LinkButton";

--- a/src/core/Slider/component.js
+++ b/src/core/Slider/component.js
@@ -1,4 +1,4 @@
-import throttle from "lodash.throttle";
+import { throttle } from "es-toolkit/compat";
 
 import { queryId, queryIdAll } from "../dom-query";
 

--- a/src/core/TabMenu.tsx
+++ b/src/core/TabMenu.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect } from "react";
 import * as Tabs from "@radix-ui/react-tabs";
-import throttle from "lodash.throttle";
+import { throttle } from "es-toolkit/compat";
 import cn from "./utils/cn";
 
 type TabTriggerContent =


### PR DESCRIPTION
Suggested by @kennethkalmer [here](https://ably-real-time.slack.com/archives/C03F5SF44C9/p1755774905091079), I looked further into it and saw no downsides to switching to the `compat` variant of `es-toolkit` (which promises 100% lodash compatibility with most of the bundle size and speed improvements `es-toolkit` promises).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated app version to 17.6.6.
  - Updated dependencies: replaced lodash.throttle with es-toolkit; cleaned up unused type package.
  - Moved Storybook dark mode package to development-only dependency.
- Refactor
  - Switched throttling utility across multiple components to use es-toolkit for consistency. No user-facing behavior changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->