### PR TITLE
[WEB-4465] Fix `ProductDescription` colours

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.6.7",
+  "version": "17.6.8",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/ProductTile/ProductDescription.tsx
+++ b/src/core/ProductTile/ProductDescription.tsx
@@ -28,7 +28,7 @@ const ProductDescription = ({
           "text-neutral-300 dark:text-neutral-1000": selected && !unavailable,
         },
         {
-          "text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300":
+          "text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300":
             !selected,
         },
         className,

--- a/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
+++ b/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
@@ -115,7 +115,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Low-level APIs for building realtime applications.
     </span>
   </div>
@@ -189,7 +189,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Build feature-rich live chat experiences.
     </span>
   </div>
@@ -261,7 +261,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Enhance your application with collaborative features.
     </span>
   </div>
@@ -336,7 +336,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Fan-out database changes to client applications.
     </span>
   </div>
@@ -409,7 +409,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Track the geographic location of assets and fleets.
     </span>
   </div>
@@ -500,7 +500,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Sync application state across client devices.
     </span>
   </div>
@@ -547,7 +547,7 @@ exports[`Components/Product Tile ProductTileWithOverriddenStylesAndClick smoke-t
       </span>
     </span>
   </div>
-  <span class="block ui-text-p3 font-medium leading-snug dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300 text-blue-500">
+  <span class="block ui-text-p3 font-medium leading-snug dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300 text-blue-500">
     Low-level APIs for building realtime applications.
   </span>
 </div>
@@ -594,7 +594,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Low-level APIs for building realtime applications.
     </span>
   </div>
@@ -637,7 +637,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Build feature-rich live chat experiences.
     </span>
   </div>
@@ -680,7 +680,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Enhance your application with collaborative features.
     </span>
   </div>
@@ -724,7 +724,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Fan-out database changes to client applications.
     </span>
   </div>
@@ -766,7 +766,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Track the geographic location of assets and fleets.
     </span>
   </div>
@@ -817,7 +817,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Sync application state across client devices.
     </span>
   </div>
@@ -1046,7 +1046,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Low-level APIs for building realtime applications.
     </span>
   </div>
@@ -1089,7 +1089,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Build feature-rich live chat experiences.
     </span>
   </div>
@@ -1132,7 +1132,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Enhance your application with collaborative features.
     </span>
   </div>
@@ -1176,7 +1176,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Fan-out database changes to client applications.
     </span>
   </div>
@@ -1218,7 +1218,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Track the geographic location of assets and fleets.
     </span>
   </div>
@@ -1269,7 +1269,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-700 dark:text-neutral-600 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
       Sync application state across client devices.
     </span>
   </div>


### PR DESCRIPTION
## Jira Ticket Link / Motivation

Noticed elsewhere that colours looked a little pale, I discovered we were slightly off the scale here since these were implemented in #753, at least as the Figma designs look today.

* [Docs homepage design](https://www.figma.com/design/femL25xz8lbKTk4sLvUIAt/Docs-Homepage-Redesign?node-id=180-10535&t=UGA2WKlYXh1egz9I-11)
* [Getting started design](https://www.figma.com/design/p7HvFxbueh53AESg4kGUtZ/Getting-Started?node-id=1061-78040&t=7Qo3CLRmh5BRitPi-11)

This change will impact the dashboard and docs.

## Summary of changes

This pull request includes a minor update to the `@ably/ui` package version and a small visual adjustment to the `ProductDescription` component's text color styles.

**Version bump:**

* Incremented the package version from `17.6.7` to `17.6.8` in `package.json` to reflect the latest changes.

**UI update:**

* Updated the text color for unselected product descriptions in `ProductDescription.tsx` to use a slightly darker neutral shade, improving visual contrast in light mode.

## How do you manually test this?

Compare [`ProductDescription`](https://ably-ui-web-4465-produc-erg1av.herokuapp.com/?path=/docs/components-product-tile--docs) colours between Storybook and Figma


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated text color for unselected product descriptions on product tiles to improve readability and contrast across themes. Text appears slightly darker in light mode and slightly lighter in dark mode. Hover behaviors remain the same and selected states are unchanged. This is a visual polish with no functional changes only.
* Chores
  * Bumped app version to 17.6.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->