### PR TITLE
[WEB-4602] Pricing card CTA should support configurable "priority"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.6.8",
+  "version": "17.7.0",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/Pricing/PricingCards.tsx
+++ b/src/core/Pricing/PricingCards.tsx
@@ -180,9 +180,7 @@ const PricingCards = ({ data, delimiter }: PricingCardsProps) => {
                     <div className="group">
                       <LinkButton
                         className={cn("w-full", cta.className)}
-                        variant={
-                          cta.url === "/contact" ? "priority" : "primary"
-                        }
+                        variant={cta.isPriority ? "priority" : "primary"}
                         href={cta.url}
                         onClick={cta.onClick}
                         disabled={cta.disabled}

--- a/src/core/Pricing/data.tsx
+++ b/src/core/Pricing/data.tsx
@@ -196,6 +196,7 @@ export const planData: PricingDataFeature[] = [
     cta: {
       text: "Contact us",
       url: "/contact",
+      isPriority: true,
     },
     sections: [
       {

--- a/src/core/Pricing/types.ts
+++ b/src/core/Pricing/types.ts
@@ -15,6 +15,7 @@ type PricingDataFeatureCta = {
   disabled?: boolean;
   onClick?: () => void;
   iconColor?: ColorClass | ColorThemeSet;
+  isPriority?: boolean;
 };
 
 export type PricingDataFeatureSection = {


### PR DESCRIPTION
## Jira Ticket Link / Motivation

This shouldn't be infered from the URL as it makes it impossible to change the URL and retain the priority appearance on the pricing card, so let's make it explicit.

WEB-4602 requires different contact URLs for MAU pricing

## Summary of changes

This pull request updates the pricing card CTA button logic to support a new `isPriority` flag, allowing more flexible control over button styling. It also bumps the package version to `17.7.0`.

Enhancements to Pricing Cards CTA logic:

* Added an `isPriority` boolean property to the `PricingDataFeatureCta` type in `types.ts` to indicate when a CTA should use the "priority" style.
* Updated the relevant CTA object in `data.tsx` to set `isPriority: true` for the "Contact us" plan.
* Modified the `PricingCards` component in `PricingCards.tsx` to use the new `isPriority` property instead of checking the CTA URL to determine the button variant.

Version update:

* Bumped the package version in `package.json` from `17.6.8` to `17.7.0` to reflect these changes.

## How do you manually test this?

Review Storybook and/or matching Voltaire PR



## Merge/Deploy Checklist

<!-- Committer checklist  -->

- [ ] Written automated tests for implemented features/fixed bugs
- [ ] Rebased and squashed commits
- [ ] Commits have clear descriptions of their changes
- [ ] Checked for any performance regressions

## Frontend Checklist

<!-- Committer frontend changes checklist  -->

- [ ] No frontend changes in this PR
- [ ] Added before/after screenshots for changes
- [ ] Tested on different platforms/browsers with [Browserstack](https://www.browserstack.com)
- [ ] Compared with the initial design / our [brand guidelines](https://www.figma.com/file/jTQgyIovrhGBOf4Zrvjvbk/Ably-Linear-Design?node-id=118%3A0)
- [ ] Checked the code for accessibility issues ([VoiceOver User Guide](https://support.apple.com/en-gb/guide/voiceover/welcome/mac))?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated Pricing page so the Enterprise plan’s call-to-action is visually emphasized with a priority button style. Styling now consistently reflects configuration, ensuring the CTA appears correctly across all contexts and links.

- Chores
  - Increased app version to 17.7.0-dev.cc33cce1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->