### PR TITLE
[EDU-1890] - Add Laravel to supported languages in CodeSnippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/ui",
-  "version": "17.7.2",
+  "version": "17.7.3",
   "description": "Home of the Ably design system library ([design.ably.com](https://design.ably.com)). It provides a showcase, development/test environment and a publishing pipeline for different distributables.",
   "repository": {
     "type": "git",

--- a/src/core/CodeSnippet/languages.ts
+++ b/src/core/CodeSnippet/languages.ts
@@ -79,6 +79,11 @@ const languages: LanguageMap = {
     icon: "icon-tech-json",
     syntaxHighlighterKey: "json",
   },
+  laravel: {
+    label: "Laravel",
+    icon: "icon-tech-laravel-broadcast",
+    syntaxHighlighterKey: "php",
+  },
   xml: {
     label: "XML",
     icon: "icon-tech-web",


### PR DESCRIPTION
## Jira Ticket Link / Motivation

For the purpose of Laravel getting started guide and in the future other Laravel content. We're going to want to have the Laravel logo for the dropdown language selection, or on the code blocks etc. This PR adds Laravel as an option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Laravel as a selectable language in code snippets, complete with dedicated icon and PHP syntax highlighting.
  - Improves readability and accuracy of Laravel examples through proper syntax coloring.
  - Enhances discoverability for Laravel developers by clearly labeling and displaying the framework option.
  - Seamlessly integrates with existing language selection without affecting other languages or user flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->