### PR TITLE
[WEB-4605] Dark mode for typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.8.0-dev.fd2e45b6",
+  "version": "17.8.0-dev.8c49cde1",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.8.0",
+  "version": "17.8.0-dev.fd2e45b6",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.7.0",
+  "version": "17.8.0",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Accordion/Accordion.stories.tsx
+++ b/src/core/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import Accordion, { AccordionProps } from "../Accordion";
 import { IconName } from "../Icon/types";
 import { accordionThemes } from "./types";
@@ -6,9 +6,7 @@ import { accordionThemes } from "./types";
 const loremText =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque congue risus id lobortis. Vivamus blandit dolor at ultricies cursus. Phasellus pharetra nunc erat, quis porttitor mauris faucibus in. Donec feugiat dapibus orci et blandit. Duis eleifend accumsan est nec euismod. Proin imperdiet malesuada lacus, a aliquam eros aliquet nec. Sed eu dolor finibus, sodales nisl a, egestas mi. In semper interdum lacinia. Duis malesuada diam quis purus blandit, sit amet imperdiet neque accumsan. Morbi viverra vitae risus ut pellentesque. Praesent ac blandit augue. Aliquam purus lectus, lacinia in semper vitae, dictum eu felis. Donec vel pulvinar eros, id facilisis neque. Aenean odio arcu, accumsan vel est in, lobortis rhoncus ligula. Pellentesque sit amet odio velit.";
 
-const lorem = (
-  <p className="mb-4 text-neutral-1300 dark:text-neutral-000">{loremText}</p>
-);
+const lorem = <p className="mb-4 text-ably-primary">{loremText}</p>;
 
 const textarea = (
   <textarea
@@ -58,7 +56,7 @@ const AccordionPresentation = ({ data, options }: AccordionProps) => (
         <div key={theme} className={"p-4 rounded-lg"}>
           <p
             className={
-              "ui-text-p3 mb-4 text-center text-neutral-1300 dark:text-neutral-000 font-mono"
+              "ui-text-p3 mb-4 text-center text-ably-primary font-mono"
             }
           >
             {theme}

--- a/src/core/Accordion/types.ts
+++ b/src/core/Accordion/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { IconName, IconSize } from "../Icon/types";
-import { ColorThemeSet } from "../styles/colors/types";
+import { ColorClass, ColorThemeSet } from "../styles/colors/types";
 
 /**
  * Represents the data structure for an Accordion component.
@@ -56,32 +56,32 @@ export type AccordionThemeColors = {
   /**
    * Background color class for the accordion.
    */
-  bg: ColorThemeSet;
+  bg: ColorClass | ColorThemeSet;
 
   /**
    * Background color when the accordion item is hovered.
    */
-  hoverBg: ColorThemeSet;
+  hoverBg: ColorClass | ColorThemeSet;
 
   /**
    * Text color class for the accordion.
    */
-  text: ColorThemeSet;
+  text: ColorClass | ColorThemeSet;
 
   /**
    * Color class for the toggle icon of the accordion.
    */
-  toggleIconColor: ColorThemeSet;
+  toggleIconColor: ColorClass | ColorThemeSet;
 
   /**
    * Optional background color class for selectable accordion items.
    */
-  selectableBg?: ColorThemeSet;
+  selectableBg?: ColorClass | ColorThemeSet;
 
   /**
    * Optional text color class for selectable accordion items.
    */
-  selectableText?: ColorThemeSet;
+  selectableText?: ColorClass | ColorThemeSet;
 
   /**
    * Optional border color for the accordion.

--- a/src/core/Accordion/utils.ts
+++ b/src/core/Accordion/utils.ts
@@ -4,10 +4,10 @@ export const themeClasses: Record<AccordionTheme, AccordionThemeColors> = {
   default: {
     bg: "bg-neutral-200 dark:bg-neutral-1100",
     hoverBg: "hover:bg-neutral-300 dark:hover:bg-neutral-1100",
-    text: "text-neutral-1300 dark:text-white",
+    text: "text-ably-primary",
     toggleIconColor: "text-neutral-1000 dark:text-orange-600",
     selectableBg: "bg-neutral-1200 dark:bg-neutral-300",
-    selectableText: "text-neutral-000 dark:text-neutral-1300",
+    selectableText: "text-ably-primary-inverse",
   },
   transparent: {
     bg: "bg-transparent dark:bg-transparent",
@@ -20,10 +20,10 @@ export const themeClasses: Record<AccordionTheme, AccordionThemeColors> = {
   static: {
     bg: "bg-neutral-200 dark:bg-neutral-1200",
     hoverBg: "hover:bg-neutral-200 dark:hover:bg-neutral-1200",
-    text: "text-neutral-1300 dark:text-white",
+    text: "text-ably-primary",
     toggleIconColor: "text-neutral-200 dark:text-neutral-1200",
     selectableBg: "bg-neutral-1200 dark:bg-neutral-1200",
-    selectableText: "text-white dark:text-neutral-1300",
+    selectableText: "text-ably-primary-inverse",
   },
 };
 

--- a/src/core/Badge.tsx
+++ b/src/core/Badge.tsx
@@ -131,7 +131,7 @@ const Badge: React.FC<PropsWithChildren<BadgeProps>> = ({
         colorClass,
         { "focus-base": focusable },
         {
-          "hover:bg-neutral-300 hover:dark:bg-neutral-1000 active:bg-neutral-300 dark:active:bg-neutral-1000":
+          "hover:bg-ably-secondary-inverse active:bg-ably-secondary-inverse":
             hoverable,
         },
         {

--- a/src/core/Badge.tsx
+++ b/src/core/Badge.tsx
@@ -126,7 +126,7 @@ const Badge: React.FC<PropsWithChildren<BadgeProps>> = ({
   return (
     <div
       className={cn(
-        "inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold",
+        "inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold",
         sizeClass,
         colorClass,
         { "focus-base": focusable },

--- a/src/core/Badge/__snapshots__/Badge.stories.tsx.snap
+++ b/src/core/Badge/__snapshots__/Badge.stories.tsx.snap
@@ -27,7 +27,7 @@ exports[`Components/Badge Focusable smoke-test 1`] = `
 `;
 
 exports[`Components/Badge Hoverable smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 hover:bg-neutral-300 hover:dark:bg-neutral-1000 active:bg-neutral-300 dark:active:bg-neutral-1000">
+<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 hover:bg-ably-secondary-inverse active:bg-ably-secondary-inverse">
   <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
     BADGE
   </span>

--- a/src/core/Badge/__snapshots__/Badge.stories.tsx.snap
+++ b/src/core/Badge/__snapshots__/Badge.stories.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Badge Default smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
+<div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
   <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
     BADGE
   </span>
@@ -9,7 +9,7 @@ exports[`Components/Badge Default smoke-test 1`] = `
 `;
 
 exports[`Components/Badge Disabled smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 cursor-not-allowed disabled:text-gui-unavailable dark:disabled:text-gui-unavailable-dark">
+<div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 cursor-not-allowed disabled:text-gui-unavailable dark:disabled:text-gui-unavailable-dark">
   <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
     BADGE
   </span>
@@ -17,7 +17,7 @@ exports[`Components/Badge Disabled smoke-test 1`] = `
 `;
 
 exports[`Components/Badge Focusable smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 focus-base"
+<div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 focus-base"
      tabindex="0"
 >
   <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
@@ -27,7 +27,7 @@ exports[`Components/Badge Focusable smoke-test 1`] = `
 `;
 
 exports[`Components/Badge Hoverable smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 hover:bg-ably-secondary-inverse active:bg-ably-secondary-inverse">
+<div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 hover:bg-ably-secondary-inverse active:bg-ably-secondary-inverse">
   <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
     BADGE
   </span>
@@ -35,7 +35,7 @@ exports[`Components/Badge Hoverable smoke-test 1`] = `
 `;
 
 exports[`Components/Badge WithAfterIcon smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
+<div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
   <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
     BADGE
   </span>
@@ -59,7 +59,7 @@ exports[`Components/Badge WithAfterIcon smoke-test 1`] = `
 `;
 
 exports[`Components/Badge WithBeforeIcon smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
+<div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
   <svg xmlns="http://www.w3.org/2000/svg"
        width="12"
        height="12"
@@ -82,7 +82,7 @@ exports[`Components/Badge WithBeforeIcon smoke-test 1`] = `
 `;
 
 exports[`Components/Badge WithLargeIconSize smoke-test 1`] = `
-<div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
+<div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400">
   <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
     BADGE
   </span>

--- a/src/core/CodeSnippet.tsx
+++ b/src/core/CodeSnippet.tsx
@@ -318,7 +318,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
               key={code.language}
               language={langInfo.syntaxHighlighterKey || cleanLang}
               snippet={processedContent}
-              additionalCSS="bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+              additionalCSS="bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
               showLines={showCodeLines}
             />
           );
@@ -440,12 +440,12 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
   return (
     <div
       className={cn(
-        "rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]",
+        "rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]",
         className,
       )}
     >
       {headerRow && (
-        <div className="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+        <div className="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
           <div className="flex space-x-1.5">
             <div className="w-3 h-3 rounded-full bg-orange-500"></div>
             <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
@@ -463,7 +463,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
       {showSDKSelector && (
         <div
           className={cn(
-            "p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14",
+            "p-2 border-b border-ably-primary-inverse-active h-14",
             headerRow ? "" : "rounded-t-lg",
           )}
         >
@@ -507,7 +507,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
         ) : (
           <div
             className={cn(
-              "border-b border-neutral-200 dark:border-neutral-1100 h-[2.125rem] inline-flex items-center px-3 w-full",
+              "border-b border-ably-primary-inverse-active h-[2.125rem] inline-flex items-center px-3 w-full",
               { "rounded-t-lg": !headerRow },
             )}
           >

--- a/src/core/CodeSnippet.tsx
+++ b/src/core/CodeSnippet.tsx
@@ -382,7 +382,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
           color="text-yellow-600 dark:text-yellow-400"
           size="24px"
         />
-        <p className="ui-text-p3 text-neutral-700 dark:text-neutral-600">
+        <p className="ui-text-p3 text-ably-label">
           You&apos;re currently viewing the {activeLanguageInfo.label} docs.
           There either isn&apos;t a {activeLanguageInfo.label} code sample for
           this example, or this feature isn&apos;t supported in{" "}
@@ -440,19 +440,19 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
   return (
     <div
       className={cn(
-        "rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]",
+        "rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]",
         className,
       )}
     >
       {headerRow && (
-        <div className="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+        <div className="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
           <div className="flex space-x-1.5">
             <div className="w-3 h-3 rounded-full bg-orange-500"></div>
             <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
             <div className="w-3 h-3 rounded-full bg-green-500"></div>
           </div>
 
-          <div className="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+          <div className="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
             {title}
           </div>
 
@@ -525,7 +525,7 @@ const CodeSnippet: React.FC<CodeSnippetProps> = ({
                   size="16px"
                   additionalCSS="mr-2"
                 />
-                <span className="ui-text-label4 font-semibold text-neutral-800 dark:text-neutral-500 select-none">
+                <span className="ui-text-label4 font-semibold text-ably-tertiary select-none">
                   {getLanguageInfo(filteredLanguages[0]).label}
                 </span>
               </div>

--- a/src/core/CodeSnippet/ApiKeySelector.tsx
+++ b/src/core/CodeSnippet/ApiKeySelector.tsx
@@ -25,9 +25,7 @@ const ApiKeySelector = ({
   const renderDemoMode = useMemo(
     () => (
       <div className="flex items-center gap-2">
-        <Badge className="ml-1 bg-neutral-200 dark:bg-neutral-1100">
-          DEMO ONLY
-        </Badge>
+        <Badge className="ml-1 bg-ably-primary-inverse-active">DEMO ONLY</Badge>
         <Tooltip
           className="ml-0"
           triggerElement={
@@ -59,7 +57,7 @@ const ApiKeySelector = ({
     return (
       <Select.Root value={selectedApiKey} onValueChange={onApiKeyChange}>
         <Select.Trigger
-          className="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-2 focus-base border"
+          className="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-2 focus-base border"
           aria-label="API Key"
         >
           <Select.Value />
@@ -69,7 +67,7 @@ const ApiKeySelector = ({
         </Select.Trigger>
 
         <Select.Portal>
-          <Select.Content className="overflow-hidden rounded-lg bg-ably-primary-inverse border border-neutral-200 dark:border-neutral-1000 shadow-md z-50">
+          <Select.Content className="overflow-hidden rounded-lg bg-ably-primary-inverse border border-ably-primary-inverse-active shadow-md z-50">
             <Select.ScrollUpButton className="flex items-center justify-center h-6 bg-ably-primary-inverse text-ably-primary cursor-default focus-base">
               <Icon
                 name="icon-gui-chevron-down-outline"
@@ -82,7 +80,7 @@ const ApiKeySelector = ({
               {apiKeys.map((apiKeyItem) => (
                 <Select.Group key={apiKeyItem.app}>
                   {apiKeys.length > 1 && (
-                    <Select.Label className="text-ably-label rounded-none p-1 bg-neutral-200 dark:bg-neutral-1100">
+                    <Select.Label className="text-ably-label rounded-none p-1 bg-ably-primary-inverse-active">
                       {apiKeyItem.app}
                     </Select.Label>
                   )}
@@ -90,7 +88,7 @@ const ApiKeySelector = ({
                     <Select.Item
                       key={`${apiKeyItem.app}-${name}-${key}`}
                       value={key}
-                      className="relative flex items-center justify-between m-2 p-2 rounded-lg text-14 text-ably-primary select-none hover:bg-neutral-100 dark:hover:bg-neutral-1200 data-[highlighted]:outline-none data-[highlighted]:bg-neutral-100 dark:data-[highlighted]:bg-neutral-1200 focus-base min-w-64"
+                      className="relative flex items-center justify-between m-2 p-2 rounded-lg text-14 text-ably-primary select-none hover:bg-ably-primary-inverse-accent data-[highlighted]:outline-none data-[highlighted]:bg-ably-primary-inverse-accent focus-base min-w-64"
                     >
                       <Select.ItemText>
                         {key.length > 10 ? `${key.substring(0, 10)}...` : key}
@@ -117,7 +115,7 @@ const ApiKeySelector = ({
   }, [apiKeys, isDemoMode, selectedApiKey, onApiKeyChange, renderDemoMode]);
 
   return (
-    <div className="flex items-center border-t border-neutral-200 dark:border-neutral-1100 px-3 py-3">
+    <div className="flex items-center border-t border-ably-primary-inverse-active px-3 py-3">
       <span className="ui-text-label4 text-ably-label mr-1">API key:</span>
       {renderApiKeyDropdown}
     </div>

--- a/src/core/CodeSnippet/ApiKeySelector.tsx
+++ b/src/core/CodeSnippet/ApiKeySelector.tsx
@@ -34,7 +34,7 @@ const ApiKeySelector = ({
             <Icon
               name="icon-gui-information-circle-outline"
               size="16px"
-              color="text-neutral-700 dark:text-neutral-600"
+              color="text-ably-label"
             />
           }
         >
@@ -59,7 +59,7 @@ const ApiKeySelector = ({
     return (
       <Select.Root value={selectedApiKey} onValueChange={onApiKeyChange}>
         <Select.Trigger
-          className="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-2 focus-base border"
+          className="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-2 focus-base border"
           aria-label="API Key"
         >
           <Select.Value />
@@ -69,8 +69,8 @@ const ApiKeySelector = ({
         </Select.Trigger>
 
         <Select.Portal>
-          <Select.Content className="overflow-hidden rounded-lg bg-neutral-000 dark:bg-neutral-1300 border border-neutral-200 dark:border-neutral-1000 shadow-md z-50">
-            <Select.ScrollUpButton className="flex items-center justify-center h-6 bg-neutral-000 dark:bg-neutral-1300 text-neutral-1300 dark:text-neutral-000 cursor-default focus-base">
+          <Select.Content className="overflow-hidden rounded-lg bg-ably-primary-inverse border border-neutral-200 dark:border-neutral-1000 shadow-md z-50">
+            <Select.ScrollUpButton className="flex items-center justify-center h-6 bg-ably-primary-inverse text-ably-primary cursor-default focus-base">
               <Icon
                 name="icon-gui-chevron-down-outline"
                 size="16px"
@@ -82,7 +82,7 @@ const ApiKeySelector = ({
               {apiKeys.map((apiKeyItem) => (
                 <Select.Group key={apiKeyItem.app}>
                   {apiKeys.length > 1 && (
-                    <Select.Label className="text-neutral-700 rounded-none dark:text-neutral-600 p-1 bg-neutral-200 dark:bg-neutral-1100">
+                    <Select.Label className="text-ably-label rounded-none p-1 bg-neutral-200 dark:bg-neutral-1100">
                       {apiKeyItem.app}
                     </Select.Label>
                   )}
@@ -90,7 +90,7 @@ const ApiKeySelector = ({
                     <Select.Item
                       key={`${apiKeyItem.app}-${name}-${key}`}
                       value={key}
-                      className="relative flex items-center justify-between m-2 p-2 rounded-lg text-14 text-neutral-1300 dark:text-neutral-000 select-none hover:bg-neutral-100 dark:hover:bg-neutral-1200 data-[highlighted]:outline-none data-[highlighted]:bg-neutral-100 dark:data-[highlighted]:bg-neutral-1200 focus-base min-w-64"
+                      className="relative flex items-center justify-between m-2 p-2 rounded-lg text-14 text-ably-primary select-none hover:bg-neutral-100 dark:hover:bg-neutral-1200 data-[highlighted]:outline-none data-[highlighted]:bg-neutral-100 dark:data-[highlighted]:bg-neutral-1200 focus-base min-w-64"
                     >
                       <Select.ItemText>
                         {key.length > 10 ? `${key.substring(0, 10)}...` : key}
@@ -107,7 +107,7 @@ const ApiKeySelector = ({
               ))}
             </Select.Viewport>
 
-            <Select.ScrollDownButton className="flex items-center justify-center h-6 bg-neutral-000 dark:bg-neutral-1300 text-neutral-1300 dark:text-neutral-000 cursor-default focus-base">
+            <Select.ScrollDownButton className="flex items-center justify-center h-6 bg-ably-primary-inverse text-ably-primary cursor-default focus-base">
               <Icon name="icon-gui-chevron-down-outline" size="16px" />
             </Select.ScrollDownButton>
           </Select.Content>
@@ -118,9 +118,7 @@ const ApiKeySelector = ({
 
   return (
     <div className="flex items-center border-t border-neutral-200 dark:border-neutral-1100 px-3 py-3">
-      <span className="ui-text-label4 text-neutral-700 dark:text-neutral-600 mr-1">
-        API key:
-      </span>
+      <span className="ui-text-label4 text-ably-label mr-1">API key:</span>
       {renderApiKeyDropdown}
     </div>
   );

--- a/src/core/CodeSnippet/CodeSnippet.stories.tsx
+++ b/src/core/CodeSnippet/CodeSnippet.stories.tsx
@@ -488,9 +488,7 @@ export const PlainMode: Story = {
 
     return (
       <div className="flex flex-col gap-4">
-        <h4 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
-          Shell
-        </h4>
+        <h4 className="ui-text-h4 text-ably-primary">Shell</h4>
         <CodeSnippet
           lang={currentLang}
           onChange={(lang) => setCurrentLang(lang)}
@@ -499,9 +497,7 @@ export const PlainMode: Story = {
             <code className="language-shell">{CODE_SNIPPETS.shellInstall}</code>
           </pre>
         </CodeSnippet>
-        <h4 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
-          Text
-        </h4>
+        <h4 className="ui-text-h4 text-ably-primary">Text</h4>
         <CodeSnippet
           lang={currentLang}
           onChange={(lang) => setCurrentLang(lang)}
@@ -528,9 +524,7 @@ export const MultipleShellExamples: Story = {
     return (
       <div className="flex flex-col gap-4">
         <div>
-          <h3 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000 mb-2">
-            Installation
-          </h3>
+          <h3 className="ui-text-h4 text-ably-primary mb-2">Installation</h3>
           <CodeSnippet
             lang={currentLang}
             onChange={(lang) => setCurrentLang(lang)}
@@ -544,7 +538,7 @@ export const MultipleShellExamples: Story = {
         </div>
 
         <div>
-          <h3 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000 mb-2">
+          <h3 className="ui-text-h4 text-ably-primary mb-2">
             Starting the server
           </h3>
           <CodeSnippet
@@ -560,9 +554,7 @@ export const MultipleShellExamples: Story = {
         </div>
 
         <div>
-          <h3 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000 mb-2">
-            Complex command
-          </h3>
+          <h3 className="ui-text-h4 text-ably-primary mb-2">Complex command</h3>
           <CodeSnippet
             lang={currentLang}
             onChange={(lang) => setCurrentLang(lang)}

--- a/src/core/CodeSnippet/CopyButton.tsx
+++ b/src/core/CodeSnippet/CopyButton.tsx
@@ -19,12 +19,12 @@ const CopyButton = memo(
           <Icon
             name="icon-gui-document-duplicate-outline"
             size="20px"
-            color="text-neutral-1300 dark:text-neutral-000"
+            color="text-ably-primary"
           />
         </TooltipButton>
 
         {isCopied ? (
-          <div className="absolute right-10 top-0 bg-neutral-1300 dark:bg-neutral-000 text-neutral-000 dark:text-neutral-1300 py-1.5 px-3 rounded ui-text-label4 whitespace-nowrap">
+          <div className="absolute right-10 top-0 bg-ably-primary text-ably-primary-inverse py-1.5 px-3 rounded ui-text-label4 whitespace-nowrap">
             Copied!
           </div>
         ) : null}

--- a/src/core/CodeSnippet/LanguageSelector.tsx
+++ b/src/core/CodeSnippet/LanguageSelector.tsx
@@ -41,7 +41,7 @@ const LanguageSelector = memo(
           <Select.Item
             key={lang}
             value={lang}
-            className="relative flex items-center rounded px-2 py-1.5 text-14 text-ably-primary select-none hover:bg-neutral-100 dark:hover:bg-neutral-1200 data-[highlighted]:outline-none data-[highlighted]:bg-neutral-100 dark:data-[highlighted]:bg-neutral-1200 focus-base"
+            className="relative flex items-center rounded px-2 py-1.5 text-14 text-ably-primary select-none hover:bg-ably-primary-inverse-accent data-[highlighted]:outline-none data-[highlighted]:bg-ably-primary-inverse-accent focus-base"
           >
             <Select.ItemText asChild>
               <div className="flex items-center gap-2">
@@ -69,7 +69,7 @@ const LanguageSelector = memo(
     );
 
     return (
-      <div className="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+      <div className="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
         <div className="hidden sm:flex gap-2">{desktopLanguageElements}</div>
 
         <div className="sm:hidden w-full">
@@ -78,7 +78,7 @@ const LanguageSelector = memo(
             onValueChange={onLanguageChange}
           >
             <Select.Trigger
-              className="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              className="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
             >
               <Select.Value asChild>{mobileSelectValue}</Select.Value>
@@ -89,7 +89,7 @@ const LanguageSelector = memo(
 
             <Select.Portal>
               <Select.Content
-                className="overflow-hidden rounded-md bg-ably-primary-inverse border border-neutral-200 dark:border-neutral-1000 shadow-md z-50 w-[var(--radix-select-trigger-width)]"
+                className="overflow-hidden rounded-md bg-ably-primary-inverse border border-ably-primary-inverse-active shadow-md z-50 w-[var(--radix-select-trigger-width)]"
                 position="popper"
               >
                 <Select.ScrollUpButton className="flex items-center justify-center h-6 bg-ably-primary-inverse text-ably-primary cursor-default focus-base">

--- a/src/core/CodeSnippet/LanguageSelector.tsx
+++ b/src/core/CodeSnippet/LanguageSelector.tsx
@@ -41,7 +41,7 @@ const LanguageSelector = memo(
           <Select.Item
             key={lang}
             value={lang}
-            className="relative flex items-center rounded px-2 py-1.5 text-14 text-neutral-1300 dark:text-neutral-000 select-none hover:bg-neutral-100 dark:hover:bg-neutral-1200 data-[highlighted]:outline-none data-[highlighted]:bg-neutral-100 dark:data-[highlighted]:bg-neutral-1200 focus-base"
+            className="relative flex items-center rounded px-2 py-1.5 text-14 text-ably-primary select-none hover:bg-neutral-100 dark:hover:bg-neutral-1200 data-[highlighted]:outline-none data-[highlighted]:bg-neutral-100 dark:data-[highlighted]:bg-neutral-1200 focus-base"
           >
             <Select.ItemText asChild>
               <div className="flex items-center gap-2">
@@ -78,7 +78,7 @@ const LanguageSelector = memo(
             onValueChange={onLanguageChange}
           >
             <Select.Trigger
-              className="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              className="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
             >
               <Select.Value asChild>{mobileSelectValue}</Select.Value>
@@ -89,10 +89,10 @@ const LanguageSelector = memo(
 
             <Select.Portal>
               <Select.Content
-                className="overflow-hidden rounded-md bg-neutral-000 dark:bg-neutral-1300 border border-neutral-200 dark:border-neutral-1000 shadow-md z-50 w-[var(--radix-select-trigger-width)]"
+                className="overflow-hidden rounded-md bg-ably-primary-inverse border border-neutral-200 dark:border-neutral-1000 shadow-md z-50 w-[var(--radix-select-trigger-width)]"
                 position="popper"
               >
-                <Select.ScrollUpButton className="flex items-center justify-center h-6 bg-neutral-000 dark:bg-neutral-1300 text-neutral-1300 dark:text-neutral-000 cursor-default focus-base">
+                <Select.ScrollUpButton className="flex items-center justify-center h-6 bg-ably-primary-inverse text-ably-primary cursor-default focus-base">
                   <Icon
                     name="icon-gui-chevron-down-outline"
                     size="16px"
@@ -104,7 +104,7 @@ const LanguageSelector = memo(
                   {mobileLanguageElements}
                 </Select.Viewport>
 
-                <Select.ScrollDownButton className="flex items-center justify-center h-6 bg-neutral-000 dark:bg-neutral-1300 text-neutral-1300 dark:text-neutral-000 cursor-default focus-base">
+                <Select.ScrollDownButton className="flex items-center justify-center h-6 bg-ably-primary-inverse text-ably-primary cursor-default focus-base">
                   <Icon name="icon-gui-chevron-down-outline" size="16px" />
                 </Select.ScrollDownButton>
               </Select.Content>

--- a/src/core/CodeSnippet/PlainCodeView.tsx
+++ b/src/core/CodeSnippet/PlainCodeView.tsx
@@ -47,7 +47,7 @@ const PlainCodeView: React.FC<PlainCodeViewProps> = ({
     >
       {icon && (
         <div className="absolute top-2 left-2 z-10">
-          <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100">
+          <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-ably-primary-inverse-active">
             <Icon name={icon} size="20px" color="text-ably-primary" />
           </div>
         </div>

--- a/src/core/CodeSnippet/PlainCodeView.tsx
+++ b/src/core/CodeSnippet/PlainCodeView.tsx
@@ -34,7 +34,7 @@ const PlainCodeView: React.FC<PlainCodeViewProps> = ({
   return (
     <div
       className={cn(
-        "rounded-lg overflow-hidden bg-neutral-000 dark:bg-neutral-1300 border border-neutral-300 dark:border-neutral-1000 relative flex items-center",
+        "rounded-lg overflow-hidden bg-ably-primary-inverse border border-ably-secondary-inverse relative flex items-center",
         language === "shell" ? "min-h-[3.375rem]" : "min-h-12",
         className,
       )}
@@ -48,11 +48,7 @@ const PlainCodeView: React.FC<PlainCodeViewProps> = ({
       {icon && (
         <div className="absolute top-2 left-2 z-10">
           <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100">
-            <Icon
-              name={icon}
-              size="20px"
-              color="text-neutral-1300 dark:text-neutral-000"
-            />
+            <Icon name={icon} size="20px" color="text-ably-primary" />
           </div>
         </div>
       )}
@@ -61,7 +57,7 @@ const PlainCodeView: React.FC<PlainCodeViewProps> = ({
         language={language}
         snippet={content}
         additionalCSS={cn(
-          "w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2",
+          "w-full bg-ably-primary-inverse text-neutral-1300 dark:text-neutral-200 px-4 py-2",
           icon && "pl-14",
         )}
         showLines={false}

--- a/src/core/CodeSnippet/TooltipButton.tsx
+++ b/src/core/CodeSnippet/TooltipButton.tsx
@@ -51,7 +51,7 @@ const TooltipButton = memo(
               "focus-base",
               active
                 ? "bg-ably-primary-inverse"
-                : "bg-neutral-100 dark:bg-neutral-1200",
+                : "bg-ably-primary-inverse-accent",
               className,
             )}
           >
@@ -64,7 +64,7 @@ const TooltipButton = memo(
         <div
           role="button"
           className={cn(
-            "w-8 h-8 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse transition-colors focus-base",
+            "w-8 h-8 rounded-lg flex items-center justify-center bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse transition-colors focus-base",
             className,
           )}
           onClick={onClick}

--- a/src/core/CodeSnippet/TooltipButton.tsx
+++ b/src/core/CodeSnippet/TooltipButton.tsx
@@ -50,7 +50,7 @@ const TooltipButton = memo(
             className={cn(
               "focus-base",
               active
-                ? "bg-neutral-000 dark:bg-neutral-1300"
+                ? "bg-ably-primary-inverse"
                 : "bg-neutral-100 dark:bg-neutral-1200",
               className,
             )}
@@ -64,7 +64,7 @@ const TooltipButton = memo(
         <div
           role="button"
           className={cn(
-            "w-8 h-8 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 transition-colors focus-base",
+            "w-8 h-8 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse transition-colors focus-base",
             className,
           )}
           onClick={onClick}

--- a/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
+++ b/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Code Snippet Default smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -14,7 +14,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -37,7 +37,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           JavaScript
         </span>
       </div>
@@ -46,7 +46,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -56,7 +56,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -93,7 +93,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -260,7 +260,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet FixedMode smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
   <div class="relative"
        tabindex="0"
   >
@@ -370,8 +370,8 @@ exports[`Components/Code Snippet FixedMode smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -380,7 +380,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       JSON-Only Example
     </div>
     <div class="w-12">
@@ -417,7 +417,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
           </path>
         </g>
       </svg>
-      <span class="ui-text-label4 font-semibold text-neutral-800 dark:text-neutral-500 select-none">
+      <span class="ui-text-label4 font-semibold text-ably-tertiary select-none">
         JSON
       </span>
     </div>
@@ -686,10 +686,10 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
 exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
 <div class="flex flex-col gap-4">
   <div>
-    <h3 class="ui-text-h4 text-neutral-1300 dark:text-neutral-000 mb-2">
+    <h3 class="ui-text-h4 text-ably-primary mb-2">
       Installation
     </h3>
-    <div class="rounded-lg overflow-hidden bg-neutral-000 dark:bg-neutral-1300 border border-neutral-300 dark:border-neutral-1000 relative flex items-center min-h-[3.375rem]"
+    <div class="rounded-lg overflow-hidden bg-ably-primary-inverse border border-ably-secondary-inverse relative flex items-center min-h-[3.375rem]"
          tabindex="0"
     >
       <div class="absolute top-2 left-2 z-10">
@@ -701,7 +701,7 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
                stroke="currentColor"
                aria-hidden="true"
                data-slot="icon"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 20px; height: 20px;"
           >
             <path stroke-linecap="round"
@@ -712,7 +712,7 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+      <div class="hljs overflow-y-auto flex p-8 w-full bg-ably-primary-inverse text-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
            data-id="code"
       >
         <pre lang="shell"
@@ -730,10 +730,10 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
     </div>
   </div>
   <div>
-    <h3 class="ui-text-h4 text-neutral-1300 dark:text-neutral-000 mb-2">
+    <h3 class="ui-text-h4 text-ably-primary mb-2">
       Starting the server
     </h3>
-    <div class="rounded-lg overflow-hidden bg-neutral-000 dark:bg-neutral-1300 border border-neutral-300 dark:border-neutral-1000 relative flex items-center min-h-[3.375rem]"
+    <div class="rounded-lg overflow-hidden bg-ably-primary-inverse border border-ably-secondary-inverse relative flex items-center min-h-[3.375rem]"
          tabindex="0"
     >
       <div class="absolute top-2 left-2 z-10">
@@ -745,7 +745,7 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
                stroke="currentColor"
                aria-hidden="true"
                data-slot="icon"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 20px; height: 20px;"
           >
             <path stroke-linecap="round"
@@ -756,7 +756,7 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+      <div class="hljs overflow-y-auto flex p-8 w-full bg-ably-primary-inverse text-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
            data-id="code"
       >
         <pre lang="shell"
@@ -774,10 +774,10 @@ npm run start
     </div>
   </div>
   <div>
-    <h3 class="ui-text-h4 text-neutral-1300 dark:text-neutral-000 mb-2">
+    <h3 class="ui-text-h4 text-ably-primary mb-2">
       Complex command
     </h3>
-    <div class="rounded-lg overflow-hidden bg-neutral-000 dark:bg-neutral-1300 border border-neutral-300 dark:border-neutral-1000 relative flex items-center min-h-[3.375rem]"
+    <div class="rounded-lg overflow-hidden bg-ably-primary-inverse border border-ably-secondary-inverse relative flex items-center min-h-[3.375rem]"
          tabindex="0"
     >
       <div class="absolute top-2 left-2 z-10">
@@ -789,7 +789,7 @@ npm run start
                stroke="currentColor"
                aria-hidden="true"
                data-slot="icon"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 20px; height: 20px;"
           >
             <path stroke-linecap="round"
@@ -800,7 +800,7 @@ npm run start
           </svg>
         </div>
       </div>
-      <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+      <div class="hljs overflow-y-auto flex p-8 w-full bg-ably-primary-inverse text-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
            data-id="code"
       >
         <pre lang="shell"
@@ -841,10 +841,10 @@ npm run start
 
 exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
 <div class="flex flex-col gap-4">
-  <h4 class="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
+  <h4 class="ui-text-h4 text-ably-primary">
     Shell
   </h4>
-  <div class="rounded-lg overflow-hidden bg-neutral-000 dark:bg-neutral-1300 border border-neutral-300 dark:border-neutral-1000 relative flex items-center min-h-[3.375rem]"
+  <div class="rounded-lg overflow-hidden bg-ably-primary-inverse border border-ably-secondary-inverse relative flex items-center min-h-[3.375rem]"
        tabindex="0"
   >
     <div class="absolute top-2 left-2 z-10">
@@ -856,7 +856,7 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
              stroke="currentColor"
              aria-hidden="true"
              data-slot="icon"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              style="width: 20px; height: 20px;"
         >
           <path stroke-linecap="round"
@@ -867,7 +867,7 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
         </svg>
       </div>
     </div>
-    <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
+    <div class="hljs overflow-y-auto flex p-8 w-full bg-ably-primary-inverse text-neutral-1300 dark:text-neutral-200 px-4 py-2 pl-14"
          data-id="code"
     >
       <pre lang="shell"
@@ -883,13 +883,13 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
       </pre>
     </div>
   </div>
-  <h4 class="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
+  <h4 class="ui-text-h4 text-ably-primary">
     Text
   </h4>
-  <div class="rounded-lg overflow-hidden bg-neutral-000 dark:bg-neutral-1300 border border-neutral-300 dark:border-neutral-1000 relative flex items-center min-h-12"
+  <div class="rounded-lg overflow-hidden bg-ably-primary-inverse border border-ably-secondary-inverse relative flex items-center min-h-12"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 w-full bg-neutral-000 text-neutral-1300 dark:bg-neutral-1300 dark:text-neutral-200 px-4 py-2"
+    <div class="hljs overflow-y-auto flex p-8 w-full bg-ably-primary-inverse text-neutral-1300 dark:text-neutral-200 px-4 py-2"
          data-id="code"
     >
       <pre lang="text"
@@ -905,7 +905,7 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
   <div class="border-b border-neutral-200 dark:border-neutral-1100 h-[2.125rem] inline-flex items-center px-3 w-full rounded-t-lg">
     <div class="inline-flex items-center cursor-pointer">
       <svg xmlns="http://www.w3.org/2000/svg"
@@ -935,7 +935,7 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
           </path>
         </g>
       </svg>
-      <span class="ui-text-label4 font-semibold text-neutral-800 dark:text-neutral-500 select-none">
+      <span class="ui-text-label4 font-semibold text-ably-tertiary select-none">
         JavaScript
       </span>
     </div>
@@ -1049,8 +1049,8 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -1059,7 +1059,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       JavaScript Example
     </div>
     <div class="w-12">
@@ -1094,7 +1094,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
           </path>
         </g>
       </svg>
-      <span class="ui-text-label4 font-semibold text-neutral-800 dark:text-neutral-500 select-none">
+      <span class="ui-text-label4 font-semibold text-ably-tertiary select-none">
         JavaScript
       </span>
     </div>
@@ -1208,8 +1208,8 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -1218,7 +1218,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       API Key Selection Example
     </div>
     <div class="w-12">
@@ -1226,7 +1226,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
   </div>
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -1236,7 +1236,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -1259,7 +1259,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           JavaScript
         </span>
       </div>
@@ -1268,7 +1268,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1278,7 +1278,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -1315,7 +1315,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -1479,7 +1479,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
     </div>
   </div>
   <div class="flex items-center border-t border-neutral-200 dark:border-neutral-1100 px-3 py-3">
-    <span class="ui-text-label4 text-neutral-700 dark:text-neutral-600 mr-1">
+    <span class="ui-text-label4 text-ably-label mr-1">
       API key:
     </span>
     <button type="button"
@@ -1489,7 +1489,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
             aria-autocomplete="none"
             dir="ltr"
             data-state="closed"
-            class="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-2 focus-base border"
+            class="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-2 focus-base border"
             aria-label="API Key"
     >
       <span style="pointer-events: none;">
@@ -1522,8 +1522,8 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -1532,7 +1532,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       Custom Language Order
     </div>
     <div class="w-12">
@@ -1540,7 +1540,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
   </div>
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -1550,7 +1550,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -1608,7 +1608,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Swift
         </span>
       </div>
@@ -1617,7 +1617,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1627,7 +1627,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -1660,7 +1660,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1670,7 +1670,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -1701,7 +1701,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1711,7 +1711,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -1799,7 +1799,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -1984,8 +1984,8 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -1994,7 +1994,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       TypeScript Example
     </div>
     <div class="w-12">
@@ -2007,7 +2007,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -2017,7 +2017,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -2048,7 +2048,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -2058,7 +2058,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -2086,7 +2086,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
           </div>
         </button>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -2096,7 +2096,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -2154,7 +2154,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Swift
         </span>
       </div>
@@ -2167,7 +2167,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -2352,8 +2352,8 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -2362,7 +2362,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       Demo API Keys
     </div>
     <div class="w-12">
@@ -2370,7 +2370,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
   </div>
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -2380,7 +2380,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -2403,7 +2403,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           JavaScript
         </span>
       </div>
@@ -2412,7 +2412,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -2422,7 +2422,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -2459,7 +2459,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -2623,7 +2623,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
     </div>
   </div>
   <div class="flex items-center border-t border-neutral-200 dark:border-neutral-1100 px-3 py-3">
-    <span class="ui-text-label4 text-neutral-700 dark:text-neutral-600 mr-1">
+    <span class="ui-text-label4 text-ably-label mr-1">
       API key:
     </span>
     <div class="flex items-center gap-2">
@@ -2644,7 +2644,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                stroke="currentColor"
                aria-hidden="true"
                data-slot="icon"
-               class="text-neutral-700 dark:text-neutral-600"
+               class="text-ably-label"
                style="width: 16px; height: 16px;"
           >
             <path stroke-linecap="round"
@@ -2662,8 +2662,8 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
 
 exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1`] = `
 <div class="flex flex-col gap-4">
-  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
       <div class="flex space-x-1.5">
         <div class="w-3 h-3 rounded-full bg-orange-500">
         </div>
@@ -2672,7 +2672,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
         <div class="w-3 h-3 rounded-full bg-green-500">
         </div>
       </div>
-      <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+      <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
         SDK Type Example (realtime only)
       </div>
       <div class="w-12">
@@ -2680,12 +2680,12 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
     </div>
     <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
       <div class="flex gap-3 justify-start">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-primary">
             Realtime
           </span>
         </div>
@@ -2693,7 +2693,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
     </div>
     <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
       <div class="hidden sm:flex gap-2">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
              tabindex="0"
              role="button"
              aria-pressed="true"
@@ -2703,7 +2703,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                aria-hidden="true"
                style="width: 22px; height: 22px;"
           >
@@ -2726,7 +2726,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
               </path>
             </g>
           </svg>
-          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-primary">
             JavaScript
           </span>
         </div>
@@ -2735,7 +2735,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                   aria-describedby="tooltip"
                   class="p-0 relative focus:outline-none h-[1rem]"
           >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                  tabindex="0"
                  role="button"
                  aria-pressed="false"
@@ -2745,7 +2745,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                    height="48"
                    fill="none"
                    viewbox="0 0 48 48"
-                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                   class="text-ably-secondary hover:text-ably-primary"
                    aria-hidden="true"
                    style="width: 22px; height: 22px;"
               >
@@ -2782,7 +2782,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                 aria-autocomplete="none"
                 dir="ltr"
                 data-state="closed"
-                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
                 aria-label="Select language"
         >
           <div class="flex items-center gap-2"
@@ -2946,8 +2946,8 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
       </div>
     </div>
   </div>
-  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
       <div class="flex space-x-1.5">
         <div class="w-3 h-3 rounded-full bg-orange-500">
         </div>
@@ -2956,7 +2956,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
         <div class="w-3 h-3 rounded-full bg-green-500">
         </div>
       </div>
-      <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+      <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
         SDK Type Example (rest only)
       </div>
       <div class="w-12">
@@ -2964,12 +2964,12 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
     </div>
     <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
       <div class="flex gap-3 justify-start">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-primary">
             REST
           </span>
         </div>
@@ -2982,7 +2982,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                   aria-describedby="tooltip"
                   class="p-0 relative focus:outline-none h-[1rem]"
           >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                  tabindex="0"
                  role="button"
                  aria-pressed="false"
@@ -2992,7 +2992,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                    height="48"
                    fill="none"
                    viewbox="0 0 48 48"
-                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                   class="text-ably-secondary hover:text-ably-primary"
                    aria-hidden="true"
                    style="width: 22px; height: 22px;"
               >
@@ -3021,7 +3021,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                   aria-describedby="tooltip"
                   class="p-0 relative focus:outline-none h-[1rem]"
           >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                  tabindex="0"
                  role="button"
                  aria-pressed="false"
@@ -3031,7 +3031,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                    height="48"
                    fill="none"
                    viewbox="0 0 48 48"
-                   class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                   class="text-ably-secondary hover:text-ably-primary"
                    aria-hidden="true"
                    style="width: 22px; height: 22px;"
               >
@@ -3138,7 +3138,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                 aria-autocomplete="none"
                 dir="ltr"
                 data-state="closed"
-                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
                 aria-label="Select language"
         >
           <div class="flex items-center gap-2"
@@ -3216,7 +3216,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
           >
           </path>
         </svg>
-        <p class="ui-text-p3 text-neutral-700 dark:text-neutral-600">
+        <p class="ui-text-p3 text-ably-label">
           You're currently viewing the JavaScript docs. There either isn't a JavaScript code sample for this example, or this feature isn't supported in JavaScript. Switch language to view this example in a different language, or check which SDKs support this feature.
         </p>
       </div>
@@ -3226,8 +3226,8 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
 `;
 
 exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -3236,7 +3236,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       Subscribe Example
     </div>
     <div class="w-12">
@@ -3244,7 +3244,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
   </div>
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -3254,7 +3254,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -3277,7 +3277,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           JavaScript
         </span>
       </div>
@@ -3286,7 +3286,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3296,7 +3296,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -3329,7 +3329,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3339,7 +3339,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -3409,7 +3409,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -3576,8 +3576,8 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -3586,7 +3586,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       Missing Language Example
     </div>
     <div class="w-12">
@@ -3599,7 +3599,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3609,7 +3609,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -3640,7 +3640,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3650,7 +3650,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -3687,7 +3687,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -4221,7 +4221,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
         >
         </path>
       </svg>
-      <p class="ui-text-p3 text-neutral-700 dark:text-neutral-600">
+      <p class="ui-text-p3 text-ably-label">
         You're currently viewing the Ruby docs. There either isn't a Ruby code sample for this example, or this feature isn't supported in Ruby. Switch language to view this example in a different language, or check which SDKs support this feature.
       </p>
     </div>
@@ -4230,8 +4230,8 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -4240,7 +4240,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       SDK Type Example
     </div>
     <div class="w-12">
@@ -4248,12 +4248,12 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
   </div>
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
     <div class="flex gap-3 justify-start">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Realtime
         </span>
       </div>
@@ -4262,12 +4262,12 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
           >
-            <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+            <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
               REST
             </span>
           </div>
@@ -4277,7 +4277,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
   </div>
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -4287,7 +4287,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -4310,7 +4310,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           JavaScript
         </span>
       </div>
@@ -4319,7 +4319,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -4329,7 +4329,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -4366,7 +4366,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -4533,8 +4533,8 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-neutral-300 dark:border-neutral-1000 min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-neutral-300 dark:border-neutral-1000 flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -4543,7 +4543,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
       <div class="w-3 h-3 rounded-full bg-green-500">
       </div>
     </div>
-    <div class="flex-1 text-center ui-text-p3 font-bold text-neutral-1300 dark:text-neutral-000">
+    <div class="flex-1 text-center ui-text-p3 font-bold text-ably-primary">
       No Line Numbers
     </div>
     <div class="w-12">
@@ -4551,7 +4551,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
   </div>
   <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-000 dark:bg-neutral-1300"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -4561,7 +4561,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -4584,7 +4584,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           JavaScript
         </span>
       </div>
@@ -4593,7 +4593,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -4603,7 +4603,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                  height="48"
                  fill="none"
                  viewbox="0 0 48 48"
-                 class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+                 class="text-ably-secondary hover:text-ably-primary"
                  aria-hidden="true"
                  style="width: 22px; height: 22px;"
             >
@@ -4640,7 +4640,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-neutral-1300 dark:text-neutral-000 bg-neutral-200 dark:bg-neutral-1100 hover:bg-neutral-300 dark:hover:bg-neutral-1000 gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"

--- a/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
+++ b/src/core/CodeSnippet/__snapshots__/CodeSnippet.stories.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Code Snippet Default smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -46,7 +46,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -93,7 +93,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -154,7 +154,7 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -260,11 +260,11 @@ exports[`Components/Code Snippet Default smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet FixedMode smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -370,8 +370,8 @@ exports[`Components/Code Snippet FixedMode smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -386,7 +386,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="border-b border-neutral-200 dark:border-neutral-1100 h-[2.125rem] inline-flex items-center px-3 w-full">
+  <div class="border-b border-ably-primary-inverse-active h-[2.125rem] inline-flex items-center px-3 w-full">
     <div class="inline-flex items-center cursor-pointer">
       <svg xmlns="http://www.w3.org/2000/svg"
            width="48"
@@ -425,7 +425,7 @@ exports[`Components/Code Snippet JsonOnlySnippet smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -693,7 +693,7 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
          tabindex="0"
     >
       <div class="absolute top-2 left-2 z-10">
-        <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100">
+        <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-ably-primary-inverse-active">
           <svg xmlns="http://www.w3.org/2000/svg"
                fill="none"
                viewbox="0 0 24 24"
@@ -737,7 +737,7 @@ exports[`Components/Code Snippet MultipleShellExamples smoke-test 1`] = `
          tabindex="0"
     >
       <div class="absolute top-2 left-2 z-10">
-        <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100">
+        <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-ably-primary-inverse-active">
           <svg xmlns="http://www.w3.org/2000/svg"
                fill="none"
                viewbox="0 0 24 24"
@@ -781,7 +781,7 @@ npm run start
          tabindex="0"
     >
       <div class="absolute top-2 left-2 z-10">
-        <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100">
+        <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-ably-primary-inverse-active">
           <svg xmlns="http://www.w3.org/2000/svg"
                fill="none"
                viewbox="0 0 24 24"
@@ -848,7 +848,7 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
        tabindex="0"
   >
     <div class="absolute top-2 left-2 z-10">
-      <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-neutral-200 dark:bg-neutral-1100">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center bg-ably-primary-inverse-active">
         <svg xmlns="http://www.w3.org/2000/svg"
              fill="none"
              viewbox="0 0 24 24"
@@ -905,8 +905,8 @@ exports[`Components/Code Snippet PlainMode smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="border-b border-neutral-200 dark:border-neutral-1100 h-[2.125rem] inline-flex items-center px-3 w-full rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="border-b border-ably-primary-inverse-active h-[2.125rem] inline-flex items-center px-3 w-full rounded-t-lg">
     <div class="inline-flex items-center cursor-pointer">
       <svg xmlns="http://www.w3.org/2000/svg"
            width="48"
@@ -943,7 +943,7 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -1049,8 +1049,8 @@ exports[`Components/Code Snippet SingleLanguage smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -1065,7 +1065,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="border-b border-neutral-200 dark:border-neutral-1100 h-[2.125rem] inline-flex items-center px-3 w-full">
+  <div class="border-b border-ably-primary-inverse-active h-[2.125rem] inline-flex items-center px-3 w-full">
     <div class="inline-flex items-center cursor-pointer">
       <svg xmlns="http://www.w3.org/2000/svg"
            width="48"
@@ -1102,7 +1102,7 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -1208,8 +1208,8 @@ exports[`Components/Code Snippet SingleLanguageWithHeader smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -1224,9 +1224,9 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -1268,7 +1268,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1315,7 +1315,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -1376,7 +1376,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -1478,7 +1478,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
       </pre>
     </div>
   </div>
-  <div class="flex items-center border-t border-neutral-200 dark:border-neutral-1100 px-3 py-3">
+  <div class="flex items-center border-t border-ably-primary-inverse-active px-3 py-3">
     <span class="ui-text-label4 text-ably-label mr-1">
       API key:
     </span>
@@ -1489,7 +1489,7 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
             aria-autocomplete="none"
             dir="ltr"
             data-state="closed"
-            class="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-2 focus-base border"
+            class="font-sans inline-flex items-center justify-between rounded px-3 py-2 ml-1 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-2 focus-base border"
             aria-label="API Key"
     >
       <span style="pointer-events: none;">
@@ -1522,8 +1522,8 @@ exports[`Components/Code Snippet WithApiKeys smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -1538,9 +1538,9 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -1617,7 +1617,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1660,7 +1660,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1701,7 +1701,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -1799,7 +1799,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -1895,7 +1895,7 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -1984,8 +1984,8 @@ exports[`Components/Code Snippet WithCustomLanguageOrder smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -2000,14 +2000,14 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
       <div class="inline-flex ml-0">
         <button type="button"
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -2048,7 +2048,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -2086,7 +2086,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
           </div>
         </button>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -2167,7 +2167,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -2263,7 +2263,7 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -2352,8 +2352,8 @@ exports[`Components/Code Snippet WithDefaultLanguage smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -2368,9 +2368,9 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -2412,7 +2412,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -2459,7 +2459,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -2520,7 +2520,7 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -2622,12 +2622,12 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
       </pre>
     </div>
   </div>
-  <div class="flex items-center border-t border-neutral-200 dark:border-neutral-1100 px-3 py-3">
+  <div class="flex items-center border-t border-ably-primary-inverse-active px-3 py-3">
     <span class="ui-text-label4 text-ably-label mr-1">
       API key:
     </span>
     <div class="flex items-center gap-2">
-      <div class="inline-flex rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 ml-1 bg-neutral-200 dark:bg-neutral-1100">
+      <div class="inline-flex rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 ml-1 bg-ably-primary-inverse-active">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           DEMO ONLY
         </span>
@@ -2662,8 +2662,8 @@ exports[`Components/Code Snippet WithDemoApiKeys smoke-test 1`] = `
 
 exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1`] = `
 <div class="flex flex-col gap-4">
-  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+  <div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+    <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
       <div class="flex space-x-1.5">
         <div class="w-3 h-3 rounded-full bg-orange-500">
         </div>
@@ -2678,9 +2678,9 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
       <div class="w-12">
       </div>
     </div>
-    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
+    <div class="p-2 border-b border-ably-primary-inverse-active h-14">
       <div class="flex gap-3 justify-start">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
              tabindex="0"
              role="button"
              aria-pressed="true"
@@ -2691,9 +2691,9 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
         </div>
       </div>
     </div>
-    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+    <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
       <div class="hidden sm:flex gap-2">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
              tabindex="0"
              role="button"
              aria-pressed="true"
@@ -2735,7 +2735,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                   aria-describedby="tooltip"
                   class="p-0 relative focus:outline-none h-[1rem]"
           >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                  tabindex="0"
                  role="button"
                  aria-pressed="false"
@@ -2782,7 +2782,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                 aria-autocomplete="none"
                 dir="ltr"
                 data-state="closed"
-                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
                 aria-label="Select language"
         >
           <div class="flex items-center gap-2"
@@ -2843,7 +2843,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
     <div class="relative"
          tabindex="0"
     >
-      <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+      <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
            data-id="code"
       >
         <div class="text-code leading-6 pt-px">
@@ -2946,8 +2946,8 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
       </div>
     </div>
   </div>
-  <div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-    <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+  <div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+    <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
       <div class="flex space-x-1.5">
         <div class="w-3 h-3 rounded-full bg-orange-500">
         </div>
@@ -2962,9 +2962,9 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
       <div class="w-12">
       </div>
     </div>
-    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
+    <div class="p-2 border-b border-ably-primary-inverse-active h-14">
       <div class="flex gap-3 justify-start">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
              tabindex="0"
              role="button"
              aria-pressed="true"
@@ -2975,14 +2975,14 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
         </div>
       </div>
     </div>
-    <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+    <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
       <div class="hidden sm:flex gap-2">
         <div class="inline-flex ml-0">
           <button type="button"
                   aria-describedby="tooltip"
                   class="p-0 relative focus:outline-none h-[1rem]"
           >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                  tabindex="0"
                  role="button"
                  aria-pressed="false"
@@ -3021,7 +3021,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                   aria-describedby="tooltip"
                   class="p-0 relative focus:outline-none h-[1rem]"
           >
-            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+            <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                  tabindex="0"
                  role="button"
                  aria-pressed="false"
@@ -3138,7 +3138,7 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
                 aria-autocomplete="none"
                 dir="ltr"
                 data-state="closed"
-                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+                class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
                 aria-label="Select language"
         >
           <div class="flex items-center gap-2"
@@ -3226,8 +3226,8 @@ exports[`Components/Code Snippet WithFallbackSDKTypeAcrossInstances smoke-test 1
 `;
 
 exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -3242,9 +3242,9 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -3286,7 +3286,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3329,7 +3329,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3409,7 +3409,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -3470,7 +3470,7 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -3576,8 +3576,8 @@ exports[`Components/Code Snippet WithHeaderRow smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -3592,14 +3592,14 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
       <div class="inline-flex ml-0">
         <button type="button"
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3640,7 +3640,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -3687,7 +3687,7 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -4230,8 +4230,8 @@ exports[`Components/Code Snippet WithMissingLanguageSnippet smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -4246,9 +4246,9 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 h-14">
+  <div class="p-2 border-b border-ably-primary-inverse-active h-14">
     <div class="flex gap-3 justify-start">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -4262,7 +4262,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -4275,9 +4275,9 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
       </div>
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -4319,7 +4319,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -4366,7 +4366,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -4427,7 +4427,7 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <div class="text-code leading-6 pt-px">
@@ -4533,8 +4533,8 @@ exports[`Components/Code Snippet WithSDKTypes smoke-test 1`] = `
 `;
 
 exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
-<div class="rounded-lg overflow-hidden bg-neutral-100 dark:bg-neutral-1200 border border-ably-secondary-inverse min-h-[3.375rem]">
-  <div class="h-[2.375rem] bg-neutral-200 dark:bg-neutral-1100 border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
+<div class="rounded-lg overflow-hidden bg-ably-primary-inverse-accent border border-ably-secondary-inverse min-h-[3.375rem]">
+  <div class="h-[2.375rem] bg-ably-primary-inverse-active border-b border-ably-secondary-inverse flex items-center py-1 px-3 rounded-t-lg">
     <div class="flex space-x-1.5">
       <div class="w-3 h-3 rounded-full bg-orange-500">
       </div>
@@ -4549,9 +4549,9 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
     <div class="w-12">
     </div>
   </div>
-  <div class="p-2 border-b border-neutral-200 dark:border-neutral-1100 overflow-x-auto h-[3.625rem]">
+  <div class="p-2 border-b border-ably-primary-inverse-active overflow-x-auto h-[3.625rem]">
     <div class="hidden sm:flex gap-2">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -4593,7 +4593,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
                 aria-describedby="tooltip"
                 class="p-0 relative focus:outline-none h-[1rem]"
         >
-          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-neutral-100 dark:bg-neutral-1200"
+          <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg focus-base bg-ably-primary-inverse-accent"
                tabindex="0"
                role="button"
                aria-pressed="false"
@@ -4640,7 +4640,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
               aria-autocomplete="none"
               dir="ltr"
               data-state="closed"
-              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-neutral-200 dark:bg-neutral-1100 hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
+              class="w-full inline-flex items-center justify-between rounded-lg px-3 py-2 text-14 text-ably-primary bg-ably-primary-inverse-active hover:bg-ably-secondary-inverse gap-1 border border-neutral-300 dark:border-neutral-900 focus-base"
               aria-label="Select language"
       >
         <div class="flex items-center gap-2"
@@ -4701,7 +4701,7 @@ exports[`Components/Code Snippet WithoutCodeLines smoke-test 1`] = `
   <div class="relative"
        tabindex="0"
   >
-    <div class="hljs overflow-y-auto flex p-8 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-200 px-6 py-4"
+    <div class="hljs overflow-y-auto flex p-8 bg-ably-primary-inverse-accent text-neutral-1300 dark:text-neutral-200 px-6 py-4"
          data-id="code"
     >
       <pre lang="javascript"

--- a/src/core/DropdownMenu.tsx
+++ b/src/core/DropdownMenu.tsx
@@ -101,7 +101,7 @@ const Trigger = ({
       role="button"
       onClick={() => setOpen(!isOpen)}
       className={cn(
-        "flex items-center ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 focus:outline-none",
+        "flex items-center ui-text-label3 font-bold text-ably-secondary focus:outline-none",
         triggerClassNames,
       )}
     >
@@ -111,7 +111,7 @@ const Trigger = ({
           isOpen ? "icon-gui-chevron-up-mini" : "icon-gui-chevron-down-mini"
         }
         size="1.25rem"
-        additionalCSS="text-neutral-1300 dark:text-neutral-000"
+        additionalCSS="text-ably-primary"
       />
     </button>
   );
@@ -133,7 +133,7 @@ const Content = ({
       id="menu-content"
       role="menu"
       className={cn(
-        "flex flex-col absolute z-10 border border-neutral-400 dark:border-neutral-900 bg-neutral-000 dark:bg-neutral-1300 rounded-lg ui-shadow-md-soft",
+        "flex flex-col absolute z-10 border border-neutral-400 dark:border-neutral-900 bg-ably-primary-inverse rounded-lg ui-shadow-md-soft",
         anchorPosition === "right" ? "right-0" : "left-0",
         contentClassNames,
       )}
@@ -148,7 +148,7 @@ const Link = ({ url, title, subtitle, iconName, children }: LinkProps) => {
     <a
       href={url}
       className="menu-link group block p-2 rounded-lg
-      hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 hover:dark:text-neutral-000"
+      hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary"
     >
       <p className="mb-1">
         {title}
@@ -156,7 +156,7 @@ const Link = ({ url, title, subtitle, iconName, children }: LinkProps) => {
           <Icon
             name={iconName}
             size="1rem"
-            additionalCSS="align-middle ml-2 relative -top-px -left-1 text-neutral-1300 dark:text-neutral-000"
+            additionalCSS="align-middle ml-2 relative -top-px -left-1 text-ably-primary"
           />
         ) : null}
       </p>

--- a/src/core/DropdownMenu.tsx
+++ b/src/core/DropdownMenu.tsx
@@ -148,7 +148,7 @@ const Link = ({ url, title, subtitle, iconName, children }: LinkProps) => {
     <a
       href={url}
       className="menu-link group block p-2 rounded-lg
-      hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary"
+      hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-active text-ably-secondary hover:text-ably-primary"
     >
       <p className="mb-1">
         {title}

--- a/src/core/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.stories.tsx
@@ -20,9 +20,7 @@ export const Default = {
           subtitle="This is using the inbuilt component which takes props for title, subtitle, icon name & children."
           iconName="icon-gui-arrow-long-right-outline"
         >
-          <p className="ui-text-p3 text-neutral-1000 dark:text-neutral-300">
-            I am a child! 🐣
-          </p>
+          <p className="ui-text-p3 text-ably-secondary">I am a child! 🐣</p>
         </DropdownMenu.Link>
         <DropdownMenu.Link
           url="https://ably.com/"
@@ -32,14 +30,14 @@ export const Default = {
           href="https://ably.com/docs"
           target="_blank"
           rel="noreferrer"
-          className="group block p-2 hover:bg-neutral-100 dark:hover:bg-neutral-1200 hover:text-neutral-1300 dark:hover:text-neutral-000 rounded-lg"
+          className="group block p-2 hover:bg-neutral-100 dark:hover:bg-neutral-1200 hover:text-ably-primary rounded-lg"
         >
-          <p className="ui-featured-link group-hover:text-gui-hover font-light text-neutral-1300 dark:text-neutral-000">
+          <p className="ui-featured-link group-hover:text-gui-hover font-light text-ably-primary">
             Using plain HTML
             <Icon
               name="icon-gui-arrow-long-right-micro"
               size="1rem"
-              color="text-neutral-1300 dark:text-neutral-000"
+              color="text-ably-primary"
               additionalCSS="ui-featured-link-icon group-hover:text-gui-hover group-active:text-gui-active group-focus:text-gui-focus"
             />
           </p>

--- a/src/core/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/core/DropdownMenu/DropdownMenu.stories.tsx
@@ -30,7 +30,7 @@ export const Default = {
           href="https://ably.com/docs"
           target="_blank"
           rel="noreferrer"
-          className="group block p-2 hover:bg-neutral-100 dark:hover:bg-neutral-1200 hover:text-ably-primary rounded-lg"
+          className="group block p-2 hover:bg-ably-primary-inverse-accent hover:text-ably-primary rounded-lg"
         >
           <p className="ui-featured-link group-hover:text-gui-hover font-light text-ably-primary">
             Using plain HTML

--- a/src/core/DropdownMenu/__snapshots__/DropdownMenu.stories.tsx.snap
+++ b/src/core/DropdownMenu/__snapshots__/DropdownMenu.stories.tsx.snap
@@ -6,7 +6,7 @@ exports[`Components/Dropdown Menu Default smoke-test 1`] = `
 >
   <button id="menu-trigger"
           role="button"
-          class="flex items-center ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 focus:outline-none ui-text-h3"
+          class="flex items-center ui-text-label3 font-bold text-ably-secondary focus:outline-none ui-text-h3"
   >
     Dropdown Menu Trigger
     <svg xmlns="http://www.w3.org/2000/svg"
@@ -14,7 +14,7 @@ exports[`Components/Dropdown Menu Default smoke-test 1`] = `
          fill="currentColor"
          aria-hidden="true"
          data-slot="icon"
-         class="text-neutral-1300 dark:text-neutral-000"
+         class="text-ably-primary"
          style="width: 1.25rem; height: 1.25rem;"
     >
       <path fill-rule="evenodd"

--- a/src/core/Flyout.tsx
+++ b/src/core/Flyout.tsx
@@ -115,8 +115,8 @@ const Flyout = ({
                   onClick={(event) => event.preventDefault()}
                   className={cn(
                     "group outline-none focus:outline-none select-none cursor-pointer relative",
-                    "rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200",
-                    "[&[data-state=open]]:bg-neutral-100 dark:[&[data-state=open]]:bg-neutral-1200",
+                    "rounded-md hover:bg-ably-primary-inverse-accent",
+                    "[&[data-state=open]]:bg-ably-primary-inverse-accent",
                     "[&[data-state=open]]:text-ably-primary",
                     DEFAULT_MENU_LINK_STYLING,
                     menuLinkClassName,

--- a/src/core/Flyout.tsx
+++ b/src/core/Flyout.tsx
@@ -55,7 +55,7 @@ type FlyoutProps = {
 };
 
 const DEFAULT_MENU_LINK_STYLING =
-  "ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 px-3 py-2 flex items-center justify-between";
+  "ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between";
 const DEFAULT_VIEWPORT_STYLING =
   "relative overflow-hidden w-full h-[var(--radix-navigation-menu-viewport-height)] origin-[top_center] transition-[width,_height] duration-300 data-[state=closed]:animate-scale-out data-[state=open]:animate-scale-in sm:w-[var(--radix-navigation-menu-viewport-width)]";
 const PANEL_ANIMATION =
@@ -117,7 +117,7 @@ const Flyout = ({
                     "group outline-none focus:outline-none select-none cursor-pointer relative",
                     "rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200",
                     "[&[data-state=open]]:bg-neutral-100 dark:[&[data-state=open]]:bg-neutral-1200",
-                    "[&[data-state=open]]:text-neutral-1300 dark:[&[data-state=open]]:text-neutral-000",
+                    "[&[data-state=open]]:text-ably-primary",
                     DEFAULT_MENU_LINK_STYLING,
                     menuLinkClassName,
                   )}

--- a/src/core/Flyout/Flyout.stories.tsx
+++ b/src/core/Flyout/Flyout.stories.tsx
@@ -18,8 +18,7 @@ const platforms = [
   "Security & Compliance",
 ];
 
-const panelClassName =
-  "w-full sm:w-[51rem] bg-neutral-000 dark:bg-neutral-1300";
+const panelClassName = "w-full sm:w-[51rem] bg-ably-primary-inverse";
 
 const Panels = ({
   panelLeft,
@@ -31,13 +30,11 @@ const Panels = ({
   <div className="flex flex-row gap-x-6">
     <div className="flex-6">{panelLeft}</div>
     <div className="flex-4 pt-3">
-      <p className="ui-text-overline2 text-neutral-700 dark:text-neutral-600 pb-1.5">
-        platform
-      </p>
+      <p className="ui-text-overline2 text-ably-label pb-1.5">platform</p>
       {platforms.map((item) => (
         <li className="list-none py-1.5" key={item}>
           <a
-            className="ui-text-label3 text-neutral-1000 dark:text-neutral-300"
+            className="ui-text-label3 text-ably-secondary"
             href={`/platform/${item.toLowerCase()}`}
           >
             {item}
@@ -50,15 +47,11 @@ const Panels = ({
 
 const DefaultPanelLeft = ({ title, desc }: { title: string; desc: string }) => (
   <div className="bg-neutral-100 dark:bg-neutral-1200 w-full p-6">
-    <h4 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
-      {title}
-    </h4>
-    <p className="ui-text-p3 text-neutral-800 dark:text-neutral-500 mt-2">
-      {desc}
-    </p>
+    <h4 className="ui-text-h4 text-ably-primary">{title}</h4>
+    <p className="ui-text-p3 text-ably-tertiary mt-2">{desc}</p>
     <FeaturedLink
       url=""
-      additionalCSS="text-neutral-1300 dark:text-neutral-000"
+      additionalCSS="text-ably-primary"
       iconColor="text-orange-600"
     >
       Learn more
@@ -128,7 +121,7 @@ const FlyoutStory = () => {
       menuItems={menuItems}
       className="justify-center relative z-40"
       flyOutClassName="flex w-full justify-center"
-      viewPortClassName="ui-shadow-lg-medium border border-neutral-000 dark:border-neutral-1300 rounded-2xl mt-2"
+      viewPortClassName="ui-shadow-lg-medium border border-ably-primary-inverse rounded-2xl mt-2"
     />
   );
 };

--- a/src/core/Flyout/Flyout.stories.tsx
+++ b/src/core/Flyout/Flyout.stories.tsx
@@ -46,7 +46,7 @@ const Panels = ({
 );
 
 const DefaultPanelLeft = ({ title, desc }: { title: string; desc: string }) => (
-  <div className="bg-neutral-100 dark:bg-neutral-1200 w-full p-6">
+  <div className="bg-ably-primary-inverse-accent w-full p-6">
     <h4 className="ui-text-h4 text-ably-primary">{title}</h4>
     <p className="ui-text-p3 text-ably-tertiary mt-2">{desc}</p>
     <FeaturedLink

--- a/src/core/Flyout/__snapshots__/Flyout.stories.tsx.snap
+++ b/src/core/Flyout/__snapshots__/Flyout.stories.tsx.snap
@@ -12,7 +12,7 @@ exports[`Components/Flyout Default smoke-test 1`] = `
         dir="ltr"
     >
       <a href
-         class="ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 px-3 py-2 flex items-center justify-between"
+         class="ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
          data-radix-collection-item
       >
         Home
@@ -22,7 +22,7 @@ exports[`Components/Flyout Default smoke-test 1`] = `
                 data-state="closed"
                 aria-expanded="false"
                 aria-controls="radix-:r0:-content-radix-:r1:"
-                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-neutral-1300 dark:[&amp;[data-state=open]]:text-neutral-000 ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 px-3 py-2 flex items-center justify-between"
+                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
                 data-radix-collection-item
         >
           Products
@@ -33,7 +33,7 @@ exports[`Components/Flyout Default smoke-test 1`] = `
                 data-state="closed"
                 aria-expanded="false"
                 aria-controls="radix-:r0:-content-radix-:r2:"
-                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-neutral-1300 dark:[&amp;[data-state=open]]:text-neutral-000 ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 px-3 py-2 flex items-center justify-between"
+                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
                 data-radix-collection-item
         >
           Solutions
@@ -44,20 +44,20 @@ exports[`Components/Flyout Default smoke-test 1`] = `
                 data-state="closed"
                 aria-expanded="false"
                 aria-controls="radix-:r0:-content-radix-:r3:"
-                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-neutral-1300 dark:[&amp;[data-state=open]]:text-neutral-000 ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 px-3 py-2 flex items-center justify-between"
+                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
                 data-radix-collection-item
         >
           Company
         </button>
       </li>
       <a href="/pricing"
-         class="ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 px-3 py-2 flex items-center justify-between"
+         class="ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
          data-radix-collection-item
       >
         Pricing
       </a>
       <a href="/docs"
-         class="ui-text-label3 font-bold text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 px-3 py-2 flex items-center justify-between"
+         class="ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
          data-radix-collection-item
       >
         Docs

--- a/src/core/Flyout/__snapshots__/Flyout.stories.tsx.snap
+++ b/src/core/Flyout/__snapshots__/Flyout.stories.tsx.snap
@@ -22,7 +22,7 @@ exports[`Components/Flyout Default smoke-test 1`] = `
                 data-state="closed"
                 aria-expanded="false"
                 aria-controls="radix-:r0:-content-radix-:r1:"
-                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
+                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-ably-primary-inverse-accent [&amp;[data-state=open]]:bg-ably-primary-inverse-accent [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
                 data-radix-collection-item
         >
           Products
@@ -33,7 +33,7 @@ exports[`Components/Flyout Default smoke-test 1`] = `
                 data-state="closed"
                 aria-expanded="false"
                 aria-controls="radix-:r0:-content-radix-:r2:"
-                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
+                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-ably-primary-inverse-accent [&amp;[data-state=open]]:bg-ably-primary-inverse-accent [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
                 data-radix-collection-item
         >
           Solutions
@@ -44,7 +44,7 @@ exports[`Components/Flyout Default smoke-test 1`] = `
                 data-state="closed"
                 aria-expanded="false"
                 aria-controls="radix-:r0:-content-radix-:r3:"
-                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-1200 [&amp;[data-state=open]]:bg-neutral-100 dark:[&amp;[data-state=open]]:bg-neutral-1200 [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
+                class="group outline-none focus:outline-none select-none cursor-pointer relative rounded-md hover:bg-ably-primary-inverse-accent [&amp;[data-state=open]]:bg-ably-primary-inverse-accent [&amp;[data-state=open]]:text-ably-primary ui-text-label3 font-bold text-ably-secondary hover:text-ably-primary px-3 py-2 flex items-center justify-between"
                 data-radix-collection-item
         >
           Company

--- a/src/core/Footer.tsx
+++ b/src/core/Footer.tsx
@@ -10,11 +10,11 @@ import { ablyAwards } from "./Meganav/data";
 
 const Footer = () => {
   const textColorClassnames =
-    "ui-text-label3 font-medium transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 hover:dark:text-neutral-000 active:text-neutral-800 active:dark:text-neutral-400 focus:outline focus:outline-gui-focus";
+    "ui-text-label3 font-medium transition-colors text-ably-secondary hover:text-ably-primary active:text-neutral-800 active:dark:text-neutral-400 focus:outline focus:outline-gui-focus";
 
   return (
     <footer
-      className="w-full bg-neutral-100 dark:bg-neutral-1200 border-t border-neutral-300 dark:border-neutral-1000"
+      className="w-full bg-neutral-100 dark:bg-neutral-1200 border-t border-ably-secondary-inverse"
       data-id="footer"
     >
       <div className="max-w-screen-xl mx-auto ui-grid-px pt-10 sm:pt-12 md:pt-16 pb-10">
@@ -49,7 +49,7 @@ const Footer = () => {
                   <Icon
                     name={link.monoIcon}
                     size="20px"
-                    additionalCSS="text-neutral-1000 dark:text-neutral-300 group-hover/social-icon:hidden"
+                    additionalCSS="text-ably-secondary group-hover/social-icon:hidden"
                   />
                   <Icon
                     name={link.colorIcon}
@@ -74,7 +74,7 @@ const Footer = () => {
           <div className="flex-1 md:flex-[2] flex flex-row flex-wrap gap-x-6 gap-y-12">
             {footerLinks.map(({ title, links }) => (
               <div key={title} className="flex-1 basis-1/3 md:basis-1">
-                <h3 className="ui-text-overline2 text-neutral-700 dark:text-neutral-600 mb-4">
+                <h3 className="ui-text-overline2 text-ably-label mb-4">
                   {title}
                 </h3>
                 <ul className="flex flex-col gap-y-3">
@@ -100,7 +100,7 @@ const Footer = () => {
           </div>
         </div>
 
-        <div className="pt-6 border-t border-neutral-300 dark:border-neutral-1000">
+        <div className="pt-6 border-t border-ably-secondary-inverse">
           <div className="flex gap-6">
             {bottomFooterLinks.map((link) => (
               <a

--- a/src/core/Footer.tsx
+++ b/src/core/Footer.tsx
@@ -14,7 +14,7 @@ const Footer = () => {
 
   return (
     <footer
-      className="w-full bg-neutral-100 dark:bg-neutral-1200 border-t border-ably-secondary-inverse"
+      className="w-full bg-ably-primary-inverse-accent border-t border-ably-secondary-inverse"
       data-id="footer"
     >
       <div className="max-w-screen-xl mx-auto ui-grid-px pt-10 sm:pt-12 md:pt-16 pb-10">

--- a/src/core/Header.tsx
+++ b/src/core/Header.tsx
@@ -242,7 +242,7 @@ const Header: React.FC<HeaderProps> = ({
   const wrappedSearchButton = useMemo(
     () =>
       searchButton ? (
-        <div className="text-neutral-1300 dark:text-neutral-000 flex items-center">
+        <div className="text-ably-primary flex items-center">
           {searchButton}
         </div>
       ) : null,
@@ -254,7 +254,7 @@ const Header: React.FC<HeaderProps> = ({
       <header
         role="banner"
         className={cn(
-          "fixed left-0 top-0 w-full z-50 bg-neutral-000 dark:bg-neutral-1300 border-b border-neutral-300 dark:border-neutral-1000 transition-colors px-6 lg:px-16",
+          "fixed left-0 top-0 w-full z-50 bg-ably-primary-inverse border-b border-ably-secondary-inverse transition-colors px-6 lg:px-16",
           scrollpointClasses,
           {
             "md:top-auto": bannerVisible,
@@ -295,7 +295,7 @@ const Header: React.FC<HeaderProps> = ({
                     ? "icon-gui-x-mark-outline"
                     : "icon-gui-bars-3-outline"
                 }
-                additionalCSS="text-neutral-1300 dark:text-neutral-000"
+                additionalCSS="text-ably-primary"
                 size="1.5rem"
               />
             </button>
@@ -338,7 +338,7 @@ const Header: React.FC<HeaderProps> = ({
           />
           <div
             id="mobile-menu"
-            className="md:hidden fixed flex flex-col top-[4.75rem] overflow-y-hidden mx-3 right-0 w-[calc(100%-24px)] bg-neutral-000 dark:bg-neutral-1300 rounded-2xl ui-shadow-lg-medium z-50"
+            className="md:hidden fixed flex flex-col top-[4.75rem] overflow-y-hidden mx-3 right-0 w-[calc(100%-24px)] bg-ably-primary-inverse rounded-2xl ui-shadow-lg-medium z-50"
             style={{
               maxWidth: MAX_MOBILE_MENU_WIDTH,
               maxHeight: componentMaxHeight(

--- a/src/core/Header/HeaderLinks.tsx
+++ b/src/core/Header/HeaderLinks.tsx
@@ -34,10 +34,10 @@ export const HeaderLinks: React.FC<
   const formRef = useRef<HTMLFormElement>(null);
 
   const headerLinkClasses =
-    "ui-text-label2 md:ui-text-label3 !font-bold py-4 text-neutral-1300 dark:text-neutral-000 md:text-neutral-1000 dark:md:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 active:text-neutral-1300 dark:active:text-neutral-000 transition-colors";
+    "ui-text-label2 md:ui-text-label3 !font-bold py-4 text-ably-primary md:text-ably-secondary hover:text-ably-primary active:text-ably-primary transition-colors";
 
   const dropdownMenuLinkClasses =
-    "block p-2 ui-text-label3 font-semibold text-neutral-1000 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-200 dark:active:bg-neutral-1100 rounded-lg";
+    "block p-2 ui-text-label3 font-semibold text-ably-secondary hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-200 dark:active:bg-neutral-1100 rounded-lg";
 
   const onClickLogout = (e: MouseEvent) => {
     e.preventDefault();
@@ -69,7 +69,7 @@ export const HeaderLinks: React.FC<
           {LogoutForm}
           <div className="block md:hidden">
             <div className="flex flex-col border-b-[1px] border-neutral-300 px-4 pb-3 mb-3">
-              <span className="py-3 ui-text-sub-header text-[18px] text-neutral-700 dark:text-neutral-600 font-bold">
+              <span className="py-3 ui-text-sub-header text-[18px] text-ably-label font-bold">
                 {sessionState.accountName}
               </span>
               {<DashboardLink className={headerLinkClasses} />}
@@ -142,14 +142,14 @@ export const HeaderLinks: React.FC<
           <LinkButton
             href="/login"
             variant="secondary"
-            className="flex-1 md:flex-none md:ui-button-secondary-xs hover:text-neutral-1300 dark:hover:text-neutral-000"
+            className="flex-1 md:flex-none md:ui-button-secondary-xs hover:text-ably-primary"
           >
             Login
           </LinkButton>
           <LinkButton
             href="/sign-up"
             variant="primary"
-            className="flex-1 md:flex-none md:ui-button-primary-xs hover:text-neutral-000 dark:hover:text-neutral-1300"
+            className="flex-1 md:flex-none md:ui-button-primary-xs hover:text-ably-primary-inverse"
           >
             Start free
           </LinkButton>

--- a/src/core/Header/HeaderLinks.tsx
+++ b/src/core/Header/HeaderLinks.tsx
@@ -37,7 +37,7 @@ export const HeaderLinks: React.FC<
     "ui-text-label2 md:ui-text-label3 !font-bold py-4 text-ably-primary md:text-ably-secondary hover:text-ably-primary active:text-ably-primary transition-colors";
 
   const dropdownMenuLinkClasses =
-    "block p-2 ui-text-label3 font-semibold text-ably-secondary hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-200 dark:active:bg-neutral-1100 rounded-lg";
+    "block p-2 ui-text-label3 font-semibold text-ably-secondary hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-active rounded-lg";
 
   const onClickLogout = (e: MouseEvent) => {
     e.preventDefault();

--- a/src/core/Icon/Icon.stories.tsx
+++ b/src/core/Icon/Icon.stories.tsx
@@ -75,9 +75,7 @@ const renderIcons = (iconSet: IconName[]) => {
       </p>
       {iconSet.some((icon) => icon.includes("-gui-")) && (
         <div className="flex items-center pt-4 gap-2 px-4 flex-wrap">
-          <span className="ui-text-p1 text-neutral-1300 dark:text-neutral-000">
-            Filter icons:
-          </span>
+          <span className="ui-text-p1 text-ably-primary">Filter icons:</span>
           {iconVariants.map((variant) => (
             <Button
               key={variant}
@@ -100,13 +98,13 @@ const renderIcons = (iconSet: IconName[]) => {
               <div className="flex">
                 <Icon
                   name={icon}
-                  additionalCSS="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+                  additionalCSS="hover:text-active-orange text-ably-primary transition-colors"
                   color="text-cool-black"
                   size={getIconSize(icon)}
                 />
               </div>
             </div>
-            <code className="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+            <code className="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
               <p>{icon}</p>
             </code>
           </div>
@@ -140,9 +138,7 @@ export const IconWithSecondaryColor = {
   render: () => (
     <div className="flex items-center justify-center p-4 gap-6">
       <div className="flex gap-6">
-        <h4 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
-          Non-themed:
-        </h4>
+        <h4 className="ui-text-h4 text-ably-primary">Non-themed:</h4>
         <Icon
           name="icon-gui-check-circled-fill"
           color="text-orange-600"
@@ -151,14 +147,12 @@ export const IconWithSecondaryColor = {
         <Icon
           name="icon-gui-check-circled-fill"
           color="text-orange-600"
-          secondaryColor="text-neutral-1300"
+          secondaryColor="text-ably-primary"
           size="1.5rem"
         />
       </div>
       <div className="flex gap-6">
-        <h4 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
-          Themed:
-        </h4>
+        <h4 className="ui-text-h4 text-ably-primary">Themed:</h4>
         <Icon
           name="icon-gui-check-circled-fill"
           color="text-orange-600"

--- a/src/core/Icon/__snapshots__/Icon.stories.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.stories.tsx.snap
@@ -22,7 +22,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -34,7 +34,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-48hrs
         </p>
@@ -48,7 +48,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#FF5416"
@@ -91,7 +91,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-ably-channels
         </p>
@@ -105,7 +105,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <circle cx="20"
@@ -125,7 +125,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-about-ably-col
         </p>
@@ -139,7 +139,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -151,7 +151,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-api
         </p>
@@ -165,7 +165,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -177,7 +177,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-api-keys
         </p>
@@ -191,7 +191,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <rect width="15"
@@ -253,7 +253,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-architectural-guidance
         </p>
@@ -267,7 +267,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -367,7 +367,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-asset-tracking-col
         </p>
@@ -381,7 +381,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -415,7 +415,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-authentication
         </p>
@@ -429,7 +429,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -466,7 +466,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-avatar-stack
         </p>
@@ -480,7 +480,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -502,7 +502,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-browser
         </p>
@@ -516,7 +516,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -528,7 +528,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-calendar
         </p>
@@ -542,7 +542,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -554,7 +554,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-call-mobile
         </p>
@@ -568,7 +568,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -613,7 +613,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-careers-col
         </p>
@@ -627,7 +627,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -651,7 +651,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-case-studies-col
         </p>
@@ -665,7 +665,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -679,7 +679,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-chat-col
         </p>
@@ -693,7 +693,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="32"
                fill="none"
                viewbox="0 0 32 32"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -707,7 +707,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-chat-mono
         </p>
@@ -721,7 +721,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -735,7 +735,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-chat-stack
         </p>
@@ -749,7 +749,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -763,7 +763,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-chat-stack-col
         </p>
@@ -777,7 +777,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -789,7 +789,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-cloud-servers
         </p>
@@ -803,7 +803,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 41 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -833,7 +833,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-compare-tech-col
         </p>
@@ -847,7 +847,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#C6CED9"
@@ -864,7 +864,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-connection-state-recovery
         </p>
@@ -878,7 +878,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <ellipse cx="14.988"
@@ -975,7 +975,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-consumer-groups
         </p>
@@ -989,7 +989,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -1012,7 +1012,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-custom
         </p>
@@ -1026,7 +1026,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -1086,7 +1086,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-custom-cname
         </p>
@@ -1100,7 +1100,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -1133,7 +1133,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-customers-col
         </p>
@@ -1147,7 +1147,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -1236,7 +1236,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-data-broadcast-col
         </p>
@@ -1250,7 +1250,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 31 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -1272,7 +1272,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-data-broadcast-mono
         </p>
@@ -1286,7 +1286,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -1358,7 +1358,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-data-synchronization-col
         </p>
@@ -1372,7 +1372,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -1436,7 +1436,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-dedicated-cluster
         </p>
@@ -1450,7 +1450,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -1482,7 +1482,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-deltas
         </p>
@@ -1496,7 +1496,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -1527,7 +1527,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-docs-col
         </p>
@@ -1541,7 +1541,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -1553,7 +1553,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-documentation
         </p>
@@ -1567,7 +1567,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -1648,7 +1648,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-dynamic-channel-groups
         </p>
@@ -1662,7 +1662,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -1710,7 +1710,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-edge-network
         </p>
@@ -1724,7 +1724,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -1768,7 +1768,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-elasticity
         </p>
@@ -1782,7 +1782,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="32"
                fill="none"
                viewbox="0 0 32 32"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -1820,7 +1820,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-equalisers-mono
         </p>
@@ -1834,7 +1834,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -1874,7 +1874,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-events-col
         </p>
@@ -1888,7 +1888,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -1930,7 +1930,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-exactly-once-delivery
         </p>
@@ -1944,7 +1944,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <rect width="19.5"
@@ -2020,7 +2020,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-examples-col
         </p>
@@ -2034,7 +2034,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <rect width="8"
@@ -2160,7 +2160,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-fan-out
         </p>
@@ -2174,7 +2174,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#FF5416"
@@ -2224,7 +2224,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-firehose
         </p>
@@ -2238,7 +2238,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -2250,7 +2250,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-gdpr
         </p>
@@ -2264,7 +2264,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -2276,7 +2276,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-general-comms
         </p>
@@ -2290,7 +2290,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <rect width="38"
@@ -2318,7 +2318,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-granular-permissions
         </p>
@@ -2332,7 +2332,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -2354,7 +2354,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-hipaa
         </p>
@@ -2368,7 +2368,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -2390,7 +2390,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-hipaa-mono
         </p>
@@ -2404,7 +2404,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#FF5416"
@@ -2430,7 +2430,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-history
         </p>
@@ -2444,7 +2444,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="60"
                fill="none"
                viewbox="0 0 60 60"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -2476,7 +2476,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-integrations
         </p>
@@ -2490,7 +2490,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -2522,7 +2522,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-integrations-col
         </p>
@@ -2536,7 +2536,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -2548,7 +2548,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-it-support-access
         </p>
@@ -2562,7 +2562,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -2574,7 +2574,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-it-support-helpdesk
         </p>
@@ -2588,7 +2588,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -2628,7 +2628,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-kafka-at-the-edge-col
         </p>
@@ -2642,7 +2642,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -2664,7 +2664,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-laptop
         </p>
@@ -2678,7 +2678,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#C6CED9"
@@ -2692,7 +2692,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-last-seen
         </p>
@@ -2706,7 +2706,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -2738,7 +2738,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-lightbulb-col
         </p>
@@ -2752,7 +2752,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -2764,7 +2764,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-live-chat
         </p>
@@ -2778,7 +2778,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -2867,7 +2867,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-live-updates-results-metrics-col
         </p>
@@ -2881,7 +2881,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -2893,7 +2893,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-map-pin
         </p>
@@ -2907,7 +2907,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -2919,7 +2919,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-message
         </p>
@@ -2933,7 +2933,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <rect width="6"
@@ -3020,7 +3020,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-message-batching
         </p>
@@ -3034,7 +3034,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#FF5416"
@@ -3069,7 +3069,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-message-persistence
         </p>
@@ -3083,7 +3083,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -3129,7 +3129,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-message-queues
         </p>
@@ -3143,7 +3143,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 49 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -3179,7 +3179,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-multi-user-spaces-col
         </p>
@@ -3193,7 +3193,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -3261,7 +3261,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-observe-analytics
         </p>
@@ -3275,7 +3275,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -3287,7 +3287,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-padlock-closed
         </p>
@@ -3301,7 +3301,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -3372,7 +3372,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-platform
         </p>
@@ -3386,7 +3386,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -3398,7 +3398,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-play
         </p>
@@ -3412,7 +3412,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <mask id="path-1-inside-1_3563_10992"
@@ -3436,7 +3436,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-premium-support
         </p>
@@ -3450,7 +3450,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#fff"
@@ -3476,7 +3476,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-privacy-shield-framework
         </p>
@@ -3490,7 +3490,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 49 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -3572,7 +3572,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-private-link
         </p>
@@ -3586,7 +3586,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -3613,7 +3613,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-push-notifications
         </p>
@@ -3627,7 +3627,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -3654,7 +3654,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-push-notifications-col
         </p>
@@ -3668,7 +3668,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="30"
                fill="none"
                viewbox="0 0 31 30"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -3692,7 +3692,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-push-notifications-mono
         </p>
@@ -3706,7 +3706,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -3742,7 +3742,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-quickstart-guides-col
         </p>
@@ -3756,7 +3756,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <rect width="46.5"
@@ -3779,7 +3779,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-reactions
         </p>
@@ -3793,7 +3793,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -3811,7 +3811,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-read-receipts
         </p>
@@ -3825,7 +3825,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -3907,7 +3907,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-resources-col
         </p>
@@ -3921,7 +3921,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#FF5416"
@@ -3939,7 +3939,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-rewind
         </p>
@@ -3953,7 +3953,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -3985,7 +3985,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-sdks-col
         </p>
@@ -3999,7 +3999,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#C6CED9"
@@ -4027,7 +4027,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-send-received-messages
         </p>
@@ -4041,7 +4041,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -4053,7 +4053,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-servers
         </p>
@@ -4067,7 +4067,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -4089,7 +4089,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-shopping-cart
         </p>
@@ -4103,7 +4103,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -4136,7 +4136,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-sla
         </p>
@@ -4150,7 +4150,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -4162,7 +4162,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-soc2-type2
         </p>
@@ -4176,7 +4176,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#C6CED9"
@@ -4188,7 +4188,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-soc2-type2-mono
         </p>
@@ -4202,7 +4202,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 46 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -4217,7 +4217,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-something-else
         </p>
@@ -4231,7 +4231,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 46 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -4246,7 +4246,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-something-else-mono
         </p>
@@ -4260,7 +4260,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <ellipse cx="24"
@@ -4320,7 +4320,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-subscription-filters
         </p>
@@ -4334,7 +4334,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="32"
                fill="none"
                viewbox="0 0 32 32"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <circle cx="15"
@@ -4369,7 +4369,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-support-chat-mono
         </p>
@@ -4383,7 +4383,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 49 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#C6CED9"
@@ -4431,7 +4431,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-system-metadata
         </p>
@@ -4445,7 +4445,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -4457,7 +4457,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-tech-account-comms
         </p>
@@ -4471,7 +4471,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -4563,7 +4563,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-tutorials-demos-col
         </p>
@@ -4577,7 +4577,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -4638,7 +4638,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-virtual-events
         </p>
@@ -4652,7 +4652,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
                height="41"
                fill="none"
                viewbox="0 0 40 41"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="#03020D"
@@ -4713,7 +4713,7 @@ exports[`Components/Icon DisplayIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-display-virtual-events-col
         </p>
@@ -4737,7 +4737,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
     library.
   </p>
   <div class="flex items-center pt-4 gap-2 px-4 flex-wrap">
-    <span class="ui-text-p1 text-neutral-1300 dark:text-neutral-000">
+    <span class="ui-text-p1 text-ably-primary">
       Filter icons:
     </span>
     <button class="ui-button-primary-xs"
@@ -4767,7 +4767,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -4777,7 +4777,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-gui-prod-asset-tracking-outline
         </p>
@@ -4791,7 +4791,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -4802,7 +4802,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-gui-prod-chat-outline
         </p>
@@ -4816,7 +4816,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -4835,7 +4835,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-gui-prod-liveobjects-outline
         </p>
@@ -4849,7 +4849,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -4861,7 +4861,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-gui-prod-livesync-outline
         </p>
@@ -4875,7 +4875,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -4886,7 +4886,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-gui-prod-pubsub-outline
         </p>
@@ -4900,7 +4900,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -4911,7 +4911,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-gui-prod-spaces-outline
         </p>
@@ -4924,7 +4924,7 @@ exports[`Components/Icon GUIIcons smoke-test 1`] = `
 exports[`Components/Icon IconWithSecondaryColor smoke-test 1`] = `
 <div class="flex items-center justify-center p-4 gap-6">
   <div class="flex gap-6">
-    <h4 class="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
+    <h4 class="ui-text-h4 text-ably-primary">
       Non-themed:
     </h4>
     <svg xmlns="http://www.w3.org/2000/svg"
@@ -4954,7 +4954,7 @@ exports[`Components/Icon IconWithSecondaryColor smoke-test 1`] = `
          fill="none"
          viewbox="0 0 24 24"
          class="text-orange-600"
-         style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-neutral-1300);"
+         style="width: 1.5rem; height: 1.5rem; --ui-icon-secondary-color: var(--color-ably-primary);"
     >
       <path fill="currentColor"
             fill-rule="evenodd"
@@ -4971,7 +4971,7 @@ exports[`Components/Icon IconWithSecondaryColor smoke-test 1`] = `
     </svg>
   </div>
   <div class="flex gap-6">
-    <h4 class="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
+    <h4 class="ui-text-h4 text-ably-primary">
       Themed:
     </h4>
     <svg xmlns="http://www.w3.org/2000/svg"
@@ -5063,7 +5063,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5091,7 +5091,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-asset-tracking
         </p>
@@ -5105,7 +5105,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -5115,7 +5115,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-asset-tracking-mono
         </p>
@@ -5129,7 +5129,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5157,7 +5157,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-chat
         </p>
@@ -5171,7 +5171,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -5182,7 +5182,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-chat-mono
         </p>
@@ -5196,7 +5196,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5233,7 +5233,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-liveobjects
         </p>
@@ -5247,7 +5247,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5284,7 +5284,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-liveobjects-dark
         </p>
@@ -5298,7 +5298,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -5317,7 +5317,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-liveobjects-mono
         </p>
@@ -5331,7 +5331,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5359,7 +5359,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-livesync
         </p>
@@ -5373,7 +5373,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -5385,7 +5385,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-livesync-mono
         </p>
@@ -5399,7 +5399,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="20"
                fill="none"
                viewbox="0 0 20 20"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#ff5416"
@@ -5417,7 +5417,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-platform
         </p>
@@ -5431,7 +5431,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="20"
                fill="none"
                viewbox="0 0 20 20"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -5443,7 +5443,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-platform-mono
         </p>
@@ -5457,7 +5457,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5485,7 +5485,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-pubsub
         </p>
@@ -5499,7 +5499,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -5510,7 +5510,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-pubsub-mono
         </p>
@@ -5524,7 +5524,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5550,7 +5550,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-spaces
         </p>
@@ -5564,7 +5564,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path stroke="currentColor"
@@ -5575,7 +5575,7 @@ exports[`Components/Icon ProductIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-product-spaces-mono
         </p>
@@ -5607,7 +5607,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#5B64EA"
@@ -5617,7 +5617,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-discord
         </p>
@@ -5631,7 +5631,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -5641,7 +5641,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-discord-mono
         </p>
@@ -5655,7 +5655,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5679,7 +5679,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-facebook
         </p>
@@ -5693,7 +5693,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -5717,7 +5717,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-facebook-mono
         </p>
@@ -5731,7 +5731,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#191717"
@@ -5743,7 +5743,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-github
         </p>
@@ -5757,7 +5757,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -5769,7 +5769,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-github-mono
         </p>
@@ -5783,7 +5783,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#0BAA41"
@@ -5793,7 +5793,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-glassdoor
         </p>
@@ -5807,7 +5807,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -5817,7 +5817,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-glassdoor-mono
         </p>
@@ -5830,7 +5830,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                width="24"
                height="24"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#4285F4"
@@ -5856,7 +5856,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-google
         </p>
@@ -5869,7 +5869,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                width="24"
                height="24"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -5895,7 +5895,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-google-mono
         </p>
@@ -5909,7 +5909,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#1269BF"
@@ -5919,7 +5919,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-linkedin
         </p>
@@ -5933,7 +5933,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -5943,7 +5943,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-linkedin-mono
         </p>
@@ -5957,7 +5957,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#36C5F0"
@@ -5979,7 +5979,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-slack
         </p>
@@ -5993,7 +5993,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -6003,7 +6003,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-slack-mono
         </p>
@@ -6017,7 +6017,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#BBB"
@@ -6033,7 +6033,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-stackoverflow
         </p>
@@ -6047,7 +6047,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -6063,7 +6063,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-stackoverflow-mono
         </p>
@@ -6077,7 +6077,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#2CAAE1"
@@ -6087,7 +6087,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-twitter
         </p>
@@ -6101,7 +6101,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -6111,7 +6111,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-twitter-mono
         </p>
@@ -6125,7 +6125,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -6135,7 +6135,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-x
         </p>
@@ -6149,7 +6149,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -6159,7 +6159,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-x-mono
         </p>
@@ -6173,7 +6173,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#ED1D24"
@@ -6187,7 +6187,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-youtube
         </p>
@@ -6201,7 +6201,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
                height="24"
                fill="none"
                viewbox="0 0 24 24"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -6215,7 +6215,7 @@ exports[`Components/Icon SocialIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-social-youtube-mono
         </p>
@@ -6247,7 +6247,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -6323,7 +6323,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ably
         </p>
@@ -6337,7 +6337,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -6387,7 +6387,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ably-api-streamer
         </p>
@@ -6401,7 +6401,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -6413,7 +6413,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ably-firehose
         </p>
@@ -6427,7 +6427,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -6517,7 +6517,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ably-native
         </p>
@@ -6531,7 +6531,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#C12766"
@@ -6575,7 +6575,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-activemq
         </p>
@@ -6589,7 +6589,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -6650,7 +6650,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-activitypub
         </p>
@@ -6664,7 +6664,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -6688,7 +6688,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-aerospike
         </p>
@@ -6702,7 +6702,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -6726,7 +6726,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-akka
         </p>
@@ -6740,7 +6740,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#D86613"
@@ -6758,7 +6758,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-amazon-ec2
         </p>
@@ -6772,7 +6772,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -6804,7 +6804,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-amazon-event-bridge
         </p>
@@ -6818,7 +6818,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#002B83"
@@ -6848,7 +6848,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-amqp091
         </p>
@@ -6862,7 +6862,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#002B83"
@@ -6892,7 +6892,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-amqp10
         </p>
@@ -6906,7 +6906,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#ABC43E"
@@ -6918,7 +6918,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-android-full
         </p>
@@ -6932,7 +6932,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#3DDC84"
@@ -6942,7 +6942,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-android-head
         </p>
@@ -6956,7 +6956,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#DD0031"
@@ -6974,7 +6974,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-angular
         </p>
@@ -6988,7 +6988,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -7112,7 +7112,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-anycable
         </p>
@@ -7126,7 +7126,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -7205,7 +7205,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-apache-cassandra
         </p>
@@ -7219,7 +7219,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -7598,7 +7598,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-apache-cordova
         </p>
@@ -7612,7 +7612,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -7622,7 +7622,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-apache-kafka
         </p>
@@ -7636,7 +7636,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#E25C26"
@@ -7654,7 +7654,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-apache-spark
         </p>
@@ -7668,7 +7668,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#188FFF"
@@ -7678,7 +7678,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-apachepulsar
         </p>
@@ -7692,7 +7692,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -7730,7 +7730,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-apachestorm
         </p>
@@ -7744,7 +7744,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -7888,7 +7888,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-apns
         </p>
@@ -7902,7 +7902,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#213ED7"
@@ -7916,7 +7916,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-assemblyai
         </p>
@@ -7930,7 +7930,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -7956,7 +7956,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-atmosphere
         </p>
@@ -7970,7 +7970,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#F90"
@@ -7986,7 +7986,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-aws
         </p>
@@ -8000,7 +8000,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8038,7 +8038,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-aws-app-sync
         </p>
@@ -8052,7 +8052,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#3B48CC"
@@ -8086,7 +8086,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-aws-aurora
         </p>
@@ -8100,7 +8100,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8128,7 +8128,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-aws-gateway-websockets
         </p>
@@ -8142,7 +8142,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8178,7 +8178,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-aws-sns
         </p>
@@ -8192,7 +8192,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8238,7 +8238,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-aws-sqs
         </p>
@@ -8252,7 +8252,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8274,7 +8274,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-awsiot
         </p>
@@ -8288,7 +8288,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8338,7 +8338,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-awskinesis
         </p>
@@ -8352,7 +8352,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8380,7 +8380,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-awslambda
         </p>
@@ -8394,7 +8394,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="49"
                fill="none"
                viewbox="0 0 48 49"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8440,7 +8440,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-awssqs
         </p>
@@ -8454,7 +8454,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#59B4D9"
@@ -8472,7 +8472,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-api
         </p>
@@ -8486,7 +8486,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#59B4D9"
@@ -8504,7 +8504,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-archive-api
         </p>
@@ -8518,7 +8518,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -8548,7 +8548,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-bus
         </p>
@@ -8562,7 +8562,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="50"
                fill="none"
                viewbox="0 0 50 50"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#0072C6"
@@ -8599,7 +8599,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-cosmos
         </p>
@@ -8613,7 +8613,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#006FD4"
@@ -8627,7 +8627,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-event-hub
         </p>
@@ -8641,7 +8641,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#3999C6"
@@ -8666,7 +8666,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-functions
         </p>
@@ -8680,7 +8680,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#59B4D9"
@@ -8698,7 +8698,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-search
         </p>
@@ -8712,7 +8712,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#0078D4"
@@ -8774,7 +8774,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-static-web-app
         </p>
@@ -8788,7 +8788,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#3999C6"
@@ -8816,7 +8816,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-static-web-apps
         </p>
@@ -8830,7 +8830,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#0072C6"
@@ -8852,7 +8852,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-storage
         </p>
@@ -8866,7 +8866,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9490,7 +9490,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azure-web-pubsub
         </p>
@@ -9504,7 +9504,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9558,7 +9558,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azurefunctions
         </p>
@@ -9572,7 +9572,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9594,7 +9594,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azureservicebus
         </p>
@@ -9608,7 +9608,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9628,7 +9628,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-azuresignalR
         </p>
@@ -9642,7 +9642,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9668,7 +9668,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-bayeux
         </p>
@@ -9679,7 +9679,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
         <div class="flex">
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-c++
         </p>
@@ -9693,7 +9693,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9729,7 +9729,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-centrifugo
         </p>
@@ -9743,7 +9743,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="44"
                fill="none"
                viewbox="0 0 45 44"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#D97757"
@@ -9753,7 +9753,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-claude
         </p>
@@ -9767,7 +9767,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="44"
                fill="none"
                viewbox="0 0 45 44"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="currentColor"
@@ -9777,7 +9777,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-claude-mono
         </p>
@@ -9791,7 +9791,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -9803,7 +9803,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-client-side-frameworks
         </p>
@@ -9817,7 +9817,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9851,7 +9851,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-clojure
         </p>
@@ -9865,7 +9865,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -9891,7 +9891,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-cloudflare-durable-objects
         </p>
@@ -9905,7 +9905,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10085,7 +10085,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-cloudflareworkers
         </p>
@@ -10099,7 +10099,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10123,7 +10123,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-cocoa
         </p>
@@ -10137,7 +10137,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10162,7 +10162,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-confluent
         </p>
@@ -10176,7 +10176,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10208,7 +10208,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-cord
         </p>
@@ -10222,7 +10222,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10266,7 +10266,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-csharp
         </p>
@@ -10280,7 +10280,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#073551"
@@ -10298,7 +10298,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-curl
         </p>
@@ -10312,7 +10312,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10336,7 +10336,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-customwebhooks
         </p>
@@ -10350,7 +10350,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#632CA6"
@@ -10362,7 +10362,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-datadog
         </p>
@@ -10376,7 +10376,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -10404,7 +10404,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-design-patterns
         </p>
@@ -10418,7 +10418,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -10448,7 +10448,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-devplatforms
         </p>
@@ -10462,7 +10462,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#00AEEF"
@@ -10476,7 +10476,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-diffusion-data
         </p>
@@ -10490,7 +10490,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <rect width="48"
@@ -10508,7 +10508,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-django
         </p>
@@ -10522,7 +10522,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10548,7 +10548,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-engineio
         </p>
@@ -10562,7 +10562,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10596,7 +10596,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-event-driven-servers
         </p>
@@ -10610,7 +10610,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#21A99E"
@@ -10622,7 +10622,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-fanout-io
         </p>
@@ -10636,7 +10636,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10660,7 +10660,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-fast-api
         </p>
@@ -10674,7 +10674,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#3A1AB6"
@@ -10684,7 +10684,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-fauna
         </p>
@@ -10698,7 +10698,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10723,7 +10723,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-featherjs
         </p>
@@ -10737,7 +10737,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10769,7 +10769,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-firebase
         </p>
@@ -10783,7 +10783,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10831,7 +10831,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-firebase-cloud-messaging
         </p>
@@ -10845,7 +10845,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -10918,7 +10918,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-flutter
         </p>
@@ -10932,7 +10932,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#AECBFA"
@@ -10968,7 +10968,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-gcloudbigquery
         </p>
@@ -10982,7 +10982,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11045,7 +11045,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-gclouddataflow
         </p>
@@ -11059,7 +11059,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11091,7 +11091,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-gcloudfunctions
         </p>
@@ -11105,7 +11105,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11190,7 +11190,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-gcloudpubsub
         </p>
@@ -11204,7 +11204,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#00ACD7"
@@ -11222,7 +11222,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-go
         </p>
@@ -11236,7 +11236,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11292,7 +11292,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-grpc
         </p>
@@ -11306,7 +11306,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11348,7 +11348,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-hivemq
         </p>
@@ -11362,7 +11362,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11392,7 +11392,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-http2
         </p>
@@ -11406,7 +11406,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11436,7 +11436,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-http3
         </p>
@@ -11450,7 +11450,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11480,7 +11480,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-httprest
         </p>
@@ -11494,7 +11494,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11526,7 +11526,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-idempotency
         </p>
@@ -11540,7 +11540,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#000"
@@ -11550,7 +11550,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ifttt
         </p>
@@ -11564,7 +11564,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -11576,7 +11576,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-integrations
         </p>
@@ -11590,7 +11590,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11616,7 +11616,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ios
         </p>
@@ -11630,7 +11630,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11652,7 +11652,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ios-generic
         </p>
@@ -11666,7 +11666,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11688,7 +11688,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ipados
         </p>
@@ -11702,7 +11702,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#4D9EA1"
@@ -11734,7 +11734,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ipfs
         </p>
@@ -11748,7 +11748,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11768,7 +11768,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ironmq
         </p>
@@ -11782,7 +11782,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11840,7 +11840,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-java
         </p>
@@ -11854,7 +11854,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11878,7 +11878,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-javascript
         </p>
@@ -11892,7 +11892,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11918,7 +11918,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-jms
         </p>
@@ -11932,7 +11932,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -11958,7 +11958,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-json
         </p>
@@ -11972,7 +11972,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#fff"
@@ -12008,7 +12008,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-json-web-tokens
         </p>
@@ -12022,7 +12022,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12049,7 +12049,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-kaazing
         </p>
@@ -12063,7 +12063,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12159,7 +12159,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-kotlin
         </p>
@@ -12173,7 +12173,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#F3555F"
@@ -12183,7 +12183,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ksql-db
         </p>
@@ -12197,7 +12197,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#326CE5"
@@ -12213,7 +12213,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-kubernetes
         </p>
@@ -12227,7 +12227,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#FF2D20"
@@ -12239,7 +12239,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-laravel-broadcast
         </p>
@@ -12253,7 +12253,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12299,7 +12299,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-laravel-echo
         </p>
@@ -12313,7 +12313,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#B5CE87"
@@ -12391,7 +12391,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-lightstreamer
         </p>
@@ -12405,7 +12405,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -12417,7 +12417,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-liveblocks
         </p>
@@ -12431,7 +12431,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12468,7 +12468,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-longpolling
         </p>
@@ -12482,7 +12482,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12504,7 +12504,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-macos
         </p>
@@ -12518,7 +12518,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#040404"
@@ -12528,7 +12528,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-matrix
         </p>
@@ -12542,7 +12542,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12564,7 +12564,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-meteor
         </p>
@@ -12578,7 +12578,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#001E2B"
@@ -12588,7 +12588,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-mongo-db
         </p>
@@ -12602,7 +12602,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12622,7 +12622,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-mono
         </p>
@@ -12636,7 +12636,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#721274"
@@ -12654,7 +12654,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-mqtt
         </p>
@@ -12668,7 +12668,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#00678C"
@@ -12680,7 +12680,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-mysql
         </p>
@@ -12694,7 +12694,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#fff"
@@ -12708,7 +12708,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-native-script
         </p>
@@ -12722,7 +12722,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12746,7 +12746,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-net
         </p>
@@ -12760,7 +12760,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <mask id="mask0_1031_1919"
@@ -12789,7 +12789,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-netlify
         </p>
@@ -12803,7 +12803,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12884,7 +12884,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-nextjs
         </p>
@@ -12898,7 +12898,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#253A7E"
@@ -12908,7 +12908,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-nkn
         </p>
@@ -12922,7 +12922,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -12999,7 +12999,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-nodejs
         </p>
@@ -13013,7 +13013,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13033,7 +13033,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-objectivec
         </p>
@@ -13047,7 +13047,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <g clip-path="url(#a)">
@@ -13059,7 +13059,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-openai
         </p>
@@ -13073,7 +13073,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#169CEE"
@@ -13083,7 +13083,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-parse-server
         </p>
@@ -13097,7 +13097,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#000"
@@ -13119,7 +13119,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-php
         </p>
@@ -13133,7 +13133,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#1A1B21"
@@ -13143,7 +13143,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-planetscale
         </p>
@@ -13157,7 +13157,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#000"
@@ -13199,7 +13199,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-postgres
         </p>
@@ -13213,7 +13213,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#16BD77"
@@ -13225,7 +13225,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-prisma
         </p>
@@ -13239,7 +13239,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13265,7 +13265,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-programminglanguages
         </p>
@@ -13279,7 +13279,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -13291,7 +13291,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-protcol-adaptors
         </p>
@@ -13305,7 +13305,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13340,7 +13340,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-protocols
         </p>
@@ -13354,7 +13354,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -13392,7 +13392,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-pub-sub
         </p>
@@ -13406,7 +13406,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13428,7 +13428,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-pubnub
         </p>
@@ -13442,7 +13442,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13464,7 +13464,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-push-technology
         </p>
@@ -13478,7 +13478,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#2E124E"
@@ -13488,7 +13488,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-pusher
         </p>
@@ -13502,7 +13502,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13579,7 +13579,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-python
         </p>
@@ -13593,7 +13593,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#27475D"
@@ -13607,7 +13607,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-quic
         </p>
@@ -13621,7 +13621,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#F60"
@@ -13633,7 +13633,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-rabbitMQ
         </p>
@@ -13647,7 +13647,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13675,7 +13675,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-railsactioncable
         </p>
@@ -13689,7 +13689,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13711,7 +13711,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-react
         </p>
@@ -13725,7 +13725,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -13747,7 +13747,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-react-app
         </p>
@@ -13761,7 +13761,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#61DAFB"
@@ -13775,7 +13775,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-reactnative
         </p>
@@ -13789,7 +13789,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#912626"
@@ -13831,7 +13831,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-redis
         </p>
@@ -13845,7 +13845,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#310401"
@@ -14055,7 +14055,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-redpanda
         </p>
@@ -14069,7 +14069,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -14157,7 +14157,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-replicache
         </p>
@@ -14171,7 +14171,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -14195,7 +14195,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-rethinkdb
         </p>
@@ -14209,7 +14209,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#D77310"
@@ -14219,7 +14219,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-rocketmq
         </p>
@@ -14233,7 +14233,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -14713,7 +14713,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-ruby
         </p>
@@ -14727,7 +14727,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -14829,7 +14829,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-scala
         </p>
@@ -14843,7 +14843,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -14889,7 +14889,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-scaledrone
         </p>
@@ -14903,7 +14903,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -14929,7 +14929,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-serversentevents
         </p>
@@ -14943,7 +14943,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -14965,7 +14965,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-serversideframeworks
         </p>
@@ -14979,7 +14979,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -14999,7 +14999,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-signalR
         </p>
@@ -15013,7 +15013,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15035,7 +15035,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-snowflake
         </p>
@@ -15049,7 +15049,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15073,7 +15073,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-socketio
         </p>
@@ -15087,7 +15087,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15107,7 +15107,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-sockjs
         </p>
@@ -15121,7 +15121,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15143,7 +15143,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-solace
         </p>
@@ -15157,7 +15157,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15177,7 +15177,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-spring
         </p>
@@ -15191,7 +15191,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#010101"
@@ -15253,7 +15253,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-stomp
         </p>
@@ -15267,7 +15267,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15289,7 +15289,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-streamdata-io
         </p>
@@ -15303,7 +15303,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15323,7 +15323,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-streamr
         </p>
@@ -15337,7 +15337,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15396,7 +15396,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-swift
         </p>
@@ -15410,7 +15410,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15432,7 +15432,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-symfony
         </p>
@@ -15446,7 +15446,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15501,7 +15501,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-symfony-mercure
         </p>
@@ -15515,7 +15515,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15537,7 +15537,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-tcp-ip
         </p>
@@ -15551,7 +15551,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15617,7 +15617,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-tenefit
         </p>
@@ -15631,7 +15631,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#7A50BA"
@@ -15641,7 +15641,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-terraform
         </p>
@@ -15655,7 +15655,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15677,7 +15677,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-tvos
         </p>
@@ -15691,7 +15691,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15711,7 +15711,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-twilio
         </p>
@@ -15725,7 +15725,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15751,7 +15751,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-typescript
         </p>
@@ -15765,7 +15765,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15787,7 +15787,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-udp-protocol
         </p>
@@ -15801,7 +15801,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#4C4C4C"
@@ -15823,7 +15823,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-unity
         </p>
@@ -15837,7 +15837,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#000"
@@ -15847,7 +15847,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-vercel
         </p>
@@ -15861,7 +15861,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="66"
                fill="none"
                viewbox="0 0 66 66"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -15976,7 +15976,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-vscode
         </p>
@@ -15990,7 +15990,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#41B883"
@@ -16004,7 +16004,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-vuejs
         </p>
@@ -16018,7 +16018,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#F09"
@@ -16032,7 +16032,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-wamp
         </p>
@@ -16046,7 +16046,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16068,7 +16068,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-watchos
         </p>
@@ -16082,7 +16082,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#03020D"
@@ -16098,7 +16098,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-web
         </p>
@@ -16112,7 +16112,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16138,7 +16138,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-web-push
         </p>
@@ -16152,7 +16152,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16180,7 +16180,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-webhooks
         </p>
@@ -16194,7 +16194,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#F60"
@@ -16244,7 +16244,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-webrtc
         </p>
@@ -16258,7 +16258,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <path fill="#231F20"
@@ -16270,7 +16270,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-websockets
         </p>
@@ -16284,7 +16284,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16309,7 +16309,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-websub
         </p>
@@ -16323,7 +16323,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16343,7 +16343,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-xamarin
         </p>
@@ -16357,7 +16357,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16383,7 +16383,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-xhr-streaming
         </p>
@@ -16397,7 +16397,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16469,7 +16469,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-xmpp
         </p>
@@ -16483,7 +16483,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16503,7 +16503,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-zapier
         </p>
@@ -16517,7 +16517,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
                height="48"
                fill="none"
                viewbox="0 0 48 48"
-               class="hover:text-active-orange text-neutral-1300 dark:text-neutral-000 transition-colors"
+               class="hover:text-active-orange text-ably-primary transition-colors"
                style="width: 24px; height: 24px;"
           >
             <defs>
@@ -16542,7 +16542,7 @@ exports[`Components/Icon TechIcons smoke-test 1`] = `
           </svg>
         </div>
       </div>
-      <code class="ui-text-code2 text-neutral-1300 dark:text-neutral-000 text-center flex flex-col items-center justify-center flex-1 gap-4">
+      <code class="ui-text-code2 text-ably-primary text-center flex flex-col items-center justify-center flex-1 gap-4">
         <p>
           icon-tech-zeromq
         </p>

--- a/src/core/Logo.tsx
+++ b/src/core/Logo.tsx
@@ -72,7 +72,7 @@ const Logo = ({
       <img src={logoSrc} width="96px" alt={logoAlt} {...additionalImgAttrs} />
       {badge && (
         <Badge
-          className="uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-neutral-800 dark:text-neutral-500"
+          className="uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-ably-tertiary"
           childClassName="tracking-[0.01em]"
         >
           {badge}

--- a/src/core/Logo/__snapshots__/Logo.stories.tsx.snap
+++ b/src/core/Logo/__snapshots__/Logo.stories.tsx.snap
@@ -96,7 +96,7 @@ exports[`Components/Logo WithBadge smoke-test 1`] = `
          width="96px"
          alt="Ably logo"
     >
-    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-neutral-800 dark:text-neutral-500">
+    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none dark:text-neutral-400 uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-ably-tertiary">
       <span class="whitespace-nowrap leading-[20px] tracking-[0.01em]">
         docs
       </span>
@@ -109,7 +109,7 @@ exports[`Components/Logo WithBadge smoke-test 1`] = `
          width="96px"
          alt="Ably logo"
     >
-    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-neutral-800 dark:text-neutral-500">
+    <div class="inline-flex gap-1 items-center focus-base transition-colors select-none dark:text-neutral-400 uppercase h-[25px] px-1.5 py-[3px] bg-transparent mt-[2px] dark:bg-transparent rounded-[4px] border border-neutral-400 dark:border-neutral-900 text-sm font-semibold text-ably-tertiary">
       <span class="whitespace-nowrap leading-[20px] tracking-[0.01em]">
         docs
       </span>

--- a/src/core/Meganav.tsx
+++ b/src/core/Meganav.tsx
@@ -56,11 +56,11 @@ const Meganav = ({
     },
     {
       id: "main",
-      className: "ui-theme-light bg-neutral-000 dark:bg-neutral-1300 border-b",
+      className: "ui-theme-light bg-ably-primary-inverse border-b",
     },
     {
       id: "main-theme-dark",
-      className: "ui-theme-dark bg-neutral-000 dark:bg-neutral-1300 border-b",
+      className: "ui-theme-dark bg-ably-primary-inverse border-b",
     },
   ];
 
@@ -93,7 +93,7 @@ const Meganav = ({
               menuItems={menuItemsForHeader}
               className="justify-left z-40"
               flyOutClassName="flex justify-left"
-              viewPortClassName="ui-shadow-lg-medium border border-neutral-200 dark:border-neutral-1100 rounded-2xl -mt-1 bg-neutral-000 dark:bg-neutral-1300"
+              viewPortClassName="ui-shadow-lg-medium border border-neutral-200 dark:border-neutral-1100 rounded-2xl -mt-1 bg-ably-primary-inverse"
             />
           }
           mobileNav={<MeganavMobile navItems={mobileNavItems} />}

--- a/src/core/Meganav.tsx
+++ b/src/core/Meganav.tsx
@@ -93,7 +93,7 @@ const Meganav = ({
               menuItems={menuItemsForHeader}
               className="justify-left z-40"
               flyOutClassName="flex justify-left"
-              viewPortClassName="ui-shadow-lg-medium border border-neutral-200 dark:border-neutral-1100 rounded-2xl -mt-1 bg-ably-primary-inverse"
+              viewPortClassName="ui-shadow-lg-medium border border-ably-primary-inverse-active rounded-2xl -mt-1 bg-ably-primary-inverse"
             />
           }
           mobileNav={<MeganavMobile navItems={mobileNavItems} />}

--- a/src/core/Meganav/MeganavMobile.tsx
+++ b/src/core/Meganav/MeganavMobile.tsx
@@ -22,7 +22,7 @@ export const MeganavMobile = ({ navItems }: { navItems: AccordionData[] }) => {
           hideBorders: true,
           headerCSS: `px-0 ${menuItemClassname}`,
           contentCSS: "px-0",
-          selectedHeaderCSS: "text-neutral-1300 dark:text-neutral-000",
+          selectedHeaderCSS: "text-ably-primary",
           rowIconSize: "24px",
         }}
       />

--- a/src/core/Meganav/MeganavPanel.tsx
+++ b/src/core/Meganav/MeganavPanel.tsx
@@ -21,7 +21,7 @@ export const MeganavPanel = ({
   panelRightBottom?: React.ReactNode;
 }) => {
   return (
-    <div className="flex flex-col md:flex-row gap-x-6 bg-neutral-000 dark:bg-neutral-1300">
+    <div className="flex flex-col md:flex-row gap-x-6 bg-ably-primary-inverse">
       <div
         className={cn(
           "flex-[7] flex-shrink-0 group",
@@ -44,13 +44,13 @@ export const MeganavPanel = ({
                 href={panelLeft.url}
               >
                 <span className="block w-full p-6">
-                  <h4 className="ui-text-h4 text-neutral-1300 dark:text-neutral-000">
+                  <h4 className="ui-text-h4 text-ably-primary">
                     {panelLeft.heading}
                   </h4>
-                  <span className="block ui-text-p3 text-neutral-800 dark:text-neutral-500 mt-2">
+                  <span className="block ui-text-p3 text-ably-tertiary mt-2">
                     {panelLeft.content}
                   </span>
-                  <span className="py-2 font-sans font-bold block group/featured-link text-neutral-1300 dark:text-neutral-000 mt-4 ui-text-p3 hover:text-neutral-1300 dark:hover:text-neutral-000">
+                  <span className="py-2 font-sans font-bold block group/featured-link text-ably-primary mt-4 ui-text-p3 hover:text-ably-primary">
                     {panelLeft.labelLink}
                     <Icon
                       name="icon-gui-arrow-long-right-outline"
@@ -76,7 +76,7 @@ export const MeganavPanel = ({
       <div className="flex-[3] flex-shrink-0 flex flex-col justify-between">
         <ul>
           {panelRightHeading && (
-            <p className="ui-text-overline2 text-neutral-700 dark:text-neutral-600 my-3">
+            <p className="ui-text-overline2 text-ably-label my-3">
               {panelRightHeading}
             </p>
           )}
@@ -92,10 +92,10 @@ export const MeganavPanel = ({
               <Icon
                 name={item.icon}
                 size="1.25rem"
-                additionalCSS="text-neutral-1000 dark:text-neutral-300"
+                additionalCSS="text-ably-secondary"
               />
               <a
-                className="pointer-events-auto ui-text-label2 md:ui-text-label3 font-semibold text-neutral-1000 dark:text-neutral-300 group-hover:text-neutral-1300 dark:group-hover:text-neutral-000"
+                className="pointer-events-auto ui-text-label2 md:ui-text-label3 font-semibold text-ably-secondary group-hover:text-ably-primary"
                 href={item.link}
               >
                 {item.label}

--- a/src/core/Meganav/MeganavProductTile.tsx
+++ b/src/core/Meganav/MeganavProductTile.tsx
@@ -26,7 +26,7 @@ const MeganavProductTile = ({
       className={cn(
         "transition-colors group/product-tile",
         "flex flex-col p-3 rounded-lg gap-2",
-        "bg-neutral-000 dark:bg-neutral-1300",
+        "bg-ably-primary-inverse",
         {
           "hover:bg-neutral-100 dark:hover:bg-neutral-1200": !unavailable,
         },

--- a/src/core/Meganav/MeganavProductTile.tsx
+++ b/src/core/Meganav/MeganavProductTile.tsx
@@ -28,7 +28,7 @@ const MeganavProductTile = ({
         "flex flex-col p-3 rounded-lg gap-2",
         "bg-ably-primary-inverse",
         {
-          "hover:bg-neutral-100 dark:hover:bg-neutral-1200": !unavailable,
+          "hover:bg-ably-primary-inverse-accent": !unavailable,
         },
         { "pointer-events-auto": !unavailable },
         { "pointer-events-none": unavailable },

--- a/src/core/Meganav/data.tsx
+++ b/src/core/Meganav/data.tsx
@@ -36,7 +36,7 @@ export type MenuItem = {
 const panelClassName = "w-full sm:w-[50.9375rem]";
 
 const panelLeftFeatureClassName =
-  "bg-neutral-100 dark:bg-neutral-1200 hidden md:grid border border-neutral-300 dark:border-neutral-1000 hover:border-neutral-400 dark:hover:border-neutral-800 rounded-lg cursor-pointer group/meganav-panel";
+  "bg-neutral-100 dark:bg-neutral-1200 hidden md:grid border border-ably-secondary-inverse hover:border-neutral-400 dark:hover:border-neutral-800 rounded-lg cursor-pointer group/meganav-panel";
 
 const productsMenu: FlyoutPanelList[] = [
   {

--- a/src/core/Meganav/data.tsx
+++ b/src/core/Meganav/data.tsx
@@ -36,7 +36,7 @@ export type MenuItem = {
 const panelClassName = "w-full sm:w-[50.9375rem]";
 
 const panelLeftFeatureClassName =
-  "bg-neutral-100 dark:bg-neutral-1200 hidden md:grid border border-ably-secondary-inverse hover:border-neutral-400 dark:hover:border-neutral-800 rounded-lg cursor-pointer group/meganav-panel";
+  "bg-ably-primary-inverse-accent hidden md:grid border border-ably-secondary-inverse hover:border-neutral-400 dark:hover:border-neutral-800 rounded-lg cursor-pointer group/meganav-panel";
 
 const productsMenu: FlyoutPanelList[] = [
   {

--- a/src/core/Notice.tsx
+++ b/src/core/Notice.tsx
@@ -39,7 +39,7 @@ export type NoticeProps = {
   options?: { collapse: boolean };
 };
 
-const defaultTextColor = "text-neutral-1300 dark:text-neutral-000";
+const defaultTextColor = "text-ably-primary";
 
 const contentWrapperClasses = "w-full pr-2 ui-text-p4 self-center";
 

--- a/src/core/Notice/Notice.stories.tsx
+++ b/src/core/Notice/Notice.stories.tsx
@@ -8,7 +8,7 @@ export default {
     buttonLink: "/",
     title: "Flashy title",
     bodyText: "This is a notice",
-    textColor: "text-neutral-1300 dark:text-neutral-000",
+    textColor: "text-ably-primary",
     closeBtn: true,
   },
 };

--- a/src/core/Notice/__snapshots__/Notice.stories.tsx.snap
+++ b/src/core/Notice/__snapshots__/Notice.stories.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Notice Default smoke-test 1`] = `
-<div class="ui-announcement bg-orange-100 dark:bg-orange-1100 text-neutral-1300 dark:text-neutral-000"
+<div class="ui-announcement bg-orange-100 dark:bg-orange-1100 text-ably-primary"
      data-id="ui-notice"
      style
 >
   <div class="ui-grid-px py-4 max-w-screen-xl mx-auto flex items-start">
     <a href="/"
-       class="w-full pr-2 ui-text-p4 self-center text-neutral-1300 dark:text-neutral-000"
+       class="w-full pr-2 ui-text-p4 self-center text-ably-primary"
     >
       <strong class="font-bold whitespace-nowrap pr-1">
         Flashy title
@@ -26,7 +26,7 @@ exports[`Components/Notice Default smoke-test 1`] = `
            stroke="currentColor"
            aria-hidden="true"
            data-slot="icon"
-           class="text-neutral-1300 dark:text-neutral-000"
+           class="text-ably-primary"
            style="width: 1.25rem; height: 1.25rem;"
       >
         <path stroke-linecap="round"
@@ -41,13 +41,13 @@ exports[`Components/Notice Default smoke-test 1`] = `
 `;
 
 exports[`Components/Notice RailsUjs smoke-test 1`] = `
-<div class="ui-announcement bg-orange-100 dark:bg-orange-1100 text-neutral-1300 dark:text-neutral-000"
+<div class="ui-announcement bg-orange-100 dark:bg-orange-1100 text-ably-primary"
      data-id="ui-notice"
      style
 >
   <div class="ui-grid-px py-4 max-w-screen-xl mx-auto flex items-start">
     <a href="/"
-       class="w-full pr-2 ui-text-p4 self-center text-neutral-1300 dark:text-neutral-000"
+       class="w-full pr-2 ui-text-p4 self-center text-ably-primary"
     >
       <strong class="font-bold whitespace-nowrap pr-1">
         With Rails UJS
@@ -71,7 +71,7 @@ exports[`Components/Notice RailsUjs smoke-test 1`] = `
            stroke="currentColor"
            aria-hidden="true"
            data-slot="icon"
-           class="text-neutral-1300 dark:text-neutral-000"
+           class="text-ably-primary"
            style="width: 1.25rem; height: 1.25rem;"
       >
         <path stroke-linecap="round"

--- a/src/core/Pricing/PricingCards.tsx
+++ b/src/core/Pricing/PricingCards.tsx
@@ -110,9 +110,9 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
               {delimiterColumn(index)}
               <div
                 className={cn(
-                  "relative border flex-1 px-6 pt-6 pb-4 flex flex-col gap-6 rounded-2xl group min-w-[17rem] backdrop-blur bg-neutral-100 dark:bg-neutral-1200",
+                  "relative border flex-1 px-6 pt-6 pb-4 flex flex-col gap-6 rounded-2xl group min-w-[17rem] backdrop-blur bg-ably-primary-inverse-accent",
                   borderClasses(border?.color)?.border ??
-                    "border-neutral-200 dark:border-neutral-1100",
+                    "border-ably-primary-inverse-active",
                   border?.style,
                   { "@[520px]:flex-row @[920px]:flex-col": delimiter },
                 )}
@@ -257,7 +257,7 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
 
                 {bottomCta && (
                   <div>
-                    <div className="border-t border-neutral-200 dark:border-neutral-1100 -mx-6"></div>
+                    <div className="border-t border-ably-primary-inverse-active -mx-6"></div>
                     <a
                       href={bottomCta.url}
                       className={cn(

--- a/src/core/Pricing/PricingCards.tsx
+++ b/src/core/Pricing/PricingCards.tsx
@@ -50,7 +50,7 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
           <Icon
             name={delimiter}
             size="20px"
-            additionalCSS={"text-neutral-800 dark:text-neutral-500"}
+            additionalCSS={"text-ably-tertiary"}
           />
         ) : null}
       </div>
@@ -169,10 +169,10 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
                         delimiter,
                     })}
                   >
-                    <p className="ui-text-h1 text-h1-xl font-medium tracking-tight leading-none text-neutral-1300 dark:text-neutral-000">
+                    <p className="ui-text-h1 text-h1-xl font-medium tracking-tight leading-none text-ably-primary">
                       {price.amount}
                     </p>
-                    <div className="ui-text-p3 text-neutral-1300 dark:text-neutral-000">
+                    <div className="ui-text-p3 text-ably-primary">
                       {price.content}
                     </div>
                   </div>
@@ -199,7 +199,7 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
                 <div className="flex flex-col gap-4 relative z-10 flex-grow">
                   {sections.map(({ title, items, listItemColors }) => (
                     <div key={title} className="flex flex-col gap-3">
-                      <p className="text-neutral-700 dark:text-neutral-600 font-mono uppercase text-overline2 font-medium tracking-[0.12em] h-4">
+                      <p className="text-ably-label font-mono uppercase text-overline2 font-medium tracking-[0.12em] h-4">
                         {title}
                       </p>
                       <div className={cn({ "flex flex-col": !delimiter })}>
@@ -221,7 +221,7 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
                                   className={cn(
                                     "ui-text-p3",
                                     index === 0 ? "font-bold" : "font-medium",
-                                    "text-neutral-1000 dark:text-neutral-300 leading-[1.4rem]",
+                                    "text-ably-secondary leading-[1.4rem]",
                                     subIndex % 2 === 1 ? "text-right" : "",
                                   )}
                                 >
@@ -242,7 +242,7 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
                               ) : null}
                               <div
                                 className={cn(
-                                  `flex-1 font-medium text-neutral-1000 dark:text-neutral-300 ui-text-p3`,
+                                  `flex-1 font-medium text-ably-secondary ui-text-p3`,
                                 )}
                               >
                                 {item}
@@ -262,7 +262,7 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
                       href={bottomCta.url}
                       className={cn(
                         "text-[13px] font-sans font-semibold group/bottom-cta cursor-pointer pt-4 flex items-center",
-                        "text-neutral-700 dark:text-neutral-600 hover:text-neutral-1300 dark:hover:text-neutral-000 focus:outline-none focus-visible:outline-gui-focus",
+                        "text-ably-label hover:text-ably-primary focus:outline-none focus-visible:outline-gui-focus",
                       )}
                     >
                       {bottomCta.text}

--- a/src/core/Pricing/data.tsx
+++ b/src/core/Pricing/data.tsx
@@ -7,18 +7,18 @@ export const planData: PricingDataFeature[] = [
     title: {
       content: "Free",
       className: "ui-text-h4 tracking-[-0.002rem]",
-      color: "text-neutral-1300 dark:text-neutral-000",
+      color: "text-ably-primary",
     },
     description: {
       content: "Build a proof of concept.",
       className: "ui-text-p3",
-      color: "text-neutral-700 dark:text-neutral-600",
+      color: "text-ably-label",
     },
     price: { amount: "$0" },
     cta: {
       text: "Start for free",
       url: "/sign-up",
-      iconColor: "text-neutral-600 dark:text-neutral-700",
+      iconColor: "text-ably-label-inverse",
     },
     sections: [
       {
@@ -37,7 +37,7 @@ export const planData: PricingDataFeature[] = [
           "No commitment",
         ],
         listItemColors: {
-          foreground: "text-neutral-700 dark:text-neutral-600",
+          foreground: "text-ably-label",
           background: "text-neutral-100 dark:text-neutral-1200",
         },
       },
@@ -51,12 +51,12 @@ export const planData: PricingDataFeature[] = [
     title: {
       content: "Standard",
       className: "ui-text-h4 tracking-[-0.002rem]",
-      color: "text-neutral-1300 dark:text-neutral-000",
+      color: "text-ably-primary",
     },
     description: {
       content: "Roll-out into production.",
       className: "ui-text-p3",
-      color: "text-neutral-700 dark:text-neutral-600",
+      color: "text-ably-label",
     },
     price: {
       amount: "$29",
@@ -84,7 +84,7 @@ export const planData: PricingDataFeature[] = [
     cta: {
       text: "Get started",
       url: "/users/paid_sign_up?package=standard",
-      iconColor: "text-neutral-600 dark:text-neutral-700",
+      iconColor: "text-ably-label-inverse",
     },
     sections: [
       {
@@ -103,7 +103,7 @@ export const planData: PricingDataFeature[] = [
           "Uptime SLO",
         ],
         listItemColors: {
-          foreground: "text-neutral-700 dark:text-neutral-600",
+          foreground: "text-ably-label",
           background: "text-neutral-100 dark:text-neutral-1200",
         },
       },
@@ -117,12 +117,12 @@ export const planData: PricingDataFeature[] = [
     title: {
       content: "Pro",
       className: "ui-text-h4 tracking-[-0.002rem]",
-      color: "text-neutral-1300 dark:text-neutral-000",
+      color: "text-ably-primary",
     },
     description: {
       content: "Scale business critical workloads.",
       className: "ui-text-p3",
-      color: "text-neutral-700 dark:text-neutral-600",
+      color: "text-ably-label",
     },
     price: {
       amount: "$399",
@@ -150,7 +150,7 @@ export const planData: PricingDataFeature[] = [
     cta: {
       text: "Get started",
       url: "/users/paid_sign_up?package=pro",
-      iconColor: "text-neutral-600 dark:text-neutral-700",
+      iconColor: "text-ably-label-inverse",
     },
     sections: [
       {
@@ -170,7 +170,7 @@ export const planData: PricingDataFeature[] = [
           "Uptime SLO",
         ],
         listItemColors: {
-          foreground: "text-neutral-700 dark:text-neutral-600",
+          foreground: "text-ably-label",
           background: "text-neutral-100 dark:text-neutral-1200",
         },
       },
@@ -190,7 +190,7 @@ export const planData: PricingDataFeature[] = [
     description: {
       content: "Serious workloads without limits.",
       className: "ui-text-p3",
-      color: "text-neutral-700 dark:text-neutral-600",
+      color: "text-ably-label",
     },
     price: { amount: "Custom" },
     cta: {
@@ -218,7 +218,7 @@ export const planData: PricingDataFeature[] = [
           "CNAME, SSO, & more",
         ],
         listItemColors: {
-          foreground: "text-orange-700 dark:text-orange-500",
+          foreground: "text-ably-label",
           background: "text-neutral-100 dark:text-neutral-1200",
         },
       },
@@ -235,13 +235,13 @@ export const consumptionData: PricingDataFeature[] = [
     title: {
       content: "Messages",
       className: "ui-text-h3",
-      color: "text-neutral-1300 dark:text-neutral-000",
+      color: "text-ably-primary",
     },
     description: {
       content:
         "Messages contain the data that a client is communicating, such as the contents of a chat message.",
       className: "ui-text-p3",
-      color: "text-neutral-700 dark:text-neutral-600",
+      color: "text-ably-label",
     },
     price: { amount: "$2.50", content: "/ million" },
     sections: [
@@ -264,7 +264,7 @@ export const consumptionData: PricingDataFeature[] = [
     title: {
       content: "Channels",
       className: "ui-text-h3",
-      color: "text-neutral-1300 dark:text-neutral-000",
+      color: "text-ably-primary",
       tooltip: (
         <p>
           We charge you for the amount of time a channel is active in our
@@ -277,7 +277,7 @@ export const consumptionData: PricingDataFeature[] = [
       content:
         "Channels are used to route messages from publishers to subscribers. Channels are billed by the minute when actively being used by a connected client.",
       className: "ui-text-p3",
-      color: "text-neutral-700 dark:text-neutral-600",
+      color: "text-ably-label",
     },
     price: { amount: "$1.00", content: "/ million mins" },
     sections: [
@@ -300,7 +300,7 @@ export const consumptionData: PricingDataFeature[] = [
     title: {
       content: "Connections",
       className: "ui-text-h3",
-      color: "text-neutral-1300 dark:text-neutral-000",
+      color: "text-ably-primary",
       tooltip: (
         <p>
           We charge you for the amount of time devices are connected to our
@@ -313,7 +313,7 @@ export const consumptionData: PricingDataFeature[] = [
       content:
         "Clients establish and maintain a connection to the Ably service, typically over WebSockets.",
       className: "ui-text-p3",
-      color: "text-neutral-700 dark:text-neutral-600",
+      color: "text-ably-label",
     },
     price: { amount: "$1.00", content: "/ million mins" },
     sections: [

--- a/src/core/Pricing/data.tsx
+++ b/src/core/Pricing/data.tsx
@@ -38,7 +38,7 @@ export const planData: PricingDataFeature[] = [
         ],
         listItemColors: {
           foreground: "text-ably-label",
-          background: "text-neutral-100 dark:text-neutral-1200",
+          background: "text-ably-primary-inverse-accent",
         },
       },
     ],
@@ -104,7 +104,7 @@ export const planData: PricingDataFeature[] = [
         ],
         listItemColors: {
           foreground: "text-ably-label",
-          background: "text-neutral-100 dark:text-neutral-1200",
+          background: "text-ably-primary-inverse-accent",
         },
       },
     ],
@@ -171,7 +171,7 @@ export const planData: PricingDataFeature[] = [
         ],
         listItemColors: {
           foreground: "text-ably-label",
-          background: "text-neutral-100 dark:text-neutral-1200",
+          background: "text-ably-primary-inverse-accent",
         },
       },
     ],
@@ -219,7 +219,7 @@ export const planData: PricingDataFeature[] = [
         ],
         listItemColors: {
           foreground: "text-ably-label",
-          background: "text-neutral-100 dark:text-neutral-1200",
+          background: "text-ably-primary-inverse-accent",
         },
       },
     ],

--- a/src/core/Pricing/types.ts
+++ b/src/core/Pricing/types.ts
@@ -21,7 +21,10 @@ type PricingDataFeatureCta = {
 export type PricingDataFeatureSection = {
   title: string;
   items: string[] | string[][];
-  listItemColors?: { foreground: ColorThemeSet; background: ColorThemeSet };
+  listItemColors?: {
+    foreground: ColorClass | ColorThemeSet;
+    background: ColorClass | ColorThemeSet;
+  };
 };
 
 export type PricingDataFeatureBorder = {

--- a/src/core/ProductTile.tsx
+++ b/src/core/ProductTile.tsx
@@ -103,7 +103,7 @@ const ProductTile = ({
           "bg-ably-primary-inverse": !selected,
         },
         {
-          "hover:bg-neutral-100 dark:hover:bg-neutral-1200":
+          "hover:bg-ably-primary-inverse-accent":
             selected === false && !unavailable,
         },
         { "cursor-pointer": selected !== undefined && !unavailable },

--- a/src/core/ProductTile.tsx
+++ b/src/core/ProductTile.tsx
@@ -98,9 +98,9 @@ const ProductTile = ({
       className={cn(
         "transition-colors group/product-tile",
         { "flex flex-col p-3 rounded-lg gap-2": containerPresent },
-        { "bg-neutral-1300 dark:bg-neutral-000": selected },
+        { "bg-ably-primary": selected },
         {
-          "bg-neutral-000 dark:bg-neutral-1300": !selected,
+          "bg-ably-primary-inverse": !selected,
         },
         {
           "hover:bg-neutral-100 dark:hover:bg-neutral-1200":
@@ -150,7 +150,7 @@ const ProductTile = ({
         <LinkButton
           variant="secondary"
           size="xs"
-          className="mt-2 !text-neutral-000 dark:!text-neutral-1300"
+          className="mt-2 !text-ably-primary-inverse"
           rightIcon="icon-gui-arrow-right-micro"
           iconColor="text-orange-600"
           href={link}

--- a/src/core/ProductTile/ProductDescription.tsx
+++ b/src/core/ProductTile/ProductDescription.tsx
@@ -25,10 +25,10 @@ const ProductDescription = ({
       className={cn(
         "block ui-text-p3 font-medium leading-snug",
         {
-          "text-neutral-300 dark:text-neutral-1000": selected && !unavailable,
+          "text-ably-secondary-inverse": selected && !unavailable,
         },
         {
-          "text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300":
+          "text-ably-tertiary group-hover/product-tile:text-ably-secondary":
             !selected,
         },
         className,

--- a/src/core/ProductTile/ProductIcon.tsx
+++ b/src/core/ProductTile/ProductIcon.tsx
@@ -44,7 +44,7 @@ const ProductIcon = ({
         className={cn("flex items-center justify-center", {
           "bg-neutral-1200 dark:bg-neutral-100": selected,
           "bg-neutral-100 dark:bg-neutral-1200": !selected,
-          "group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300":
+          "group-hover/product-tile:bg-ably-primary-inverse":
             selected === false && !unavailable,
         })}
         style={{ height: innerSize, borderRadius: size / 4 }}
@@ -64,11 +64,10 @@ const ProductIcon = ({
           name={name}
           size={`${iconSize}px`}
           additionalCSS={cn({
-            "text-neutral-000 dark:text-neutral-1300": selected && !unavailable,
-            "text-neutral-1300 dark:text-neutral-000":
-              !selected && !unavailable,
-            "text-neutral-700 dark:text-neutral-600": selected && unavailable,
-            "text-neutral-600 dark:text-neutral-700": !selected && unavailable,
+            "text-ably-primary-inverse": selected && !unavailable,
+            "text-ably-primary": !selected && !unavailable,
+            "text-ably-label": selected && unavailable,
+            "text-ably-label-inverse": !selected && unavailable,
             "flex group-hover/product-tile:hidden": hoverName && !selected,
             hidden: hoverName && selected,
           })}

--- a/src/core/ProductTile/ProductIcon.tsx
+++ b/src/core/ProductTile/ProductIcon.tsx
@@ -42,8 +42,8 @@ const ProductIcon = ({
       {/* Inner container, contains the foreground container element */}
       <span
         className={cn("flex items-center justify-center", {
-          "bg-neutral-1200 dark:bg-neutral-100": selected,
-          "bg-neutral-100 dark:bg-neutral-1200": !selected,
+          "bg-ably-primary-accent": selected,
+          "bg-ably-primary-inverse-accent": !selected,
           "group-hover/product-tile:bg-ably-primary-inverse":
             selected === false && !unavailable,
         })}

--- a/src/core/ProductTile/ProductLabel.tsx
+++ b/src/core/ProductTile/ProductLabel.tsx
@@ -60,19 +60,17 @@ const ProductLabel = ({
         className={cn(
           "block ui-text-p2 font-bold",
           {
-            "text-neutral-000 dark:text-neutral-1300":
-              selected === true && !unavailable,
+            "text-ably-primary-inverse": selected === true && !unavailable,
           },
           {
-            "text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000":
+            "text-ably-secondary group-hover/product-tile:text-ably-primary":
               selected === false && !unavailable,
           },
           {
-            "text-neutral-1300 dark:text-neutral-000":
-              selected === undefined && !unavailable,
+            "text-ably-primary": selected === undefined && !unavailable,
           },
           {
-            "text-neutral-700 dark:text-neutral-600": unavailable,
+            "text-ably-label": unavailable,
           },
           { "mt-[-3px]": !unavailable },
           className,

--- a/src/core/ProductTile/ProductLabel.tsx
+++ b/src/core/ProductTile/ProductLabel.tsx
@@ -32,7 +32,7 @@ const ProductLabel = ({
       {unavailable ? (
         <span className="block">
           <span
-            className="table-cell font-sans bg-neutral-300 dark:bg-neutral-1000 rounded-full text-gui-unavailable tracking-[0.04em] font-bold leading-snug"
+            className="table-cell font-sans bg-ably-secondary-inverse rounded-full text-gui-unavailable tracking-[0.04em] font-bold leading-snug"
             style={{
               fontSize: dynamicFontSize * 0.6,
               padding: `${dynamicFontSize * 0.25}px ${dynamicFontSize * 0.5}px`,

--- a/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
+++ b/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Product Tile LargerProductTile smoke-test 1`] = `
-<div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300">
+<div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse">
   <div class="items-center flex"
        style="gap: 48px;"
   >
@@ -16,7 +16,7 @@ exports[`Components/Product Tile LargerProductTile smoke-test 1`] = `
              height="128"
              fill="none"
              viewbox="0 0 128 128"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              style="width: 96px; height: 96px;"
         >
           <path stroke="currentColor"
@@ -33,7 +33,7 @@ exports[`Components/Product Tile LargerProductTile smoke-test 1`] = `
       >
         Ably
       </span>
-      <span class="block ui-text-p2 font-bold text-neutral-1300 dark:text-neutral-000 mt-[-3px]"
+      <span class="block ui-text-p2 font-bold text-ably-primary mt-[-3px]"
             style="font-size: 55.3846px;"
       >
         Pub/Sub
@@ -45,14 +45,14 @@ exports[`Components/Product Tile LargerProductTile smoke-test 1`] = `
 
 exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-8">
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -91,7 +91,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000 flex group-hover/product-tile:hidden"
+               class="text-ably-primary flex group-hover/product-tile:hidden"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -108,25 +108,25 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Pub/Sub
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Low-level APIs for building realtime applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -165,7 +165,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000 flex group-hover/product-tile:hidden"
+               class="text-ably-primary flex group-hover/product-tile:hidden"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -182,25 +182,25 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Chat
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Build feature-rich live chat experiences.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -237,7 +237,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000 flex group-hover/product-tile:hidden"
+               class="text-ably-primary flex group-hover/product-tile:hidden"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -254,25 +254,25 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Spaces
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Enhance your application with collaborative features.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -311,7 +311,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000 flex group-hover/product-tile:hidden"
+               class="text-ably-primary flex group-hover/product-tile:hidden"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -329,25 +329,25 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           LiveSync
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Fan-out database changes to client applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -386,7 +386,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000 flex group-hover/product-tile:hidden"
+               class="text-ably-primary flex group-hover/product-tile:hidden"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path fill="currentColor"
@@ -402,25 +402,25 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Asset Tracking
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Track the geographic location of assets and fleets.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -468,7 +468,7 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000 flex group-hover/product-tile:hidden"
+               class="text-ably-primary flex group-hover/product-tile:hidden"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -493,14 +493,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           LiveObjects
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Sync application state across client devices.
     </span>
   </div>
@@ -523,7 +523,7 @@ exports[`Components/Product Tile ProductTileWithOverriddenStylesAndClick smoke-t
              height="128"
              fill="none"
              viewbox="0 0 128 128"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              style="width: 26.6667px; height: 26.6667px;"
         >
           <path stroke="currentColor"
@@ -540,14 +540,14 @@ exports[`Components/Product Tile ProductTileWithOverriddenStylesAndClick smoke-t
       >
         Ably
       </span>
-      <span class="block ui-text-p2 font-bold dark:text-neutral-000 mt-[-3px] text-orange-500"
+      <span class="block ui-text-p2 font-bold mt-[-3px] text-orange-500"
             style="font-size: 15.3846px;"
       >
         Pub/Sub
       </span>
     </span>
   </div>
-  <span class="block ui-text-p3 font-medium leading-snug dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300 text-blue-500">
+  <span class="block ui-text-p3 font-medium leading-snug group-hover/product-tile:text-ably-secondary text-blue-500">
     Low-level APIs for building realtime applications.
   </span>
 </div>
@@ -555,14 +555,14 @@ exports[`Components/Product Tile ProductTileWithOverriddenStylesAndClick smoke-t
 
 exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-8">
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -570,7 +570,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -587,25 +587,25 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Pub/Sub
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Low-level APIs for building realtime applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -613,7 +613,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -630,25 +630,25 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Chat
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Build feature-rich live chat experiences.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -656,7 +656,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -673,25 +673,25 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Spaces
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Enhance your application with collaborative features.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -699,7 +699,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -717,25 +717,25 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           LiveSync
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Fan-out database changes to client applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -743,7 +743,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path fill="currentColor"
@@ -759,25 +759,25 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Asset Tracking
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Track the geographic location of assets and fleets.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-neutral-000 dark:group-hover/product-tile:bg-neutral-1300"
+        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -785,7 +785,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -810,14 +810,14 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1000 dark:text-neutral-300 group-hover/product-tile:text-neutral-1300 dark:group-hover/product-tile:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-secondary group-hover/product-tile:text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           LiveObjects
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Sync application state across client devices.
     </span>
   </div>
@@ -826,7 +826,7 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
 
 exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-8 justify-center">
-  <div class="transition-colors group/product-tile bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile bg-ably-primary-inverse">
     <div class="items-center inline-flex"
          style="gap: 0px;"
     >
@@ -841,7 +841,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -854,7 +854,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       </span>
     </div>
   </div>
-  <div class="transition-colors group/product-tile bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile bg-ably-primary-inverse">
     <div class="items-center inline-flex"
          style="gap: 0px;"
     >
@@ -869,7 +869,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -882,7 +882,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       </span>
     </div>
   </div>
-  <div class="transition-colors group/product-tile bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile bg-ably-primary-inverse">
     <div class="items-center inline-flex"
          style="gap: 0px;"
     >
@@ -897,7 +897,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -910,7 +910,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       </span>
     </div>
   </div>
-  <div class="transition-colors group/product-tile bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile bg-ably-primary-inverse">
     <div class="items-center inline-flex"
          style="gap: 0px;"
     >
@@ -925,7 +925,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -939,7 +939,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       </span>
     </div>
   </div>
-  <div class="transition-colors group/product-tile bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile bg-ably-primary-inverse">
     <div class="items-center inline-flex"
          style="gap: 0px;"
     >
@@ -954,7 +954,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path fill="currentColor"
@@ -966,7 +966,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       </span>
     </div>
   </div>
-  <div class="transition-colors group/product-tile bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile bg-ably-primary-inverse">
     <div class="items-center inline-flex"
          style="gap: 0px;"
     >
@@ -981,7 +981,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -1007,7 +1007,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
 
 exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-8">
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
@@ -1022,7 +1022,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -1039,18 +1039,18 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1300 dark:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Pub/Sub
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Low-level APIs for building realtime applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
@@ -1065,7 +1065,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -1082,18 +1082,18 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1300 dark:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Chat
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Build feature-rich live chat experiences.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
@@ -1108,7 +1108,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -1125,18 +1125,18 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1300 dark:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Spaces
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Enhance your application with collaborative features.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
@@ -1151,7 +1151,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -1169,18 +1169,18 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1300 dark:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           LiveSync
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Fan-out database changes to client applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
@@ -1195,7 +1195,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path fill="currentColor"
@@ -1211,18 +1211,18 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1300 dark:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           Asset Tracking
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Track the geographic location of assets and fleets.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-neutral-000 dark:bg-neutral-1300">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
@@ -1237,7 +1237,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
                height="128"
                fill="none"
                viewbox="0 0 128 128"
-               class="text-neutral-1300 dark:text-neutral-000"
+               class="text-ably-primary"
                style="width: 26.6667px; height: 26.6667px;"
           >
             <path stroke="currentColor"
@@ -1262,14 +1262,14 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
         >
           Ably
         </span>
-        <span class="block ui-text-p2 font-bold text-neutral-1300 dark:text-neutral-000 mt-[-3px]"
+        <span class="block ui-text-p2 font-bold text-ably-primary mt-[-3px]"
               style="font-size: 15.3846px;"
         >
           LiveObjects
         </span>
       </span>
     </div>
-    <span class="block ui-text-p3 font-medium leading-snug text-neutral-800 dark:text-neutral-500 group-hover/product-tile:text-neutral-1000 dark:group-hover/product-tile:text-neutral-300">
+    <span class="block ui-text-p3 font-medium leading-snug text-ably-tertiary group-hover/product-tile:text-ably-secondary">
       Sync application state across client devices.
     </span>
   </div>

--- a/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
+++ b/src/core/ProductTile/__snapshots__/ProductTile.stories.tsx.snap
@@ -8,7 +8,7 @@ exports[`Components/Product Tile LargerProductTile smoke-test 1`] = `
     <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
           style="width: 144px; height: 144px; border-radius: 36px;"
     >
-      <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+      <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
             style="height: 142px; border-radius: 36px;"
       >
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -45,14 +45,14 @@ exports[`Components/Product Tile LargerProductTile smoke-test 1`] = `
 
 exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-8">
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -119,14 +119,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
       Low-level APIs for building realtime applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -193,14 +193,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
       Build feature-rich live chat experiences.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -265,14 +265,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
       Enhance your application with collaborative features.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -340,14 +340,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
       Fan-out database changes to client applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -413,14 +413,14 @@ exports[`Components/Product Tile ProductTileWithFilledIcons smoke-test 1`] = `
       Track the geographic location of assets and fleets.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -515,7 +515,7 @@ exports[`Components/Product Tile ProductTileWithOverriddenStylesAndClick smoke-t
     <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
           style="width: 40px; height: 40px; border-radius: 10px;"
     >
-      <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+      <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
             style="height: 38px; border-radius: 10px;"
       >
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -555,14 +555,14 @@ exports[`Components/Product Tile ProductTileWithOverriddenStylesAndClick smoke-t
 
 exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-8">
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -598,14 +598,14 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
       Low-level APIs for building realtime applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -641,14 +641,14 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
       Build feature-rich live chat experiences.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -684,14 +684,14 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
       Enhance your application with collaborative features.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -728,14 +728,14 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
       Fan-out database changes to client applications.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -770,14 +770,14 @@ exports[`Components/Product Tile ProductTiles smoke-test 1`] = `
       Track the geographic location of assets and fleets.
     </span>
   </div>
-  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 cursor-pointer">
+  <div class="transition-colors group/product-tile flex flex-col p-3 rounded-lg gap-2 bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent cursor-pointer">
     <div class="items-center flex"
          style="gap: 13.3333px;"
     >
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200 group-hover/product-tile:bg-ably-primary-inverse"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent group-hover/product-tile:bg-ably-primary-inverse"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -833,7 +833,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -861,7 +861,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -889,7 +889,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -917,7 +917,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -946,7 +946,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -973,7 +973,7 @@ exports[`Components/Product Tile ProductTilesWithoutDescriptionsOrLabels smoke-t
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -1014,7 +1014,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -1057,7 +1057,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -1100,7 +1100,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -1143,7 +1143,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -1187,7 +1187,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"
@@ -1229,7 +1229,7 @@ exports[`Components/Product Tile StaticProductTiles smoke-test 1`] = `
       <span class="block p-px bg-gradient-to-b from-neutral-000 to-neutral-300 dark:from-neutral-1000 dark:to-neutral-1300"
             style="width: 40px; height: 40px; border-radius: 10px;"
       >
-        <span class="flex items-center justify-center bg-neutral-100 dark:bg-neutral-1200"
+        <span class="flex items-center justify-center bg-ably-primary-inverse-accent"
               style="height: 38px; border-radius: 10px;"
         >
           <svg xmlns="http://www.w3.org/2000/svg"

--- a/src/core/SegmentedControl.tsx
+++ b/src/core/SegmentedControl.tsx
@@ -32,19 +32,19 @@ const SegmentedControl: React.FC<PropsWithChildren<SegmentedControlProps>> = ({
 }) => {
   const colorStyles = {
     default: {
-      active: "bg-neutral-200 dark:bg-neutral-1100",
+      active: "bg-ably-primary-inverse-active",
       inactive:
-        "bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200",
+        "bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent",
     },
     subtle: {
       active: "bg-ably-primary-inverse",
       inactive:
-        "bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100",
+        "bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active",
     },
     strong: {
       active: "bg-ably-secondary",
       inactive:
-        "bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100",
+        "bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active",
     },
   };
 

--- a/src/core/SegmentedControl.tsx
+++ b/src/core/SegmentedControl.tsx
@@ -34,15 +34,15 @@ const SegmentedControl: React.FC<PropsWithChildren<SegmentedControlProps>> = ({
     default: {
       active: "bg-neutral-200 dark:bg-neutral-1100",
       inactive:
-        "bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200",
+        "bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200",
     },
     subtle: {
-      active: "bg-neutral-000 dark:bg-neutral-1000",
+      active: "bg-ably-primary-inverse",
       inactive:
         "bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100",
     },
     strong: {
-      active: "bg-neutral-1000 dark:bg-neutral-300",
+      active: "bg-ably-secondary",
       inactive:
         "bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100",
     },
@@ -50,19 +50,16 @@ const SegmentedControl: React.FC<PropsWithChildren<SegmentedControlProps>> = ({
 
   const contentColorStyles = {
     default: {
-      active: "text-neutral-1300 dark:text-neutral-000",
-      inactive:
-        "text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000",
+      active: "text-ably-primary",
+      inactive: "text-ably-secondary hover:text-ably-primary",
     },
     subtle: {
-      active: "text-neutral-1300 dark:text-neutral-000",
-      inactive:
-        "text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000",
+      active: "text-ably-primary",
+      inactive: "text-ably-secondary hover:text-ably-primary",
     },
     strong: {
-      active: "text-neutral-000 dark:text-neutral-1300",
-      inactive:
-        "text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000",
+      active: "text-ably-primary-inverse",
+      inactive: "text-ably-secondary hover:text-ably-primary",
     },
   };
 

--- a/src/core/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/core/SegmentedControl/SegmentedControl.stories.tsx
@@ -70,7 +70,7 @@ export const DefaultVariant: Story = {
  */
 export const SubtleVariant: Story = {
   render: () => (
-    <div className="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-4">
+    <div className="bg-ably-primary-inverse-accent rounded-lg p-4">
       <SegmentedControlGrid variant="subtle" />
     </div>
   ),
@@ -82,7 +82,7 @@ export const SubtleVariant: Story = {
  */
 export const StrongVariant: Story = {
   render: () => (
-    <div className="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-4">
+    <div className="bg-ably-primary-inverse-accent rounded-lg p-4">
       <SegmentedControlGrid variant="strong" />
     </div>
   ),

--- a/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
+++ b/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
@@ -4,14 +4,14 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
 <div class="flex flex-col sm:flex-row gap-2">
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           md
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -20,7 +20,7 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -33,14 +33,14 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           sm
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -49,7 +49,7 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -62,14 +62,14 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           xs
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -78,7 +78,7 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -96,14 +96,14 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
 <div class="flex flex-col sm:flex-row gap-2">
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           md
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="true"
@@ -127,14 +127,14 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           sm
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="true"
@@ -158,14 +158,14 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           xs
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-9 p-2 gap-2 ui-text-label4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="true"
@@ -194,14 +194,14 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
 <div class="flex flex-col sm:flex-row gap-2">
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           md
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -210,7 +210,7 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -223,14 +223,14 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           sm
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -239,7 +239,7 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -252,14 +252,14 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           xs
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -268,7 +268,7 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -283,11 +283,11 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
 `;
 
 exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
-<div class="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-4">
+<div class="bg-ably-primary-inverse-accent rounded-lg p-4">
   <div class="flex flex-col sm:flex-row gap-2">
     <div class="flex flex-col gap-1">
       <div class="flex flex-col items-center">
-        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+        <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
           <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
             md
           </span>
@@ -303,7 +303,7 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
@@ -316,7 +316,7 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
     </div>
     <div class="flex flex-col gap-1">
       <div class="flex flex-col items-center">
-        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+        <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
           <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
             sm
           </span>
@@ -332,7 +332,7 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
@@ -345,7 +345,7 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
     </div>
     <div class="flex flex-col gap-1">
       <div class="flex flex-col items-center">
-        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+        <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
           <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
             xs
           </span>
@@ -361,7 +361,7 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
@@ -377,11 +377,11 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
 `;
 
 exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
-<div class="bg-neutral-100 dark:bg-neutral-1200 rounded-lg p-4">
+<div class="bg-ably-primary-inverse-accent rounded-lg p-4">
   <div class="flex flex-col sm:flex-row gap-2">
     <div class="flex flex-col gap-1">
       <div class="flex flex-col items-center">
-        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+        <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
           <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
             md
           </span>
@@ -397,7 +397,7 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
@@ -410,7 +410,7 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
     </div>
     <div class="flex flex-col gap-1">
       <div class="flex flex-col items-center">
-        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+        <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
           <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
             sm
           </span>
@@ -426,7 +426,7 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
@@ -439,7 +439,7 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
     </div>
     <div class="flex flex-col gap-1">
       <div class="flex flex-col items-center">
-        <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+        <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
           <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
             xs
           </span>
@@ -455,7 +455,7 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-accent hover:bg-ably-primary-inverse-active active:bg-ably-primary-inverse-active text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
@@ -474,14 +474,14 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
 <div class="flex flex-col sm:flex-row gap-2">
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           md
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -518,7 +518,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -559,14 +559,14 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           sm
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -603,7 +603,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -644,14 +644,14 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           xs
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -688,7 +688,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -734,14 +734,14 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
 <div class="flex flex-col sm:flex-row gap-2">
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           md
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -778,7 +778,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
           </g>
         </svg>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -819,14 +819,14 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           sm
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -863,7 +863,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
           </g>
         </svg>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -904,14 +904,14 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
   </div>
   <div class="flex flex-col gap-1">
     <div class="flex flex-col items-center">
-      <div class="inline-flex bg-neutral-100 dark:bg-neutral-1200 rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
+      <div class="inline-flex bg-ably-primary-inverse-accent rounded-2xl gap-1 items-center focus-base transition-colors select-none font-semibold px-2.5 py-0.5 text-[11px] leading-normal text-neutral-900 dark:text-neutral-400 mb-2">
         <span class="whitespace-nowrap tracking-[0.04em] leading-[20px]">
           xs
         </span>
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse-active text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -948,7 +948,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
           </g>
         </svg>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-ably-primary-inverse-accent active:bg-ably-primary-inverse-accent text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"

--- a/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
+++ b/src/core/SegmentedControl/__snapshots__/SegmentedControl.stories.tsx.snap
@@ -11,21 +11,21 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -40,21 +40,21 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -69,21 +69,21 @@ exports[`Components/Segmented Control DefaultVariant smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -103,7 +103,7 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="true"
@@ -113,7 +113,7 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-ably-primary-inverse text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="false"
@@ -134,7 +134,7 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="true"
@@ -144,7 +144,7 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-ably-primary-inverse text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="false"
@@ -165,7 +165,7 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="true"
@@ -175,7 +175,7 @@ exports[`Components/Segmented Control Disabled smoke-test 1`] = `
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
+      <div class="focus-base flex items-center justify-center select-none transition-colors bg-ably-primary-inverse text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 cursor-not-allowed hover:bg-inherit dark:hover:bg-inherit active:bg-inherit dark:active:bg-inherit rounded-lg"
            tabindex="-1"
            role="button"
            aria-pressed="false"
@@ -201,21 +201,21 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 px-[1.125rem] ui-text-label2 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -230,21 +230,21 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] px-3.5 ui-text-label3 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -259,21 +259,21 @@ exports[`Components/Segmented Control Rounded smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 px-3 ui-text-label4 rounded-full"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -294,21 +294,21 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
         </div>
       </div>
       <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-1000 dark:bg-neutral-300 text-neutral-000 dark:text-neutral-1300 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-secondary text-ably-primary-inverse h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-000 dark:text-neutral-1300">
+          <span class="font-semibold transition-colors text-ably-primary-inverse">
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
         >
-          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
             Option 2
           </span>
         </div>
@@ -323,21 +323,21 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
         </div>
       </div>
       <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-1000 dark:bg-neutral-300 text-neutral-000 dark:text-neutral-1300 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-secondary text-ably-primary-inverse h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-000 dark:text-neutral-1300">
+          <span class="font-semibold transition-colors text-ably-primary-inverse">
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
         >
-          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
             Option 2
           </span>
         </div>
@@ -352,21 +352,21 @@ exports[`Components/Segmented Control StrongVariant smoke-test 1`] = `
         </div>
       </div>
       <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-1000 dark:bg-neutral-300 text-neutral-000 dark:text-neutral-1300 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-secondary text-ably-primary-inverse h-9 p-2 gap-2 ui-text-label4 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-000 dark:text-neutral-1300">
+          <span class="font-semibold transition-colors text-ably-primary-inverse">
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
         >
-          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
             Option 2
           </span>
         </div>
@@ -388,21 +388,21 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
         </div>
       </div>
       <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1000 text-neutral-1300 dark:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-primary">
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
         >
-          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
             Option 2
           </span>
         </div>
@@ -417,21 +417,21 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
         </div>
       </div>
       <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1000 text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-primary">
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
         >
-          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
             Option 2
           </span>
         </div>
@@ -446,21 +446,21 @@ exports[`Components/Segmented Control SubtleVariant smoke-test 1`] = `
         </div>
       </div>
       <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1000 text-neutral-1300 dark:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="true"
         >
-          <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-primary">
             Option 1
           </span>
         </div>
-        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+        <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-100 dark:bg-neutral-1200 hover:bg-neutral-200 dark:hover:bg-neutral-1100 active:bg-neutral-200 dark:active:bg-neutral-1100 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
              tabindex="0"
              role="button"
              aria-pressed="false"
         >
-          <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+          <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
             Option 2
           </span>
         </div>
@@ -481,7 +481,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -491,7 +491,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
@@ -514,11 +514,11 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -528,7 +528,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+             class="text-ably-secondary hover:text-ably-primary"
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
@@ -551,7 +551,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -566,7 +566,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -576,7 +576,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -599,11 +599,11 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -613,7 +613,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+             class="text-ably-secondary hover:text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -636,7 +636,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -651,7 +651,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
@@ -661,7 +661,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >
@@ -684,11 +684,11 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
@@ -698,7 +698,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+             class="text-ably-secondary hover:text-ably-primary"
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >
@@ -721,7 +721,7 @@ exports[`Components/Segmented Control WithLeftIcon smoke-test 1`] = `
             </path>
           </g>
         </svg>
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
       </div>
@@ -741,12 +741,12 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -754,7 +754,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
@@ -778,12 +778,12 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
           </g>
         </svg>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-12 p-3 gap-2.5 ui-text-label2 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -791,7 +791,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+             class="text-ably-secondary hover:text-ably-primary"
              aria-hidden="true"
              style="width: 23px; height: 23px;"
         >
@@ -826,12 +826,12 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -839,7 +839,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -863,12 +863,12 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
           </g>
         </svg>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-10 p-[0.5625rem] gap-[0.5625rem] ui-text-label3 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -876,7 +876,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+             class="text-ably-secondary hover:text-ably-primary"
              aria-hidden="true"
              style="width: 22px; height: 22px;"
         >
@@ -911,12 +911,12 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
       </div>
     </div>
     <div class="flex gap-2 justify-center items-center p-2 border rounded-lg">
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-neutral-1300 dark:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-200 dark:bg-neutral-1100 text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="true"
       >
-        <span class="font-semibold transition-colors text-neutral-1300 dark:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-primary">
           Option 1
         </span>
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -924,7 +924,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1300 dark:text-neutral-000"
+             class="text-ably-primary"
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >
@@ -948,12 +948,12 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
           </g>
         </svg>
       </div>
-      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-neutral-000 dark:bg-neutral-1300 hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000 h-9 p-2 gap-2 ui-text-label4 rounded-lg"
+      <div class="focus-base flex items-center justify-center cursor-pointer select-none transition-colors bg-ably-primary-inverse hover:bg-neutral-100 dark:hover:bg-neutral-1200 active:bg-neutral-100 dark:active:bg-neutral-1200 text-ably-secondary hover:text-ably-primary h-9 p-2 gap-2 ui-text-label4 rounded-lg"
            tabindex="0"
            role="button"
            aria-pressed="false"
       >
-        <span class="font-semibold transition-colors text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000">
+        <span class="font-semibold transition-colors text-ably-secondary hover:text-ably-primary">
           Option 2
         </span>
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -961,7 +961,7 @@ exports[`Components/Segmented Control WithRightIcon smoke-test 1`] = `
              height="48"
              fill="none"
              viewbox="0 0 48 48"
-             class="text-neutral-1000 dark:text-neutral-300 hover:text-neutral-1300 dark:hover:text-neutral-000"
+             class="text-ably-secondary hover:text-ably-primary"
              aria-hidden="true"
              style="width: 20px; height: 20px;"
         >

--- a/src/core/Status.tsx
+++ b/src/core/Status.tsx
@@ -87,7 +87,7 @@ const Status = ({
         refreshInterval={refreshInterval ?? 1000 * 60}
       />
       {showDescription && data?.status?.description && (
-        <div className="flex gap-2 ui-text-label4 font-medium text-neutral-900 group-hover/status:text-neutral-1300 dark:text-neutral-400 dark:group-hover/status:text-neutral-000 transition-colors">
+        <div className="flex gap-2 ui-text-label4 font-medium text-neutral-900 group-hover/status:text-ably-primary dark:text-neutral-400 transition-colors">
           <span>
             {data.status.description.charAt(0).toUpperCase() +
               data.status.description.slice(1).toLowerCase()}

--- a/src/core/TabMenu.tsx
+++ b/src/core/TabMenu.tsx
@@ -170,8 +170,7 @@ const TabMenu: React.FC<TabMenuProps> = ({
         className={cn(
           "relative",
           {
-            "flex border-b border-neutral-300 dark:border-neutral-1000":
-              underline,
+            "flex border-b border-ably-secondary-inverse": underline,
           },
           { "h-full": flexibleTabHeight },
         )}
@@ -182,7 +181,7 @@ const TabMenu: React.FC<TabMenuProps> = ({
               <Tabs.Trigger
                 key={`tab-${index}`}
                 className={cn(
-                  "lg:px-6 md:px-5 px-4 py-4 ui-text-label1 font-bold data-[state=active]:text-neutral-1300 text-neutral-1000 dark:data-[state=active]:text-neutral-000 dark:text-neutral-300 focus:outline-none focus-visible:outline-gui-focus transition-colors hover:text-neutral-1300 dark:hover:text-neutral-000 active:text-neutral-900 dark:active:text-neutral-400 disabled:text-gui-unavailable dark:disabled:text-gui-unavailable-dark disabled:cursor-not-allowed",
+                  "lg:px-6 md:px-5 px-4 py-4 ui-text-label1 font-bold data-[state=active]:text-ably-primary text-ably-secondary focus:outline-none focus-visible:outline-gui-focus transition-colors hover:text-ably-primary active:text-neutral-900 dark:active:text-neutral-400 disabled:text-gui-unavailable dark:disabled:text-gui-unavailable-dark disabled:cursor-not-allowed",
                   { "flex-1": flexibleTabWidth },
                   { "h-full": flexibleTabHeight },
                   tabClassName,
@@ -200,10 +199,9 @@ const TabMenu: React.FC<TabMenuProps> = ({
             ),
         )}
         <div
-          className={cn(
-            "absolute bottom-0 bg-neutral-1300 dark:bg-neutral-000 h-[0.1875rem] w-6",
-            { "transition-[transform,width]": animated },
-          )}
+          className={cn("absolute bottom-0 bg-ably-primary h-[0.1875rem] w-6", {
+            "transition-[transform,width]": animated,
+          })}
           style={{
             transform: `translateX(${highlight.offset}px)`,
             width: `${highlight.width}px`,

--- a/src/core/Table/__snapshots__/Table.stories.tsx.snap
+++ b/src/core/Table/__snapshots__/Table.stories.tsx.snap
@@ -75,7 +75,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -181,7 +181,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -287,7 +287,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -393,7 +393,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -499,7 +499,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -616,7 +616,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -722,7 +722,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -828,7 +828,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -934,7 +934,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -1040,7 +1040,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -1157,7 +1157,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -1263,7 +1263,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -1369,7 +1369,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -1475,7 +1475,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"
@@ -1581,7 +1581,7 @@ exports[`Components/Table PricingPage smoke-test 1`] = `
                    stroke="currentColor"
                    aria-hidden="true"
                    data-slot="icon"
-                   class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+                   class="text-ably-label hover:text-ably-secondary"
                    style="width: 1rem; height: 1rem;"
               >
                 <path stroke-linecap="round"

--- a/src/core/Tooltip.tsx
+++ b/src/core/Tooltip.tsx
@@ -186,7 +186,7 @@ const Tooltip = ({
               }}
               {...tooltipProps}
               className={cn(
-                "bg-neutral-300 dark:bg-neutral-1000 text-neutral-1100 dark:text-neutral-200 ui-text-p3 font-medium p-4",
+                "bg-ably-secondary-inverse text-neutral-1100 dark:text-neutral-200 ui-text-p3 font-medium p-4",
                 { "pointer-events-none": !interactive },
                 "rounded-lg absolute",
                 tooltipProps?.className,

--- a/src/core/Tooltip.tsx
+++ b/src/core/Tooltip.tsx
@@ -163,7 +163,8 @@ const Tooltip = ({
         {triggerElement ?? (
           <Icon
             name="icon-gui-information-circle-outline"
-            color="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+            color="text-ably-label"
+            additionalCSS="hover:text-ably-secondary"
             size={iconSize}
           />
         )}

--- a/src/core/Tooltip/__snapshots__/Tooltip.stories.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/Tooltip.stories.tsx.snap
@@ -21,7 +21,7 @@ exports[`Components/Tooltip Central smoke-test 1`] = `
              stroke="currentColor"
              aria-hidden="true"
              data-slot="icon"
-             class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+             class="text-ably-label hover:text-ably-secondary"
              style="width: 1rem; height: 1rem;"
         >
           <path stroke-linecap="round"
@@ -48,7 +48,7 @@ exports[`Components/Tooltip Central smoke-test 1`] = `
              stroke="currentColor"
              aria-hidden="true"
              data-slot="icon"
-             class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+             class="text-ably-label hover:text-ably-secondary"
              style="width: 1rem; height: 1rem;"
         >
           <path stroke-linecap="round"
@@ -84,7 +84,7 @@ exports[`Components/Tooltip Interactive smoke-test 1`] = `
              stroke="currentColor"
              aria-hidden="true"
              data-slot="icon"
-             class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+             class="text-ably-label hover:text-ably-secondary"
              style="width: 1rem; height: 1rem;"
         >
           <path stroke-linecap="round"
@@ -111,7 +111,7 @@ exports[`Components/Tooltip Interactive smoke-test 1`] = `
              stroke="currentColor"
              aria-hidden="true"
              data-slot="icon"
-             class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+             class="text-ably-label hover:text-ably-secondary"
              style="width: 1rem; height: 1rem;"
         >
           <path stroke-linecap="round"
@@ -147,7 +147,7 @@ exports[`Components/Tooltip LeftBound smoke-test 1`] = `
              stroke="currentColor"
              aria-hidden="true"
              data-slot="icon"
-             class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+             class="text-ably-label hover:text-ably-secondary"
              style="width: 1rem; height: 1rem;"
         >
           <path stroke-linecap="round"
@@ -174,7 +174,7 @@ exports[`Components/Tooltip LeftBound smoke-test 1`] = `
              stroke="currentColor"
              aria-hidden="true"
              data-slot="icon"
-             class="text-neutral-700 dark:text-neutral-600 hover:text-neutral-1000 dark:hover:text-neutral-300"
+             class="text-ably-label hover:text-ably-secondary"
              style="width: 1rem; height: 1rem;"
         >
           <path stroke-linecap="round"

--- a/src/core/styles/Typography.stories.tsx
+++ b/src/core/styles/Typography.stories.tsx
@@ -49,12 +49,12 @@ const fontCell = (style) => (
   <div
     key={style.label}
     className={cn(
-      "rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000",
+      "rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200",
       style.className,
     )}
   >
     <div>{style.label}</div>
-    <code className="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code className="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       {style.className
         .split(" ")
         .map((className) => `.${className}`)
@@ -112,7 +112,7 @@ export const Links = {
       </p>
       <div className="flex flex-wrap">
         <div className="p-4 mb-4 mr-4 border rounded">
-          <p className="ui-text-p1 text-charcoal-grey">
+          <p className="ui-text-p1">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
             odio. Class aptent taciti sociosqu ad litora torquent per conubia
             nostra,{" "}
@@ -124,7 +124,7 @@ export const Links = {
           </p>
         </div>
         <div className="p-4 mb-4 mr-4 border rounded bg-cool-black">
-          <p className="ui-text-p1 text-white">
+          <p className="ui-text-p1">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
             odio. Class aptent taciti sociosqu ad litora torquent per conubia
             nostra,{" "}
@@ -136,7 +136,7 @@ export const Links = {
           </p>
         </div>
         <div className="p-4 mb-4 mr-4 border rounded bg-jazzy-pink">
-          <p className="ui-text-p1 text-charcoal-grey">
+          <p className="ui-text-p1">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
             odio. Class aptent taciti sociosqu ad litora torquent per conubia
             nostra{" "}

--- a/src/core/styles/Typography.stories.tsx
+++ b/src/core/styles/Typography.stories.tsx
@@ -49,12 +49,12 @@ const fontCell = (style) => (
   <div
     key={style.label}
     className={cn(
-      "rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200",
+      "rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent",
       style.className,
     )}
   >
     <div>{style.label}</div>
-    <code className="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code className="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       {style.className
         .split(" ")
         .map((className) => `.${className}`)

--- a/src/core/styles/__snapshots__/Forms.stories.tsx.snap
+++ b/src/core/styles/__snapshots__/Forms.stories.tsx.snap
@@ -371,7 +371,7 @@ exports[`Styles/Forms RadioButtons smoke-test 1`] = `
              class="ui-radio"
              value="option-1"
       >
-      <label class="text-neutral-1300 dark:text-neutral-000"
+      <label class="text-ably-primary"
              for="radio-example-1"
       >
         Option 1
@@ -385,7 +385,7 @@ exports[`Styles/Forms RadioButtons smoke-test 1`] = `
              class="ui-radio"
              value="option-2"
       >
-      <label class="text-neutral-1300 dark:text-neutral-000"
+      <label class="text-ably-primary"
              for="radio-example-2"
       >
         Option 2
@@ -399,7 +399,7 @@ exports[`Styles/Forms RadioButtons smoke-test 1`] = `
              class="ui-radio"
              value="option-3"
       >
-      <label class="text-neutral-1300 dark:text-neutral-000"
+      <label class="text-ably-primary"
              for="radio-example-3"
       >
         Option 3
@@ -419,7 +419,7 @@ exports[`Styles/Forms RadioButtons smoke-test 1`] = `
              disabled
              value="option-4"
       >
-      <label class="text-neutral-1300 dark:text-neutral-000"
+      <label class="text-ably-primary"
              for="radio-example-4"
       >
         Option 4
@@ -434,7 +434,7 @@ exports[`Styles/Forms RadioButtons smoke-test 1`] = `
              disabled
              value="option-5"
       >
-      <label class="text-neutral-1300 dark:text-neutral-000"
+      <label class="text-ably-primary"
              for="radio-example-5"
       >
         Option 5
@@ -449,7 +449,7 @@ exports[`Styles/Forms RadioButtons smoke-test 1`] = `
              disabled
              value="option-6"
       >
-      <label class="text-neutral-1300 dark:text-neutral-000"
+      <label class="text-ably-primary"
              for="radio-example-6"
       >
         Option 6

--- a/src/core/styles/__snapshots__/Typography.stories.tsx.snap
+++ b/src/core/styles/__snapshots__/Typography.stories.tsx.snap
@@ -2,19 +2,19 @@
 
 exports[`Styles/Typography Code smoke-test 1`] = `
 <div class="grid grid-cols-2 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-code">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-code">
     <div>
       Code 1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-code
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-code2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-code2">
     <div>
       Code 2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-code2
     </code>
   </div>
@@ -23,35 +23,35 @@ exports[`Styles/Typography Code smoke-test 1`] = `
 
 exports[`Styles/Typography Decorative smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-sub-header">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-sub-header">
     <div>
       Sub-header
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-sub-header
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-sub-header text-sub-header-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-sub-header text-sub-header-xs">
     <div>
       Sub-header XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-sub-header.text-sub-header-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-overline1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-overline1">
     <div>
       Overline 1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-overline1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-overline2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-overline2">
     <div>
       Overline 2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-overline2
     </code>
   </div>
@@ -60,35 +60,35 @@ exports[`Styles/Typography Decorative smoke-test 1`] = `
 
 exports[`Styles/Typography GUI smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-label1">
     <div>
       Label 1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-label1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-label2">
     <div>
       Label 2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-label2
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label3">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-label3">
     <div>
       Label 3
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-label3
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label4">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-label4">
     <div>
       Label 4
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-label4
     </code>
   </div>
@@ -214,131 +214,131 @@ exports[`Styles/Typography Lists smoke-test 1`] = `
 
 exports[`Styles/Typography Primary smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-title text-title-xl">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-title text-title-xl">
     <div>
       Title XL
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-title.text-title-xl
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-title">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-title">
     <div>
       Title
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-title
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-title text-title-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-title text-title-xs">
     <div>
       Title XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-title.text-title-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h1 text-h1-xl">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h1 text-h1-xl">
     <div>
       h1 XL
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h1.text-h1-xl
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h1">
     <div>
       h1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h1 text-h1-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h1 text-h1-xs">
     <div>
       h1 XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h1.text-h1-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h2 text-h2-xl">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h2 text-h2-xl">
     <div>
       h2 XL
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h2.text-h2-xl
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h2">
     <div>
       h2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h2
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h2 text-h2-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h2 text-h2-xs">
     <div>
       h2 XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h2.text-h2-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h3">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h3">
     <div>
       h3
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h3
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h4">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h4">
     <div>
       h4
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h4
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h5">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-h5">
     <div>
       h5
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-h5
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-p1">
     <div>
       p1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-p1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-p2">
     <div>
       p2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-p2
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p3">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-p3">
     <div>
       p3
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-p3
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p4">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-ably-primary-inverse-accent ui-text-p4">
     <div>
       p4
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-ably-primary-inverse-active rounded-lg p-2">
       .ui-text-p4
     </code>
   </div>

--- a/src/core/styles/__snapshots__/Typography.stories.tsx.snap
+++ b/src/core/styles/__snapshots__/Typography.stories.tsx.snap
@@ -2,19 +2,19 @@
 
 exports[`Styles/Typography Code smoke-test 1`] = `
 <div class="grid grid-cols-2 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-code">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-code">
     <div>
       Code 1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-code
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-code2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-code2">
     <div>
       Code 2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-code2
     </code>
   </div>
@@ -23,35 +23,35 @@ exports[`Styles/Typography Code smoke-test 1`] = `
 
 exports[`Styles/Typography Decorative smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-sub-header">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-sub-header">
     <div>
       Sub-header
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-sub-header
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-sub-header text-sub-header-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-sub-header text-sub-header-xs">
     <div>
       Sub-header XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-sub-header.text-sub-header-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-overline1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-overline1">
     <div>
       Overline 1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-overline1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-overline2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-overline2">
     <div>
       Overline 2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-overline2
     </code>
   </div>
@@ -60,35 +60,35 @@ exports[`Styles/Typography Decorative smoke-test 1`] = `
 
 exports[`Styles/Typography GUI smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-label1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label1">
     <div>
       Label 1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-label1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-label2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label2">
     <div>
       Label 2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-label2
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-label3">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label3">
     <div>
       Label 3
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-label3
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-label4">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-label4">
     <div>
       Label 4
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-label4
     </code>
   </div>
@@ -104,7 +104,7 @@ exports[`Styles/Typography Links smoke-test 1`] = `
 </p>
 <div class="flex flex-wrap">
   <div class="p-4 mb-4 mr-4 border rounded">
-    <p class="ui-text-p1 text-charcoal-grey">
+    <p class="ui-text-p1">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra,
       <a href="/xyz"
          class="ui-link"
@@ -115,7 +115,7 @@ exports[`Styles/Typography Links smoke-test 1`] = `
     </p>
   </div>
   <div class="p-4 mb-4 mr-4 border rounded bg-cool-black">
-    <p class="ui-text-p1 text-white">
+    <p class="ui-text-p1">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra,
       <a href="/123"
          class="ui-link"
@@ -126,7 +126,7 @@ exports[`Styles/Typography Links smoke-test 1`] = `
     </p>
   </div>
   <div class="p-4 mb-4 mr-4 border rounded bg-jazzy-pink">
-    <p class="ui-text-p1 text-charcoal-grey">
+    <p class="ui-text-p1">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra
       <a href="/123"
          class="ui-link-neutral"
@@ -214,131 +214,131 @@ exports[`Styles/Typography Lists smoke-test 1`] = `
 
 exports[`Styles/Typography Primary smoke-test 1`] = `
 <div class="grid sm:grid-cols-3 gap-4">
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-title text-title-xl">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-title text-title-xl">
     <div>
       Title XL
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-title.text-title-xl
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-title">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-title">
     <div>
       Title
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-title
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-title text-title-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-title text-title-xs">
     <div>
       Title XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-title.text-title-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h1 text-h1-xl">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h1 text-h1-xl">
     <div>
       h1 XL
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h1.text-h1-xl
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h1">
     <div>
       h1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h1 text-h1-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h1 text-h1-xs">
     <div>
       h1 XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h1.text-h1-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h2 text-h2-xl">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h2 text-h2-xl">
     <div>
       h2 XL
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h2.text-h2-xl
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h2">
     <div>
       h2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h2
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h2 text-h2-xs">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h2 text-h2-xs">
     <div>
       h2 XS
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h2.text-h2-xs
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h3">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h3">
     <div>
       h3
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h3
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h4">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h4">
     <div>
       h4
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h4
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-h5">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-h5">
     <div>
       h5
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-h5
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-p1">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p1">
     <div>
       p1
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-p1
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-p2">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p2">
     <div>
       p2
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-p2
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-p3">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p3">
     <div>
       p3
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-p3
     </code>
   </div>
-  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 text-neutral-1300 dark:bg-neutral-1200 dark:text-neutral-000 ui-text-p4">
+  <div class="rounded-lg p-4 flex flex-col gap-2 bg-neutral-100 dark:bg-neutral-1200 ui-text-p4">
     <div>
       p4
     </div>
-    <code class="font-mono ui-text-code2 bg-neutral-200 text-neutral-1200 dark:bg-neutral-1100 dark:text-neutral-100 rounded-lg p-2">
+    <code class="font-mono ui-text-code2 bg-neutral-200 dark:bg-neutral-1100 rounded-lg p-2">
       .ui-text-p4
     </code>
   </div>

--- a/src/core/styles/buttons.css
+++ b/src/core/styles/buttons.css
@@ -36,19 +36,19 @@
   }
 
   .ui-button-primary-base {
-    @apply bg-neutral-1300 text-neutral-000 hover:bg-neutral-1100 active:bg-neutral-1200 active:text-neutral-300 ui-button-disabled-base;
+    @apply bg-ably-primary text-ably-primary-inverse hover:bg-neutral-1100 active:bg-neutral-1200 active:text-neutral-300 ui-button-disabled-base;
   }
 
   .ui-theme-dark .ui-button-primary-base {
-    @apply bg-neutral-000 text-neutral-1300 hover:bg-neutral-200 active:bg-neutral-100 active:text-neutral-1000 ui-button-disabled-base-dark;
+    @apply hover:bg-neutral-200 active:bg-neutral-100 active:text-neutral-1000 ui-button-disabled-base-dark;
   }
 
   .ui-button-secondary-base {
-    @apply text-neutral-1300 active:text-neutral-1000 border border-neutral-600 hover:border-neutral-800 active:border-neutral-700 disabled:border-gui-unavailable disabled:text-gui-unavailable;
+    @apply text-ably-primary active:text-neutral-1000 border border-neutral-600 hover:border-neutral-800 active:border-neutral-700 disabled:border-gui-unavailable disabled:text-gui-unavailable;
   }
 
   .ui-theme-dark .ui-button-secondary-base {
-    @apply text-neutral-000 active:text-neutral-300 border-neutral-700 hover:border-neutral-500 active:border-neutral-600 disabled:border-gui-unavailable-dark disabled:text-gui-unavailable-dark;
+    @apply active:text-neutral-300 border-neutral-700 hover:border-neutral-500 active:border-neutral-600 disabled:border-gui-unavailable-dark disabled:text-gui-unavailable-dark;
   }
 
   .ui-button-priority-lg {

--- a/src/core/styles/colors/Colors.stories.tsx
+++ b/src/core/styles/colors/Colors.stories.tsx
@@ -6,28 +6,54 @@ export default {
 };
 
 const colorSet = (colors, useClass = "") =>
-  colors.map((color) => (
-    <div
-      key={color}
-      className="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col"
-    >
+  colors.map((color) => {
+    // Check if this is a utility object with light/dark colors
+    const isUtility = typeof color === "object" && "lightColor" in color;
+    const displayName = isUtility ? color.name : color;
+    const key = isUtility ? color.name : color;
+
+    return (
       <div
-        className={`h-[6.25rem] rounded-t-lg ${useClass}`}
-        style={{ backgroundColor: useClass ? `` : `var(--color-${color})` }}
-      />
-      <div className="p-3 flex flex-col flex-1">
-        <p className="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
-          {color}
-        </p>
-        <p className="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
-          {varToValues(color)[0]}
-        </p>
-        <p className="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
-          {varToValues(color)[1]}
-        </p>
+        key={key}
+        className="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col"
+      >
+        {isUtility ? (
+          // Split color view for utilities (diagonal)
+          <div
+            className="h-[6.25rem] rounded-t-lg"
+            style={{
+              background: `linear-gradient(45deg, var(--color-${color.lightColor}) 50%, var(--color-${color.darkColor}) 50%)`,
+            }}
+          />
+        ) : (
+          // Single color view for regular colors
+          <div
+            className={`h-[6.25rem] rounded-t-lg ${useClass}`}
+            style={{ backgroundColor: useClass ? `` : `var(--color-${color})` }}
+          />
+        )}
+        <div className="p-3 flex flex-col flex-1">
+          <p className="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+            {displayName}
+          </p>
+          {isUtility ? (
+            <p className="ui-text-p3 font-normal text-ably-tertiary text-xs">
+              {color.lightColor} / {color.darkColor}
+            </p>
+          ) : (
+            <>
+              <p className="ui-text-p3 font-normal text-ably-tertiary">
+                {varToValues(color)[0]}
+              </p>
+              <p className="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
+                {varToValues(color)[1]}
+              </p>
+            </>
+          )}
+        </div>
       </div>
-    </div>
-  ));
+    );
+  });
 
 const varToValues = (color: string) => {
   // Convert the computed color value in the page to a hex string
@@ -42,6 +68,63 @@ const varToValues = (color: string) => {
   const b = bigint & 255;
 
   return [hex, `rgb(${r}, ${g}, ${b})`];
+};
+
+export const AblyUtilityClasses = {
+  render: () => (
+    <div className="flex flex-wrap gap-6">
+      {colorSet([
+        {
+          name: "ably-primary",
+          lightColor: "neutral-1300",
+          darkColor: "neutral-000",
+        },
+        {
+          name: "ably-primary-inverse",
+          lightColor: "neutral-000",
+          darkColor: "neutral-1300",
+        },
+        {
+          name: "ably-secondary",
+          lightColor: "neutral-1000",
+          darkColor: "neutral-300",
+        },
+        {
+          name: "ably-secondary-inverse",
+          lightColor: "neutral-300",
+          darkColor: "neutral-1000",
+        },
+        {
+          name: "ably-tertiary",
+          lightColor: "neutral-800",
+          darkColor: "neutral-500",
+        },
+        {
+          name: "ably-tertiary-inverse",
+          lightColor: "neutral-500",
+          darkColor: "neutral-800",
+        },
+        {
+          name: "ably-label",
+          lightColor: "neutral-700",
+          darkColor: "neutral-600",
+        },
+        {
+          name: "ably-label-inverse",
+          lightColor: "neutral-600",
+          darkColor: "neutral-700",
+        },
+      ])}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Utility classes that replace common light/dark theme pairs. Example: `.text-ably-primary` replaces `.text-neutral-1300 dark:text-neutral-000`",
+      },
+    },
+  },
 };
 
 export const NeutralColors = {

--- a/src/core/styles/colors/Colors.stories.tsx
+++ b/src/core/styles/colors/Colors.stories.tsx
@@ -15,7 +15,7 @@ const colorSet = (colors, useClass = "") =>
     return (
       <div
         key={key}
-        className="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col"
+        className="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col"
       >
         {isUtility ? (
           // Split color view for utilities (diagonal)
@@ -83,6 +83,26 @@ export const AblyUtilityClasses = {
           name: "ably-primary-inverse",
           lightColor: "neutral-000",
           darkColor: "neutral-1300",
+        },
+        {
+          name: "ably-primary-accent",
+          lightColor: "neutral-1200",
+          darkColor: "neutral-100",
+        },
+        {
+          name: "ably-primary-inverse-accent",
+          lightColor: "neutral-100",
+          darkColor: "neutral-1200",
+        },
+        {
+          name: "ably-primary-active",
+          lightColor: "neutral-1100",
+          darkColor: "neutral-200",
+        },
+        {
+          name: "ably-primary-inverse-active",
+          lightColor: "neutral-200",
+          darkColor: "neutral-1100",
         },
         {
           name: "ably-secondary",

--- a/src/core/styles/colors/__snapshots__/Colors.stories.tsx.snap
+++ b/src/core/styles/colors/__snapshots__/Colors.stories.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
 <div class="flex flex-wrap gap-6">
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-1300) 50%, var(--color-neutral-000) 50%);"
     >
@@ -16,7 +16,7 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-000) 50%, var(--color-neutral-1300) 50%);"
     >
@@ -30,7 +30,63 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-1200) 50%, var(--color-neutral-100) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-primary-accent
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-1200 / neutral-100
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-100) 50%, var(--color-neutral-1200) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-primary-inverse-accent
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-100 / neutral-1200
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-1100) 50%, var(--color-neutral-200) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-primary-active
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-1100 / neutral-200
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-200) 50%, var(--color-neutral-1100) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-primary-inverse-active
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-200 / neutral-1100
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-1000) 50%, var(--color-neutral-300) 50%);"
     >
@@ -44,7 +100,7 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-300) 50%, var(--color-neutral-1000) 50%);"
     >
@@ -58,7 +114,7 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-800) 50%, var(--color-neutral-500) 50%);"
     >
@@ -72,7 +128,7 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-500) 50%, var(--color-neutral-800) 50%);"
     >
@@ -86,7 +142,7 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-700) 50%, var(--color-neutral-600) 50%);"
     >
@@ -100,7 +156,7 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg"
          style="background: linear-gradient(45deg, var(--color-neutral-600) 50%, var(--color-neutral-700) 50%);"
     >
@@ -119,7 +175,7 @@ exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
 
 exports[`Styles/Colors GUIColors smoke-test 1`] = `
 <div class="flex flex-wrap gap-6">
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-blue-default-light);"
     >
@@ -136,7 +192,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-blue-hover-light);"
     >
@@ -153,7 +209,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-blue-active-light);"
     >
@@ -170,7 +226,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-blue-default-dark);"
     >
@@ -187,7 +243,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-blue-hover-dark);"
     >
@@ -204,7 +260,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-blue-active-dark);"
     >
@@ -221,7 +277,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-blue-focus);"
     >
@@ -238,7 +294,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-unavailable);"
     >
@@ -255,7 +311,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-success-green);"
     >
@@ -272,7 +328,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-error-red);"
     >
@@ -289,7 +345,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-focus);"
     >
@@ -306,7 +362,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-focus-outline);"
     >
@@ -323,7 +379,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-gui-visited);"
     >
@@ -345,7 +401,7 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
 
 exports[`Styles/Colors NeutralColors smoke-test 1`] = `
 <div class="flex flex-wrap gap-6">
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-000);"
     >
@@ -362,7 +418,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-100);"
     >
@@ -379,7 +435,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-200);"
     >
@@ -396,7 +452,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-300);"
     >
@@ -413,7 +469,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-400);"
     >
@@ -430,7 +486,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-500);"
     >
@@ -447,7 +503,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-600);"
     >
@@ -464,7 +520,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-700);"
     >
@@ -481,7 +537,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-800);"
     >
@@ -498,7 +554,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-900);"
     >
@@ -515,7 +571,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-1000);"
     >
@@ -532,7 +588,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-1100);"
     >
@@ -549,7 +605,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-1200);"
     >
@@ -566,7 +622,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-neutral-1300);"
     >
@@ -588,7 +644,7 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
 
 exports[`Styles/Colors OrangeColors smoke-test 1`] = `
 <div class="flex flex-wrap gap-6">
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-100);"
     >
@@ -605,7 +661,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-200);"
     >
@@ -622,7 +678,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-300);"
     >
@@ -639,7 +695,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-400);"
     >
@@ -656,7 +712,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-500);"
     >
@@ -673,7 +729,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-600);"
     >
@@ -690,7 +746,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-700);"
     >
@@ -707,7 +763,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-800);"
     >
@@ -724,7 +780,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-900);"
     >
@@ -741,7 +797,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-1000);"
     >
@@ -758,7 +814,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-orange-1100);"
     >
@@ -780,7 +836,7 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
 
 exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
 <div class="flex flex-wrap gap-6">
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-100);"
     >
@@ -797,7 +853,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-200);"
     >
@@ -814,7 +870,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-300);"
     >
@@ -831,7 +887,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-400);"
     >
@@ -848,7 +904,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-500);"
     >
@@ -865,7 +921,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-600);"
     >
@@ -882,7 +938,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-700);"
     >
@@ -899,7 +955,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-800);"
     >
@@ -916,7 +972,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-yellow-900);"
     >
@@ -933,7 +989,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-100);"
     >
@@ -950,7 +1006,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-200);"
     >
@@ -967,7 +1023,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-300);"
     >
@@ -984,7 +1040,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-400);"
     >
@@ -1001,7 +1057,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-500);"
     >
@@ -1018,7 +1074,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-600);"
     >
@@ -1035,7 +1091,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-700);"
     >
@@ -1052,7 +1108,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-800);"
     >
@@ -1069,7 +1125,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-green-900);"
     >
@@ -1086,7 +1142,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-100);"
     >
@@ -1103,7 +1159,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-200);"
     >
@@ -1120,7 +1176,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-300);"
     >
@@ -1137,7 +1193,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-400);"
     >
@@ -1154,7 +1210,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-500);"
     >
@@ -1171,7 +1227,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-600);"
     >
@@ -1188,7 +1244,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-700);"
     >
@@ -1205,7 +1261,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-800);"
     >
@@ -1222,7 +1278,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-blue-900);"
     >
@@ -1239,7 +1295,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-100);"
     >
@@ -1256,7 +1312,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-200);"
     >
@@ -1273,7 +1329,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-300);"
     >
@@ -1290,7 +1346,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-400);"
     >
@@ -1307,7 +1363,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-500);"
     >
@@ -1324,7 +1380,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-600);"
     >
@@ -1341,7 +1397,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-700);"
     >
@@ -1358,7 +1414,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-800);"
     >
@@ -1375,7 +1431,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-violet-900);"
     >
@@ -1392,7 +1448,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-100);"
     >
@@ -1409,7 +1465,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-200);"
     >
@@ -1426,7 +1482,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-300);"
     >
@@ -1443,7 +1499,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-400);"
     >
@@ -1460,7 +1516,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-500);"
     >
@@ -1477,7 +1533,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-600);"
     >
@@ -1494,7 +1550,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-700);"
     >
@@ -1511,7 +1567,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-800);"
     >
@@ -1528,7 +1584,7 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
       </p>
     </div>
   </div>
-  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+  <div class="rounded-lg w-32 bg-ably-primary-inverse-accent flex flex-col">
     <div class="h-[6.25rem] rounded-t-lg "
          style="background-color: var(--color-pink-900);"
     >

--- a/src/core/styles/colors/__snapshots__/Colors.stories.tsx.snap
+++ b/src/core/styles/colors/__snapshots__/Colors.stories.tsx.snap
@@ -1,5 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Styles/Colors AblyUtilityClasses smoke-test 1`] = `
+<div class="flex flex-wrap gap-6">
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-1300) 50%, var(--color-neutral-000) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-primary
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-1300 / neutral-000
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-000) 50%, var(--color-neutral-1300) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-primary-inverse
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-000 / neutral-1300
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-1000) 50%, var(--color-neutral-300) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-secondary
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-1000 / neutral-300
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-300) 50%, var(--color-neutral-1000) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-secondary-inverse
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-300 / neutral-1000
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-800) 50%, var(--color-neutral-500) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-tertiary
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-800 / neutral-500
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-500) 50%, var(--color-neutral-800) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-tertiary-inverse
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-500 / neutral-800
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-700) 50%, var(--color-neutral-600) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-label
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-700 / neutral-600
+      </p>
+    </div>
+  </div>
+  <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
+    <div class="h-[6.25rem] rounded-t-lg"
+         style="background: linear-gradient(45deg, var(--color-neutral-600) 50%, var(--color-neutral-700) 50%);"
+    >
+    </div>
+    <div class="p-3 flex flex-col flex-1">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
+        ably-label-inverse
+      </p>
+      <p class="ui-text-p3 font-normal text-ably-tertiary text-xs">
+        neutral-600 / neutral-700
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Styles/Colors GUIColors smoke-test 1`] = `
 <div class="flex flex-wrap gap-6">
   <div class="rounded-lg w-32 bg-neutral-100 dark:bg-neutral-1200 flex flex-col">
@@ -8,13 +125,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-blue-default-light
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #006edc
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 110, 220)
       </p>
     </div>
@@ -25,13 +142,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-blue-hover-light
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #0862b9
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(8, 98, 185)
       </p>
     </div>
@@ -42,13 +159,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-blue-active-light
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #074095
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(7, 64, 149)
       </p>
     </div>
@@ -59,13 +176,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-blue-default-dark
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #4da6ff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(77, 166, 255)
       </p>
     </div>
@@ -76,13 +193,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-blue-hover-dark
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #2894ff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(40, 148, 255)
       </p>
     </div>
@@ -93,13 +210,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-blue-active-dark
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #0080ff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 128, 255)
       </p>
     </div>
@@ -110,13 +227,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-blue-focus
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #80b9f2
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(128, 185, 242)
       </p>
     </div>
@@ -127,13 +244,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-unavailable
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #a8a8a8
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(168, 168, 168)
       </p>
     </div>
@@ -144,13 +261,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-success-green
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #11cb24
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(17, 203, 36)
       </p>
     </div>
@@ -161,13 +278,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-error-red
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #fb0c0c
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(251, 12, 12)
       </p>
     </div>
@@ -178,13 +295,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-focus
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #80b9f2
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(128, 185, 242)
       </p>
     </div>
@@ -195,13 +312,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-focus-outline
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #80b9f2
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(128, 185, 242)
       </p>
     </div>
@@ -212,13 +329,13 @@ exports[`Styles/Colors GUIColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         gui-visited
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #4887c2
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(72, 135, 194)
       </p>
     </div>
@@ -234,13 +351,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-000
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ffffff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 255, 255)
       </p>
     </div>
@@ -251,13 +368,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #f6f8fa
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(246, 248, 250)
       </p>
     </div>
@@ -268,13 +385,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #eef1f6
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(238, 241, 246)
       </p>
     </div>
@@ -285,13 +402,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #e6eaf0
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(230, 234, 240)
       </p>
     </div>
@@ -302,13 +419,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-400
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #e2e7ef
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(226, 231, 239)
       </p>
     </div>
@@ -319,13 +436,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-500
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #c6ced9
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(198, 206, 217)
       </p>
     </div>
@@ -336,13 +453,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-600
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #a7b1be
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(167, 177, 190)
       </p>
     </div>
@@ -353,13 +470,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-700
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #8992a4
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(137, 146, 164)
       </p>
     </div>
@@ -370,13 +487,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-800
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #687288
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(104, 114, 136)
       </p>
     </div>
@@ -387,13 +504,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-900
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #5b5a72
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(91, 90, 114)
       </p>
     </div>
@@ -404,13 +521,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-1000
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #434356
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(67, 67, 86)
       </p>
     </div>
@@ -421,13 +538,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-1100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #2c3344
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(44, 51, 68)
       </p>
     </div>
@@ -438,13 +555,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-1200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #141924
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(20, 25, 36)
       </p>
     </div>
@@ -455,13 +572,13 @@ exports[`Styles/Colors NeutralColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         neutral-1300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #03020d
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(3, 2, 13)
       </p>
     </div>
@@ -477,13 +594,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #fff5f1
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 245, 241)
       </p>
     </div>
@@ -494,13 +611,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ffe3d8
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 227, 216)
       </p>
     </div>
@@ -511,13 +628,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ffc4ae
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 196, 174)
       </p>
     </div>
@@ -528,13 +645,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-400
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ff9c79
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 156, 121)
       </p>
     </div>
@@ -545,13 +662,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-500
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ff723f
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 114, 63)
       </p>
     </div>
@@ -562,13 +679,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-600
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ff5416
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 84, 22)
       </p>
     </div>
@@ -579,13 +696,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-700
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ff2739
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 39, 57)
       </p>
     </div>
@@ -596,13 +713,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-800
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #e40000
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(228, 0, 0)
       </p>
     </div>
@@ -613,13 +730,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-900
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #b82202
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(184, 34, 2)
       </p>
     </div>
@@ -630,13 +747,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-1000
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #751500
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(117, 21, 0)
       </p>
     </div>
@@ -647,13 +764,13 @@ exports[`Styles/Colors OrangeColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         orange-1100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #2a0b00
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(42, 11, 0)
       </p>
     </div>
@@ -669,13 +786,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #fffbef
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 251, 239)
       </p>
     </div>
@@ -686,13 +803,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #fff0ba
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 240, 186)
       </p>
     </div>
@@ -703,13 +820,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ffe27c
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 226, 124)
       </p>
     </div>
@@ -720,13 +837,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-400
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ffd43d
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 212, 61)
       </p>
     </div>
@@ -737,13 +854,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-500
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #f8c100
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(248, 193, 0)
       </p>
     </div>
@@ -754,13 +871,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-600
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #e8a700
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(232, 167, 0)
       </p>
     </div>
@@ -771,13 +888,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-700
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ac8600
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(172, 134, 0)
       </p>
     </div>
@@ -788,13 +905,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-800
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #654f00
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(101, 79, 0)
       </p>
     </div>
@@ -805,13 +922,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         yellow-900
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #291c01
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(41, 28, 1)
       </p>
     </div>
@@ -822,13 +939,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #f1fff1
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(241, 255, 241)
       </p>
     </div>
@@ -839,13 +956,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #b8ffbb
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(184, 255, 187)
       </p>
     </div>
@@ -856,13 +973,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #80ff85
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(128, 255, 133)
       </p>
     </div>
@@ -873,13 +990,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-400
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #08ff13
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(8, 255, 19)
       </p>
     </div>
@@ -890,13 +1007,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-500
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #00e80b
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 232, 11)
       </p>
     </div>
@@ -907,13 +1024,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-600
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #00c008
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 192, 8)
       </p>
     </div>
@@ -924,13 +1041,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-700
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #008e06
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 142, 6)
       </p>
     </div>
@@ -941,13 +1058,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-800
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #005303
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 83, 3)
       </p>
     </div>
@@ -958,13 +1075,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         green-900
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #002a02
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 42, 2)
       </p>
     </div>
@@ -975,13 +1092,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #f1fbff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(241, 251, 255)
       </p>
     </div>
@@ -992,13 +1109,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #b8eaff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(184, 234, 255)
       </p>
     </div>
@@ -1009,13 +1126,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #80d9ff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(128, 217, 255)
       </p>
     </div>
@@ -1026,13 +1143,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-400
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #4ad4ff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(74, 212, 255)
       </p>
     </div>
@@ -1043,13 +1160,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-500
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #2cc0ff
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(44, 192, 255)
       </p>
     </div>
@@ -1060,13 +1177,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-600
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #00a5ec
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 165, 236)
       </p>
     </div>
@@ -1077,13 +1194,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-700
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #0284cd
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(2, 132, 205)
       </p>
     </div>
@@ -1094,13 +1211,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-800
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #004b75
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 75, 117)
       </p>
     </div>
@@ -1111,13 +1228,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         blue-900
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #001b2a
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(0, 27, 42)
       </p>
     </div>
@@ -1128,13 +1245,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #f7f2fe
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(247, 242, 254)
       </p>
     </div>
@@ -1145,13 +1262,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #d8bcfb
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(216, 188, 251)
       </p>
     </div>
@@ -1162,13 +1279,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #b986f8
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(185, 134, 248)
       </p>
     </div>
@@ -1179,13 +1296,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-400
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #9951f5
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(153, 81, 245)
       </p>
     </div>
@@ -1196,13 +1313,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-500
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #7a1bf2
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(122, 27, 242)
       </p>
     </div>
@@ -1213,13 +1330,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-600
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #5f0bc9
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(95, 11, 201)
       </p>
     </div>
@@ -1230,13 +1347,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-700
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #460894
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(70, 8, 148)
       </p>
     </div>
@@ -1247,13 +1364,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-800
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #2d055e
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(45, 5, 94)
       </p>
     </div>
@@ -1264,13 +1381,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         violet-900
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #130228
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(19, 2, 40)
       </p>
     </div>
@@ -1281,13 +1398,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-100
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #fff1fc
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 241, 252)
       </p>
     </div>
@@ -1298,13 +1415,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-200
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ffb8f1
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 184, 241)
       </p>
     </div>
@@ -1315,13 +1432,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-300
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ff80e6
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 128, 230)
       </p>
     </div>
@@ -1332,13 +1449,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-400
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ff47db
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 71, 219)
       </p>
     </div>
@@ -1349,13 +1466,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-500
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #ff17d2
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(255, 23, 210)
       </p>
     </div>
@@ -1366,13 +1483,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-600
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #d400ab
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(212, 0, 171)
       </p>
     </div>
@@ -1383,13 +1500,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-700
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #9c007e
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(156, 0, 126)
       </p>
     </div>
@@ -1400,13 +1517,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-800
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #630050
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(99, 0, 80)
       </p>
     </div>
@@ -1417,13 +1534,13 @@ exports[`Styles/Colors SecondaryColors smoke-test 1`] = `
     >
     </div>
     <div class="p-3 flex flex-col flex-1">
-      <p class="ui-text-p2 font-semibold flex-1 text-neutral-1000 dark:text-neutral-300">
+      <p class="ui-text-p2 font-semibold flex-1 text-ably-secondary">
         pink-900
       </p>
-      <p class="ui-text-p3 font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 font-normal text-ably-tertiary">
         #2a0022
       </p>
-      <p class="ui-text-p3 text-[12px] font-normal text-neutral-800 dark:text-neutral-500">
+      <p class="ui-text-p3 text-[12px] font-normal text-ably-tertiary">
         rgb(42, 0, 34)
       </p>
     </div>

--- a/src/core/styles/colors/types.ts
+++ b/src/core/styles/colors/types.ts
@@ -3,7 +3,15 @@ export type ColorName =
   | (typeof orangeColors)[number]
   | (typeof secondaryColors)[number]
   | (typeof guiColors)[number]
-  | (typeof aliasedColors)[number];
+  | (typeof aliasedColors)[number]
+  | "ably-primary"
+  | "ably-primary-inverse"
+  | "ably-secondary"
+  | "ably-secondary-inverse"
+  | "ably-tertiary"
+  | "ably-tertiary-inverse"
+  | "ably-label"
+  | "ably-label-inverse";
 
 export const variants = ["", "dark:"] as const;
 

--- a/src/core/styles/colors/types.ts
+++ b/src/core/styles/colors/types.ts
@@ -6,6 +6,10 @@ export type ColorName =
   | (typeof aliasedColors)[number]
   | "ably-primary"
   | "ably-primary-inverse"
+  | "ably-primary-accent"
+  | "ably-primary-inverse-accent"
+  | "ably-primary-active"
+  | "ably-primary-inverse-active"
   | "ably-secondary"
   | "ably-secondary-inverse"
   | "ably-tertiary"

--- a/src/core/styles/forms.css
+++ b/src/core/styles/forms.css
@@ -28,12 +28,12 @@
 
   .ui-checkbox-label-p1 {
     @apply select-none;
-    @apply text-p1 font-medium text-neutral-1300;
+    @apply text-p1 font-medium text-ably-primary;
   }
 
   .ui-checkbox-label-p2 {
     @apply select-none;
-    @apply text-p2 font-medium text-neutral-1300;
+    @apply text-p2 font-medium text-ably-primary;
   }
 
   .ui-theme-dark .ui-checkbox-label-p1,

--- a/src/core/styles/forms/story-components.tsx
+++ b/src/core/styles/forms/story-components.tsx
@@ -44,10 +44,7 @@ export const RadioButton = ({ index, disabled }: FormElementProps) => (
       className="ui-radio"
       disabled={disabled}
     />
-    <label
-      className="text-neutral-1300 dark:text-neutral-000"
-      htmlFor={`radio-example-${index}`}
-    >
+    <label className="text-ably-primary" htmlFor={`radio-example-${index}`}>
       Option {index}
     </label>
   </div>

--- a/src/core/styles/properties.css
+++ b/src/core/styles/properties.css
@@ -166,6 +166,16 @@
       var(--color-jazzy-pink) 100%
     );
 
+    /* Used for theming */
+    --color-ably-primary: var(--color-neutral-1300);
+    --color-ably-primary-inverse: var(--color-neutral-000);
+    --color-ably-secondary: var(--color-neutral-1000);
+    --color-ably-secondary-inverse: var(--color-neutral-300);
+    --color-ably-tertiary: var(--color-neutral-800);
+    --color-ably-tertiary-inverse: var(--color-neutral-500);
+    --color-ably-label: var(--color-neutral-700);
+    --color-ably-label-inverse: var(--color-neutral-600);
+
     --fs-title-xl: 3rem;
     --fs-title: 2.75rem;
     --fs-title-xs: 2.5rem;
@@ -266,5 +276,16 @@
 
     /* Expose component values for cross-component usage */
     --ui-meganav-height: 4rem;
+  }
+
+  .ui-theme-dark {
+    --color-ably-primary: var(--color-neutral-000);
+    --color-ably-primary-inverse: var(--color-neutral-1300);
+    --color-ably-secondary: var(--color-neutral-300);
+    --color-ably-secondary-inverse: var(--color-neutral-1000);
+    --color-ably-tertiary: var(--color-neutral-500);
+    --color-ably-tertiary-inverse: var(--color-neutral-800);
+    --color-ably-label: var(--color-neutral-600);
+    --color-ably-label-inverse: var(--color-neutral-700);
   }
 }

--- a/src/core/styles/properties.css
+++ b/src/core/styles/properties.css
@@ -169,6 +169,10 @@
     /* Used for theming */
     --color-ably-primary: var(--color-neutral-1300);
     --color-ably-primary-inverse: var(--color-neutral-000);
+    --color-ably-primary-accent: var(--color-neutral-1200);
+    --color-ably-primary-inverse-accent: var(--color-neutral-100);
+    --color-ably-primary-active: var(--color-neutral-1100);
+    --color-ably-primary-inverse-active: var(--color-neutral-200);
     --color-ably-secondary: var(--color-neutral-1000);
     --color-ably-secondary-inverse: var(--color-neutral-300);
     --color-ably-tertiary: var(--color-neutral-800);
@@ -281,6 +285,10 @@
   .ui-theme-dark {
     --color-ably-primary: var(--color-neutral-000);
     --color-ably-primary-inverse: var(--color-neutral-1300);
+    --color-ably-primary-accent: var(--color-neutral-100);
+    --color-ably-primary-inverse-accent: var(--color-neutral-1200);
+    --color-ably-primary-active: var(--color-neutral-200);
+    --color-ably-primary-inverse-active: var(--color-neutral-1100);
     --color-ably-secondary: var(--color-neutral-300);
     --color-ably-secondary-inverse: var(--color-neutral-1000);
     --color-ably-tertiary: var(--color-neutral-500);

--- a/src/core/styles/text.css
+++ b/src/core/styles/text.css
@@ -1,54 +1,54 @@
 @layer components {
   .ui-text-title {
-    @apply font-sans font-bold text-cool-black;
+    @apply font-sans font-bold text-ably-primary;
     @apply text-title-xs xs:text-title xl:text-title-xl;
     @apply tracking-[-0.015em] xs:tracking-[-0.02em] xl:tracking-[-0.02em];
   }
 
   .ui-text-h1 {
-    @apply font-sans font-bold text-cool-black;
+    @apply font-sans font-bold text-ably-primary;
     @apply text-h1-xs xs:text-h1 xl:text-h1-xl;
     @apply tracking-[-0.0125em] xs:tracking-[-0.015em];
   }
 
   .ui-text-h2 {
-    @apply font-sans font-bold text-cool-black;
+    @apply font-sans font-bold text-ably-primary;
     @apply text-h2-xs xs:text-h2 xl:text-h2-xl;
     @apply tracking-[-0.015em] xs:tracking-[-0.01em];
   }
 
   .ui-text-h3 {
-    @apply font-sans font-bold text-cool-black;
+    @apply font-sans font-bold text-ably-primary;
     @apply text-h3;
     @apply tracking-[-0.005em];
   }
 
   .ui-text-h4 {
-    @apply font-sans font-bold text-cool-black;
+    @apply font-sans font-bold text-ably-primary;
     @apply text-h4;
     @apply tracking-[-0.0015em];
   }
 
   .ui-text-h5 {
-    @apply font-sans font-bold text-cool-black;
+    @apply font-sans font-bold text-ably-primary;
     @apply text-h5;
     @apply tracking-[-0.0025em];
   }
 
   .ui-text-p1 {
-    @apply font-sans font-medium text-charcoal-grey text-p1;
+    @apply font-sans font-medium text-ably-primary text-p1;
   }
 
   .ui-text-p2 {
-    @apply font-sans font-medium text-charcoal-grey text-p2;
+    @apply font-sans font-medium text-ably-primary text-p2;
   }
 
   .ui-text-p3 {
-    @apply font-sans font-medium text-charcoal-grey text-p3;
+    @apply font-sans font-medium text-ably-primary text-p3;
   }
 
   .ui-text-p4 {
-    @apply font-sans font-medium text-charcoal-grey text-p4;
+    @apply font-sans font-medium text-ably-primary text-p4;
   }
 
   .ui-text-standfirst {
@@ -58,13 +58,13 @@
   }
 
   .ui-text-quote {
-    @apply font-sans font-normal text-cool-black;
+    @apply font-sans font-normal text-ably-primary;
     @apply text-quote leading-normal;
     @apply tracking-[-0.0015em];
   }
 
   .ui-text-sub-header {
-    @apply font-sans font-semibold text-neutral-800;
+    @apply font-sans font-semibold text-ably-secondary;
     @apply text-sub-header-xs xs:text-sub-header leading-normal;
   }
 
@@ -81,26 +81,19 @@
   }
 
   .ui-text-label1 {
-    @apply font-sans text-neutral-900 text-label1 font-semibold;
+    @apply font-sans text-ably-label text-label1 font-semibold;
   }
 
   .ui-text-label2 {
-    @apply font-sans text-neutral-900 text-label2 font-semibold;
+    @apply font-sans text-ably-label text-label2 font-semibold;
   }
 
   .ui-text-label3 {
-    @apply font-sans text-neutral-900 text-label3 font-semibold;
+    @apply font-sans text-ably-label text-label3 font-semibold;
   }
 
   .ui-text-label4 {
-    @apply font-sans text-neutral-900 text-label4 font-semibold;
-  }
-
-  .ui-theme-dark .ui-text-label1,
-  .ui-theme-dark .ui-text-label2,
-  .ui-theme-dark .ui-text-label3,
-  .ui-theme-dark .ui-text-label4 {
-    @apply text-neutral-300;
+    @apply font-sans text-ably-label text-label4 font-semibold;
   }
 
   .ui-text-code {
@@ -112,21 +105,21 @@
   }
 
   .ui-text-code-inline {
-    @apply inline-flex font-mono px-[0.1875rem] py-1 text-code text-neutral-1000 font-medium bg-neutral-200 border border-neutral-400 rounded-md;
+    @apply inline-flex font-mono px-[0.1875rem] py-1 text-code text-ably-primary font-medium bg-neutral-200 border border-neutral-400 rounded-md;
   }
 
-  .dark .ui-text-code-inline {
-    @apply text-neutral-300 bg-neutral-1000 border-neutral-900;
+  .ui-theme-dark .ui-text-code-inline {
+    @apply text-ably-primary bg-neutral-1000 border-neutral-900;
   }
 
   .ui-unordered-list {
-    @apply text-p1 font-medium text-charcoal-grey;
+    @apply text-p1 font-medium text-ably-secondary;
     @apply ml-8 my-4;
     @apply list-disc;
   }
 
   .ui-ordered-list {
-    @apply text-p1 font-medium text-charcoal-grey;
+    @apply text-p1 font-medium text-ably-secondary;
     @apply ml-8 my-4;
     @apply list-decimal;
   }
@@ -162,15 +155,5 @@
     @apply hover:text-gui-hover active:text-gui-active disabled:text-gui-unavailable;
     @apply focus:text-gui-default focus-base;
     @apply no-underline;
-  }
-
-  .ui-link-neutral {
-    @apply hover:text-dark-grey active:text-cool-black disabled:text-gui-unavailable;
-    @apply focus:text-charcoal-grey focus-base;
-    @apply underline;
-  }
-
-  .ui-figcaption {
-    @apply font-mono text-p3 text-neutral-800;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,12 @@ module.exports = {
       colors: {
         "ably-primary": "var(--color-ably-primary)",
         "ably-primary-inverse": "var(--color-ably-primary-inverse)",
+        "ably-primary-accent": "var(--color-ably-primary-accent)",
+        "ably-primary-inverse-accent":
+          "var(--color-ably-primary-inverse-accent)",
+        "ably-primary-active": "var(--color-ably-primary-active)",
+        "ably-primary-inverse-active":
+          "var(--color-ably-primary-inverse-active)",
         "ably-secondary": "var(--color-ably-secondary)",
         "ably-secondary-inverse": "var(--color-ably-secondary-inverse)",
         "ably-tertiary": "var(--color-ably-tertiary)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,14 @@ module.exports = {
     },
     extend: {
       colors: {
+        "ably-primary": "var(--color-ably-primary)",
+        "ably-primary-inverse": "var(--color-ably-primary-inverse)",
+        "ably-secondary": "var(--color-ably-secondary)",
+        "ably-secondary-inverse": "var(--color-ably-secondary-inverse)",
+        "ably-tertiary": "var(--color-ably-tertiary)",
+        "ably-tertiary-inverse": "var(--color-ably-tertiary-inverse)",
+        "ably-label": "var(--color-ably-label)",
+        "ably-label-inverse": "var(--color-ably-label-inverse)",
         "neutral-000": "var(--color-neutral-000)",
         "neutral-100": "var(--color-neutral-100)",
         "neutral-200": "var(--color-neutral-200)",


### PR DESCRIPTION
To facilitate the rollout of dark mode across the dash and beyond, we need to make the core typographic classes theme-aware. I'm proposing to do this by borrowing the approach `shadcn` takes, which is to define role-oriented CSS variables that we then pipe through to tailwind.

I've prefixed them with `ably-` to distinguish them from the un-prefixed shadcn classes, and to allow more to be added easily. Maybe one day we can merge the definitions, but this is the easiest thing to transform classes that are already in use today.

Variables:
```css
--color-ably-primary: var(--color-neutral-1300);
--color-ably-primary-inverse: var(--color-neutral-000);
--color-ably-primary-accent: var(--color-neutral-1200);
--color-ably-primary-inverse-accent: var(--color-neutral-100);
--color-ably-primary-active: var(--color-neutral-1100);
--color-ably-primary-inverse-active: var(--color-neutral-200);
--color-ably-secondary: var(--color-neutral-1000);
--color-ably-secondary-inverse: var(--color-neutral-300);
--color-ably-tertiary: var(--color-neutral-800);
--color-ably-tertiary-inverse: var(--color-neutral-500);
--color-ably-label: var(--color-neutral-700);
--color-ably-label-inverse: var(--color-neutral-600);

.ui-theme-dark {
  --color-ably-primary: var(--color-neutral-000);
  --color-ably-primary-inverse: var(--color-neutral-1300);
  --color-ably-primary-accent: var(--color-neutral-100);
  --color-ably-primary-inverse-accent: var(--color-neutral-1200);
  --color-ably-primary-active: var(--color-neutral-200);
  --color-ably-primary-inverse-active: var(--color-neutral-1100);
  --color-ably-secondary: var(--color-neutral-300);
  --color-ably-secondary-inverse: var(--color-neutral-1000);
  --color-ably-tertiary: var(--color-neutral-500);
  --color-ably-tertiary-inverse: var(--color-neutral-800);
  --color-ably-label: var(--color-neutral-600);
  --color-ably-label-inverse: var(--color-neutral-700);
}
```

As an example, with this, we can use `text-ably-primary` and it will automatically switch from 1300 to 000 depending on the theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a set of Ably-branded design tokens and exposed them in the color system.

* **Style**
  * Re-themed UI: replaced neutral/dark color usages with Ably tokens across typography, components, controls, and stories for consistent branding and simplified dark-mode handling.
  * Updated Tailwind palette to map new tokens for use in styling utilities.

* **Chores**
  * Bumped package version to 17.8.0-dev.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->